### PR TITLE
iCub3: fix neck_yaw axis direction

### DIFF
--- a/simmechanics/data/icub3/ICUB_3_all_options.yaml
+++ b/simmechanics/data/icub3/ICUB_3_all_options.yaml
@@ -483,6 +483,7 @@ reverseRotationAxis:
     torso_yaw
     torso_pitch
     torso_roll
+    neck_yaw
 XMLBlobs:
     # upperbody
     - |

--- a/simmechanics/data/icub3/ICUB_3_all_options_gazebo.yaml.in
+++ b/simmechanics/data/icub3/ICUB_3_all_options_gazebo.yaml.in
@@ -573,6 +573,7 @@ reverseRotationAxis:
     torso_yaw
     torso_pitch
     torso_roll
+    neck_yaw
 XMLBlobs:
     # upperbody
     - |

--- a/simmechanics/data/icub3/ICUB_3_head_options.yaml
+++ b/simmechanics/data/icub3/ICUB_3_head_options.yaml
@@ -50,6 +50,8 @@ forceTorqueSensors:
         <plugin name="left_foot_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
           <yarpConfigurationFile>model://iCub/conf/FT/gazebo_icub_left_foot_ft.ini</yarpConfigurationFile>
         </plugin>
+reverseRotationAxis:
+    neck_yaw        
 # TODO: fix different mapping of torso joints in controlboard
 XMLBlobs:
     - |


### PR DESCRIPTION
Today while @kouroshD @Yeshasvitvs @lrapetti @S-Dafarra were testing XSens retargeting on the robot, they realized that the `neck_yaw` joint axis has been reversed from the currently available URDF model. It was simply fixed by changing the axis tag sign in the URDF for the neck_yaw joint an was tested to be working as expected.

This PR fixes the `neck_yaw` axis direction.