### PR TITLE
Fix link in autogenerated commit in icub-models

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,9 +102,9 @@ jobs:
         cmake --build . --target copy-models-to-icub-models
         # Generate commit message 
         echo "Automatic build. GitHub Actions build: $GITHUB_RUN_ID" >> ${GITHUB_WORKSPACE}/deploy_commit_message
-        echo "icub-model-generator commit:robotology/icub-models-generator@$GITHUB_SHA" >> ${GITHUB_WORKSPACE}/deploy_commit_message
-        echo "urdf_parser_py commit:ros/urdf_parser_py@$URDF_PARSER_PY_COMMIT" >> ${GITHUB_WORKSPACE}/deploy_commit_message
-        echo "simmechanics-to-urdf commit:robotology/simmechanics-to-urdf@$SIMMECHANICS_TO_URDF_COMMIT" >> ${GITHUB_WORKSPACE}/deploy_commit_message
+        echo "icub-model-generator commit: robotology/icub-models-generator@$GITHUB_SHA" >> ${GITHUB_WORKSPACE}/deploy_commit_message
+        echo "urdf_parser_py commit: ros/urdf_parser_py@$URDF_PARSER_PY_COMMIT" >> ${GITHUB_WORKSPACE}/deploy_commit_message
+        echo "simmechanics-to-urdf commit: robotology/simmechanics-to-urdf@$SIMMECHANICS_TO_URDF_COMMIT" >> ${GITHUB_WORKSPACE}/deploy_commit_message
 
     - name: Print generated models differences
       run: |


### PR DESCRIPTION
Unfortunately https://github.com/robotology/icub-models-generator/pull/190 does not add the link in the ` icub-models` commits.

![image](https://user-images.githubusercontent.com/16744101/102017016-7bebb180-3d64-11eb-9fdd-1540df69cd34.png)

Adding white space between `commit:` and the `Username/Repository@SHA` the issue should be solved

Please find here further details: https://docs.github.com/en/free-pro-team@latest/github/writing-on-github/autolinked-references-and-urls