### PR TITLE
icub3: fix the feet's ft measurement direction

### DIFF
--- a/simmechanics/data/icub3/ICUB_3_all_options.yaml
+++ b/simmechanics/data/icub3/ICUB_3_all_options.yaml
@@ -249,7 +249,7 @@ forceTorqueSensors:
             <yarpConfigurationFile>model://iCub/conf_icub3/FT/gazebo_icub_left_leg_ft.ini</yarpConfigurationFile>
           </plugin>
     - jointName: l_foot_front_ft_sensor
-      directionChildToParent: Yes
+      directionChildToParent: No
       frame: sensor
       frameName: SCSYS_L_ANKLE_2_FT_FRONT
       sensorBlobs:
@@ -258,7 +258,7 @@ forceTorqueSensors:
             <yarpConfigurationFile>model://iCub/conf_icub3/FT/gazebo_icub_left_foot_front_ft.ini</yarpConfigurationFile>
           </plugin>
     - jointName: l_foot_rear_ft_sensor
-      directionChildToParent: Yes
+      directionChildToParent: No
       frame: sensor
       frameName: SCSYS_L_ANKLE_2_FT_REAR
       sensorBlobs:
@@ -277,7 +277,7 @@ forceTorqueSensors:
             <yarpConfigurationFile>model://iCub/conf_icub3/FT/gazebo_icub_right_leg_ft.ini</yarpConfigurationFile>
           </plugin>
     - jointName: r_foot_front_ft_sensor
-      directionChildToParent: Yes
+      directionChildToParent: No
       frame: sensor
       frameName: SCSYS_R_ANKLE_2_FT_FRONT
       sensorBlobs:
@@ -286,7 +286,7 @@ forceTorqueSensors:
             <yarpConfigurationFile>model://iCub/conf_icub3/FT/gazebo_icub_right_foot_front_ft.ini</yarpConfigurationFile>
           </plugin>
     - jointName: r_foot_rear_ft_sensor
-      directionChildToParent: Yes
+      directionChildToParent: No
       frame: sensor
       frameName: SCSYS_R_ANKLE_2_FT_REAR
       sensorBlobs:
@@ -356,9 +356,9 @@ sensors:
             <far>3000</far>
           </clip>
         </camera>
-    - | 
+    - |
         <visualize>false</visualize>
-    - | 
+    - |
         <plugin name="iCub_yarp_gazebo_plugin_depthCamera" filename="libgazebo_yarp_depthCamera.so">
             <yarpConfigurationFile>model://iCub/conf_icub3/gazebo_icub_depth_camera.ini</yarpConfigurationFile>
         </plugin>
@@ -390,9 +390,9 @@ sensors:
             <far>3000</far>
           </clip>
         </camera>
-    - | 
+    - |
         <visualize>false</visualize>
-    - |   
+    - |
         <plugin name="iCub_yarp_gazebo_plugin_camera" filename="libgazebo_yarp_camera.so">
             <yarpConfigurationFile>model://iCub/conf_icub3/gazebo_icub_rgb_camera.ini</yarpConfigurationFile>
         </plugin>
@@ -557,7 +557,7 @@ XMLBlobs:
             <!-- For compatibility with SDFormat < 4.4 -->
             <disableFixedJointLumping>true</disableFixedJointLumping>
             </gazebo>
-        
+
     - |
             <gazebo reference="l_foot_front">
               <collision> <surface> <bounce>
@@ -698,7 +698,7 @@ XMLBlobs:
             <gazebo reference="r_ankle_roll">
                 <implicitSpringDamper>1</implicitSpringDamper>
             </gazebo>
-            
+
     # head
     - |
             <gazebo>
@@ -720,7 +720,7 @@ XMLBlobs:
             </gazebo>
 
     # left arm
-    - | 
+    - |
             <gazebo>
             <plugin name="controlboard_left_arm_no_hand" filename="libgazebo_yarp_controlboard.so">
             <yarpConfigurationFile>model://iCub/conf_icub3/gazebo_icub_left_arm_no_hand_for_no_hand_model.ini</yarpConfigurationFile>

--- a/simmechanics/data/icub3/ICUB_3_all_options_gazebo.yaml.in
+++ b/simmechanics/data/icub3/ICUB_3_all_options_gazebo.yaml.in
@@ -246,7 +246,7 @@ forceTorqueSensors:
             <yarpConfigurationFile>model://iCub/conf_icub3/FT/gazebo_icub_left_leg_ft.ini</yarpConfigurationFile>
           </plugin>
     - jointName: l_foot_front_ft_sensor
-      directionChildToParent: Yes
+      directionChildToParent: No
       frame: sensor
       frameName: SCSYS_L_ANKLE_2_FT_FRONT
       sensorBlobs:
@@ -255,7 +255,7 @@ forceTorqueSensors:
             <yarpConfigurationFile>model://iCub/conf_icub3/FT/gazebo_icub_left_foot_front_ft.ini</yarpConfigurationFile>
           </plugin>
     - jointName: l_foot_rear_ft_sensor
-      directionChildToParent: Yes
+      directionChildToParent: No
       frame: sensor
       frameName: SCSYS_L_ANKLE_2_FT_REAR
       sensorBlobs:
@@ -274,7 +274,7 @@ forceTorqueSensors:
             <yarpConfigurationFile>model://iCub/conf_icub3/FT/gazebo_icub_right_leg_ft.ini</yarpConfigurationFile>
           </plugin>
     - jointName: r_foot_front_ft_sensor
-      directionChildToParent: Yes
+      directionChildToParent: No
       frame: sensor
       frameName: SCSYS_R_ANKLE_2_FT_FRONT
       sensorBlobs:
@@ -283,7 +283,7 @@ forceTorqueSensors:
             <yarpConfigurationFile>model://iCub/conf_icub3/FT/gazebo_icub_right_foot_front_ft.ini</yarpConfigurationFile>
           </plugin>
     - jointName: r_foot_rear_ft_sensor
-      directionChildToParent: Yes
+      directionChildToParent: No
       frame: sensor
       frameName: SCSYS_R_ANKLE_2_FT_REAR
       sensorBlobs:
@@ -351,9 +351,9 @@ sensors:
             <far>3000</far>
           </clip>
         </camera>
-    - | 
+    - |
         <visualize>false</visualize>
-    - | 
+    - |
         <plugin name="iCub_yarp_gazebo_plugin_depthCamera" filename="libgazebo_yarp_depthCamera.so">
             <yarpConfigurationFile>model://iCub/conf_icub3/gazebo_icub_depth_camera.ini</yarpConfigurationFile>
         </plugin>
@@ -385,9 +385,9 @@ sensors:
             <far>3000</far>
           </clip>
         </camera>
-    - | 
+    - |
         <visualize>false</visualize>
-    - |   
+    - |
         <plugin name="iCub_yarp_gazebo_plugin_camera" filename="libgazebo_yarp_camera.so">
             <yarpConfigurationFile>model://iCub/conf_icub3/gazebo_icub_rgb_camera.ini</yarpConfigurationFile>
         </plugin>
@@ -644,7 +644,7 @@ XMLBlobs:
             <!-- For compatibility with SDFormat < 4.4 -->
             <disableFixedJointLumping>true</disableFixedJointLumping>
             </gazebo>
-        
+
     - |
             <gazebo reference="l_foot_front">
               <collision> <surface> <bounce>
@@ -785,7 +785,7 @@ XMLBlobs:
             <gazebo reference="r_ankle_roll">
                 <implicitSpringDamper>1</implicitSpringDamper>
             </gazebo>
-            
+
     # head
     - |
             <gazebo>
@@ -807,7 +807,7 @@ XMLBlobs:
             </gazebo>
 
     # left arm
-    - | 
+    - |
             <gazebo>
             <plugin name="controlboard_left_arm_no_hand" filename="libgazebo_yarp_controlboard.so">
             <yarpConfigurationFile>model://iCub/conf_icub3/gazebo_icub_left_arm_no_hand_for_no_hand_model.ini</yarpConfigurationFile>


### PR DESCRIPTION
We noticed from the cad that the FT sensors in the feet are mounted upwards, and in the arms are mounted downwards, and following what the wiki states (see https://wiki.icub.org/wiki/FT_sensor) in the feet the direction are `parent_to_child`

Ft in the arm

![immagine](https://user-images.githubusercontent.com/19152494/100887942-d576f500-34b5-11eb-82c9-db1fe8fb8899.png)


Ft in the feet

![immagine](https://user-images.githubusercontent.com/19152494/100887997-e58ed480-34b5-11eb-9c71-07116415615f.png)




Please review code