### PR TITLE
iCub3: add realsense imu

### DIFF
--- a/simmechanics/data/icub3/ICUB_3_all_options.yaml
+++ b/simmechanics/data/icub3/ICUB_3_all_options.yaml
@@ -396,7 +396,17 @@ sensors:
         <plugin name="iCub_yarp_gazebo_plugin_camera" filename="libgazebo_yarp_camera.so">
             <yarpConfigurationFile>model://iCub/conf_icub3/gazebo_icub_rgb_camera.ini</yarpConfigurationFile>
         </plugin>
-
+  # According to https://github.com/IntelRealSense/realsense-ros/issues/927 in the realsense
+  # the imu measurements are referred to the depth frame.
+  - frameName: SCSYS_CHEST_DEPTH
+    linkName: chest
+    sensorName: chest_imu_acc_1x1
+    sensorType: "accelerometer"
+    sensorBlobs:
+    - |
+        <plugin name="iCub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
+            <yarpConfigurationFile>model://iCub/conf_icub3/gazebo_icub_chest_inertial.ini</yarpConfigurationFile>
+        </plugin>
 assignedMasses:
   # It fixes the right/left asymmetry for the legs
   r_hip_1: 2.48546

--- a/simmechanics/data/icub3/ICUB_3_all_options_gazebo.yaml.in
+++ b/simmechanics/data/icub3/ICUB_3_all_options_gazebo.yaml.in
@@ -391,6 +391,19 @@ sensors:
         <plugin name="iCub_yarp_gazebo_plugin_camera" filename="libgazebo_yarp_camera.so">
             <yarpConfigurationFile>model://iCub/conf_icub3/gazebo_icub_rgb_camera.ini</yarpConfigurationFile>
         </plugin>
+  # According to https://github.com/IntelRealSense/realsense-ros/issues/927 in the realsense
+  # the imu measurements are referred to the depth frame.
+  - frameName: SCSYS_CHEST_DEPTH
+    linkName: chest
+    sensorName: chest_imu_acc_1x1
+    sensorType: "accelerometer"
+    sensorBlobs:
+    - |
+        <plugin name="iCub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
+            <yarpConfigurationFile>model://iCub/conf_icub3/gazebo_icub_chest_inertial.ini</yarpConfigurationFile>
+        </plugin>
+
+
 
 @ASSIGNED_COLLISION_GEOMETRIES@
 

--- a/simmechanics/data/icub3/conf/gazebo_icub_chest_inertial.ini
+++ b/simmechanics/data/icub3/conf/gazebo_icub_chest_inertial.ini
@@ -1,0 +1,14 @@
+[include "gazebo_icub_robotname.ini"]
+
+[WRAPPER]
+device multipleanalogsensorsserver
+name /${gazeboYarpPluginsRobotName}/chest/inertials
+period 10
+
+[ADDITIONAL_WRAPPER]
+device inertial
+name /${gazeboYarpPluginsRobotName}/chest/inertial
+period 0.01
+
+[IMU_DRIVER]
+device gazebo_imu

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,8 +4,7 @@ find_package(iDynTree REQUIRED)
 find_package(YARP     REQUIRED)
 
 add_executable(icub-model-test icub-model-test.cpp)
-include_directories(${YARP_INCLUDE_DIRS})
-target_link_libraries(icub-model-test ${iDynTree_LIBRARIES} ${YARP_LIBRARIES})
+target_link_libraries(icub-model-test ${iDynTree_LIBRARIES} YARP::YARP_os)
 
 macro(add_icub_model_test yarpRobotName)
     add_test(NAME ${yarpRobotName}ConsistencyCheck


### PR DESCRIPTION
This PR adds the imu sensor contained in the intel realsense of the chest (D435i).

The sensor has been called simply `chest_imu_acc_1x1` similarly to the one in the head (`head_imu_acc_1x1`).

The name can be changed/discussed.

As explained here https://github.com/IntelRealSense/realsense-ros/issues/927, the imu measurement are referred to the depth frame, and here it is what I read from the `/icubSim/chest/inertials/measures:o`:

```
(((-0.0803231336812528090574 0.105600261803569975272 -0.0575165845263962208223) 39.9040000000000034674)) (((0.0139543972809083767495 -9.89029974843219328307 -0.000291674178350950774607) 39.9040000000000034674)) (((0.0 0.0 0.0) 39.9040000000000034674)) (((-0.0392458976633651424049 0.00484875015179548479738 0.00352405535083964369103) 39.9040000000000034674)) () () () () () ()
```
As you can see, on the y we measure the g (-9.8) since in the depth frame the y points downwards.

Please review code.

cc @S-Dafarra @prashanthr05 @pattacini 