### PR TITLE
icub3: comment out the ft in the legs that are not yet mounted in the real robot

### DIFF
--- a/simmechanics/data/icub3/ICUB_3_all_options.yaml
+++ b/simmechanics/data/icub3/ICUB_3_all_options.yaml
@@ -2,7 +2,7 @@
 robotName: iCub
 
 # Model base origin
-originXYZ: [0.0,0.0,0.80]
+originXYZ: [0.0,0.0,0.64]
 originRPY: [0.0,0.0,0.0]
 # Meshes options
 scale: "0.001 0.001 0.001"
@@ -239,15 +239,15 @@ forceTorqueSensors:
             <yarpConfigurationFile>model://iCub/conf_icub3/FT/gazebo_icub_right_arm_ft.ini</yarpConfigurationFile>
           </plugin>
     # left leg
-    - jointName: l_leg_ft_sensor
-      directionChildToParent: Yes
-      frame: sensor
-      frameName: SCSYS_L_HIP_2_FT
-      sensorBlobs:
-      - |
-          <plugin name="left_leg_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
-            <yarpConfigurationFile>model://iCub/conf_icub3/FT/gazebo_icub_left_leg_ft.ini</yarpConfigurationFile>
-          </plugin>
+    #- jointName: l_leg_ft_sensor
+    #  directionChildToParent: Yes
+    #  frame: sensor
+    #  frameName: SCSYS_L_HIP_2_FT
+    #  sensorBlobs:
+    #  - |
+    #      <plugin name="left_leg_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
+    #        <yarpConfigurationFile>model://iCub/conf_icub3/FT/gazebo_icub_left_leg_ft.ini</yarpConfigurationFile>
+    #      </plugin>
     - jointName: l_foot_front_ft_sensor
       directionChildToParent: No
       frame: sensor
@@ -267,15 +267,15 @@ forceTorqueSensors:
             <yarpConfigurationFile>model://iCub/conf_icub3/FT/gazebo_icub_left_foot_rear_ft.ini</yarpConfigurationFile>
           </plugin>
     # right leg
-    - jointName: r_leg_ft_sensor
-      directionChildToParent: Yes
-      frame: sensor
-      frameName: SCSYS_R_HIP_2_FT
-      sensorBlobs:
-      - |
-          <plugin name="right_leg_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
-            <yarpConfigurationFile>model://iCub/conf_icub3/FT/gazebo_icub_right_leg_ft.ini</yarpConfigurationFile>
-          </plugin>
+    #- jointName: r_leg_ft_sensor
+    #  directionChildToParent: Yes
+    #  frame: sensor
+    #  frameName: SCSYS_R_HIP_2_FT
+    #  sensorBlobs:
+    #  - |
+    #      <plugin name="right_leg_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
+    #        <yarpConfigurationFile>model://iCub/conf_icub3/FT/gazebo_icub_right_leg_ft.ini</yarpConfigurationFile>
+    #      </plugin>
     - jointName: r_foot_front_ft_sensor
       directionChildToParent: No
       frame: sensor

--- a/simmechanics/data/icub3/ICUB_3_all_options_gazebo.yaml.in
+++ b/simmechanics/data/icub3/ICUB_3_all_options_gazebo.yaml.in
@@ -236,15 +236,15 @@ forceTorqueSensors:
             <yarpConfigurationFile>model://iCub/conf_icub3/FT/gazebo_icub_right_arm_ft.ini</yarpConfigurationFile>
           </plugin>
     # left leg
-    - jointName: l_leg_ft_sensor
-      directionChildToParent: Yes
-      frame: sensor
-      frameName: SCSYS_L_HIP_2_FT
-      sensorBlobs:
-      - |
-          <plugin name="left_leg_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
-            <yarpConfigurationFile>model://iCub/conf_icub3/FT/gazebo_icub_left_leg_ft.ini</yarpConfigurationFile>
-          </plugin>
+    #- jointName: l_leg_ft_sensor
+    #  directionChildToParent: Yes
+    #  frame: sensor
+    #  frameName: SCSYS_L_HIP_2_FT
+    #  sensorBlobs:
+    #  - |
+    #      <plugin name="left_leg_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
+    #        <yarpConfigurationFile>model://iCub/conf_icub3/FT/gazebo_icub_left_leg_ft.ini</yarpConfigurationFile>
+    #      </plugin>
     - jointName: l_foot_front_ft_sensor
       directionChildToParent: No
       frame: sensor
@@ -264,15 +264,15 @@ forceTorqueSensors:
             <yarpConfigurationFile>model://iCub/conf_icub3/FT/gazebo_icub_left_foot_rear_ft.ini</yarpConfigurationFile>
           </plugin>
     # right leg
-    - jointName: r_leg_ft_sensor
-      directionChildToParent: Yes
-      frame: sensor
-      frameName: SCSYS_R_HIP_2_FT
-      sensorBlobs:
-      - |
-          <plugin name="right_leg_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
-            <yarpConfigurationFile>model://iCub/conf_icub3/FT/gazebo_icub_right_leg_ft.ini</yarpConfigurationFile>
-          </plugin>
+    #- jointName: r_leg_ft_sensor
+    #  directionChildToParent: Yes
+    #  frame: sensor
+    #  frameName: SCSYS_R_HIP_2_FT
+    #  sensorBlobs:
+    #  - |
+    #      <plugin name="right_leg_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
+    #        <yarpConfigurationFile>model://iCub/conf_icub3/FT/gazebo_icub_right_leg_ft.ini</yarpConfigurationFile>
+    #      </plugin>
     - jointName: r_foot_front_ft_sensor
       directionChildToParent: No
       frame: sensor


### PR DESCRIPTION
As per title.

I kept the fixed joints, it should be harmless.

Moreover I set the height of the origin of the model to 64 cm also in `iCubGenvoa09`(~ the height of the root link from the ground)

cc @S-Dafarra @pattacini 