### PR TITLE
Improve the generation of the commit message in icub-models

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,9 +102,9 @@ jobs:
         cmake --build . --target copy-models-to-icub-models
         # Generate commit message 
         echo "Automatic build. GitHub Actions build: $GITHUB_RUN_ID" >> ${GITHUB_WORKSPACE}/deploy_commit_message
-        echo "icub-model-generator commit:$GITHUB_SHA" >> ${GITHUB_WORKSPACE}/deploy_commit_message
-        echo "urdf_parser_py commit:$URDF_PARSER_PY_COMMIT" >> ${GITHUB_WORKSPACE}/deploy_commit_message
-        echo "simmechanics-to-urdf commit:$SIMMECHANICS_TO_URDF_COMMIT" >> ${GITHUB_WORKSPACE}/deploy_commit_message
+        echo "icub-model-generator commit:robotology/icub-models-generator@$GITHUB_SHA" >> ${GITHUB_WORKSPACE}/deploy_commit_message
+        echo "urdf_parser_py commit:ros/urdf_parser_py@$URDF_PARSER_PY_COMMIT" >> ${GITHUB_WORKSPACE}/deploy_commit_message
+        echo "simmechanics-to-urdf commit:robotology/simmechanics-to-urdf@$SIMMECHANICS_TO_URDF_COMMIT" >> ${GITHUB_WORKSPACE}/deploy_commit_message
 
     - name: Print generated models differences
       run: |


### PR DESCRIPTION
With this PR the commits in `icub-models` will contain the link to the commit of:
- icub-model-generator
- urdf_parser_py
- simmechanics-to-urdf


cc @Nicogene and @traversaro 