### PR TITLE
CI: Remove unnecessary dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
     - name: Generate models
       run: |
         sudo apt-get update
+        sudo apt-get install libeigen3-dev libace-dev libtinyxml-dev libxml2-dev
         # Save the url of the repository and the user-name of the committ author
         export CURRENT_REPOSITORY_URL=`git remote get-url origin`
         # Start in the parent directory of icub-model-generator
@@ -58,6 +59,36 @@ jobs:
         cd simmechanics-to-urdf
         export SIMMECHANICS_TO_URDF_COMMIT=`git rev-parse HEAD`
         sudo python setup.py install
+        cd ${GITHUB_WORKSPACE}
+        # get C++ dependencies and save their last commit SHA1 hash
+        # ycm
+        git clone https://github.com/robotology/ycm.git
+        cd ycm
+        git checkout v0.12.0
+        mkdir build
+        cd build
+        cmake ..
+        sudo cmake --build . --target install
+        cd ${GITHUB_WORKSPACE}
+        ## yarp
+        git clone https://github.com/robotology/yarp.git
+        cd yarp
+        git checkout v3.4.0
+        export YARP_COMMIT=`git rev-parse HEAD`
+        mkdir build
+        cd build
+        cmake -DCREATE_LIB_MATH:BOOL=OFF -DYARP_COMPILE_EXECUTABLES:BOOL=OFF ..
+        sudo cmake --build . --target install
+        cd ${GITHUB_WORKSPACE}
+        ## idyntree
+        git clone https://github.com/robotology/idyntree.git
+        cd idyntree
+        git checkout v1.2.0
+        export IDYNTREE_COMMIT=`git rev-parse HEAD`
+        mkdir build
+        cd build
+        cmake ..
+        sudo cmake --build . --target install
         cd ${GITHUB_WORKSPACE}
         # Prepare icub-model-generator build
         mkdir build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,6 @@ jobs:
     - name: Generate models
       run: |
         sudo apt-get update
-        sudo apt-get install libeigen3-dev libace-dev libboost-dev libgsl0-dev libtinyxml-dev libxml2-dev
         # Save the url of the repository and the user-name of the committ author
         export CURRENT_REPOSITORY_URL=`git remote get-url origin`
         # Start in the parent directory of icub-model-generator
@@ -60,90 +59,6 @@ jobs:
         export SIMMECHANICS_TO_URDF_COMMIT=`git rev-parse HEAD`
         sudo python setup.py install
         cd ${GITHUB_WORKSPACE}
-        # get C++ dependencies and save their last commit SHA1 hash
-        # ycm
-        git clone https://github.com/robotology/ycm.git
-        cd ycm
-        git checkout v0.11.3
-        mkdir build
-        cd build
-        cmake ..
-        sudo cmake --build . --target install
-        cd ${GITHUB_WORKSPACE}
-        ## yarp
-        git clone https://github.com/robotology/yarp.git
-        cd yarp
-        git checkout v3.4.0
-        export YARP_COMMIT=`git rev-parse HEAD`
-        mkdir build
-        cd build
-        cmake -DCREATE_LIB_MATH:BOOL=ON ..
-        sudo cmake --build . --target install
-        cd ${GITHUB_WORKSPACE}
-        ## icub-main
-        git clone https://github.com/robotology/icub-main.git
-        cd icub-main
-        git checkout v1.17.0
-        export ICUB_MAIN_COMMIT=`git rev-parse HEAD`
-        mkdir build
-        cd build
-        cmake ..
-        sudo cmake --build . --target install
-        cd ${GITHUB_WORKSPACE}
-        ## orocos_kdl
-        git clone https://github.com/orocos/orocos_kinematics_dynamics
-        cd orocos_kinematics_dynamics/orocos_kdl
-        git checkout v1.4.0
-        mkdir build
-        cd build
-        cmake ..
-        sudo cmake --build . --target install
-        cd ${GITHUB_WORKSPACE}
-        ## console_bridge
-        git clone https://github.com/ros/console_bridge
-        cd console_bridge
-        # Go the commit of the 7th Septmber 2018 for
-        # console_bridge, urdfdom_headers and urdfdom, see
-        # https://travis-ci.org/robotology/icub-model-generator/builds/425819092?utm_source=github_status&utm_medium=notification
-        git checkout ad25f7307da76be2857545e7e5c2a20727eee542
-        mkdir build
-        cd build
-        cmake ..
-        sudo cmake --build . --target install
-        cd ${GITHUB_WORKSPACE}
-        # urdfdom_headers
-        git clone https://github.com/ros/urdfdom_headers
-        cd urdfdom_headers
-        git checkout e7e0972a4617b8a5df7a274ea3ba3b92e3895a35
-        mkdir build
-        cd build
-        cmake ..
-        sudo cmake --build . --target install
-        cd ${GITHUB_WORKSPACE}
-        # urdfdom
-        git clone https://github.com/ros/urdfdom
-        cd urdfdom
-        git checkout 06f5f9bc34f09b530d9f3743cb0516934625da54
-        mkdir build
-        cd build
-        cmake  ..
-        sudo cmake --build . --target install
-        cd ${GITHUB_WORKSPACE}
-        ## idyntree
-        git clone https://github.com/robotology/idyntree.git
-        cd idyntree
-        git checkout v0.11.1
-        export IDYNTREE_COMMIT=`git rev-parse HEAD`
-        mkdir build
-        cd build
-        cmake -DIDYNTREE_USES_KDL:BOOL=ON ..
-        sudo cmake --build . --target install
-        cd ${GITHUB_WORKSPACE}
-        # Install sdformat
-        sudo sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list'
-        wget https://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
-        sudo apt-get update
-        sudo apt-get install --assume-yes --force-yes libsdformat6-dev
         # Prepare icub-model-generator build
         mkdir build
         cd build
@@ -159,8 +74,6 @@ jobs:
         echo "icub-model-generator commit:$GITHUB_SHA" >> ${GITHUB_WORKSPACE}/deploy_commit_message
         echo "urdf_parser_py commit:$URDF_PARSER_PY_COMMIT" >> ${GITHUB_WORKSPACE}/deploy_commit_message
         echo "simmechanics-to-urdf commit:$SIMMECHANICS_TO_URDF_COMMIT" >> ${GITHUB_WORKSPACE}/deploy_commit_message
-        echo "icub-main commit:$ICUB_MAIN_COMMIT" >> ${GITHUB_WORKSPACE}/deploy_commit_message
-        echo "idyntree commit:$IDYNTREE_COMMIT" >> ${GITHUB_WORKSPACE}/deploy_commit_message
 
     - name: Print generated models differences
       run: |


### PR DESCRIPTION
After https://github.com/robotology/icub-models-generator/pull/171, we can just remove a lot of C++ dependencies of the old DH-based generator. This should speed up CI a bit. 

By the way, I just noticed those lines in CI, that I probably I added myself:
~~~
# probably python on the path return a python interpreter and the find_package(PythonInterp) in CMake another,
# let's install both debian packages and pip packages to be sure
~~~

That does not seem a great idea. 