### PR TITLE
Change the direction of some axes of iCubGenova09

### DIFF
--- a/simmechanics/data/icub3/ICUB_3_all_options.yaml
+++ b/simmechanics/data/icub3/ICUB_3_all_options.yaml
@@ -416,8 +416,12 @@ reverseRotationAxis:
     r_ankle_roll
     l_ankle_pitch
     r_elbow
+    l_shoulder_yaw
     l_shoulder_pitch
     l_shoulder_roll
+    l_wrist_prosup
+    l_wrist_pitch
+    l_wrist_yaw
     torso_yaw
     torso_pitch
     torso_roll

--- a/simmechanics/data/icub3/ICUB_3_all_options_gazebo.yaml.in
+++ b/simmechanics/data/icub3/ICUB_3_all_options_gazebo.yaml.in
@@ -503,8 +503,12 @@ reverseRotationAxis:
     r_ankle_roll
     l_ankle_pitch
     r_elbow
+    l_shoulder_yaw
     l_shoulder_pitch
     l_shoulder_roll
+    l_wrist_prosup
+    l_wrist_pitch
+    l_wrist_yaw
     torso_yaw
     torso_pitch
     torso_roll

--- a/simmechanics/data/icub3/ICUB_3_upperbody_options.yaml
+++ b/simmechanics/data/icub3/ICUB_3_upperbody_options.yaml
@@ -87,6 +87,13 @@ reverseRotationAxis:
   torso_yaw
   torso_pitch
   torso_roll
+  r_elbow
+  l_shoulder_yaw
+  l_shoulder_pitch
+  l_shoulder_roll
+  l_wrist_prosup
+  l_wrist_pitch
+  l_wrist_yaw
 XMLBlobs:
     - |
             <link name="base_link" />


### PR DESCRIPTION
In details it changes: 
- l_shoulder_yaw
- l_wrist_prosup
- l_wrist_pitch
- l_wrist_yaw

I added the reverse joints also in the `ICUB_3_upperbody_options.yaml` file but I'm not sure it is used somewhere since 
https://github.com/robotology/icub-models-generator/blob/add55e8a10302f6b224ecc3d19e3053cf4ebdce3/simmechanics/CMakeLists.txt#L407-L410

It fixes https://github.com/robotology/icub-models/issues/70

cc @prashanthr05 @S-Dafarra @Nicogene @traversaro and @pattacini  
