### PR TITLE
iCub3 masses updated

### DIFF
--- a/simmechanics/data/icub3/ICUB3_ALL_SIM_MODEL.xml
+++ b/simmechanics/data/icub3/ICUB3_ALL_SIM_MODEL.xml
@@ -9,7 +9,7 @@
 
   <createdFrom>"Pro/E Wildfire Creo 7.0 - 2020454"</createdFrom>
 
-  <createdOn>"04/30/21||15:05:46"</createdOn>
+  <createdOn>"08/06/21||09:42:39"</createdOn>
 
   <createdBy>"silo-mech"</createdBy>
 
@@ -84,7 +84,7 @@
             <orientationUnits>"rad"</orientationUnits>
             <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
           </Frame>
-          <Frame ref="13">
+          <Frame ref="33">
             <name>"CS4"</name>
             <displayName>""</displayName>
             <nodeID>"61:-:65::61(AUTOGEN)"</nodeID>
@@ -97,10 +97,10 @@
             <orientationUnits>"rad"</orientationUnits>
             <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
           </Frame>
-          <Frame ref="31">
+          <Frame ref="35">
             <name>"CS5"</name>
             <displayName>""</displayName>
-            <nodeID>"61:-:88::61(AUTOGEN)"</nodeID>
+            <nodeID>"134:-:61::61(AUTOGEN)"</nodeID>
             <position>0.05,21.6,-313.858</position>
             <positionOrigin>"WORLD"</positionOrigin>
             <positionReferenceFrame>"WORLD"</positionReferenceFrame>
@@ -110,10 +110,10 @@
             <orientationUnits>"rad"</orientationUnits>
             <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
           </Frame>
-          <Frame ref="33">
+          <Frame ref="37">
             <name>"CS6"</name>
             <displayName>""</displayName>
-            <nodeID>"61:-:97::61(AUTOGEN)"</nodeID>
+            <nodeID>"135:-:61::61(AUTOGEN)"</nodeID>
             <position>-46.75,21.6,-313.858</position>
             <positionOrigin>"WORLD"</positionOrigin>
             <positionReferenceFrame>"WORLD"</positionReferenceFrame>
@@ -143,7 +143,7 @@
             <name>"CG"</name>
             <displayName>""</displayName>
             <nodeID>"SIM_ICUB3/RootPart::CG(AUTOGEN)"</nodeID>
-            <position>1.72376,6.36182,-369.626</position>
+            <position>1.13206,6.44551,-352.786</position>
             <positionOrigin>"WORLD"</positionOrigin>
             <positionReferenceFrame>"WORLD"</positionReferenceFrame>
             <positionUnits>"mm"</positionUnits>
@@ -182,7 +182,7 @@
             <name>"CS3"</name>
             <displayName>""</displayName>
             <nodeID>"RootGround:-:SIM_ICUB3/RootPart::SIM_ICUB3/RootPart(AUTOGEN)"</nodeID>
-            <position>1.72376,6.36182,-369.626</position>
+            <position>1.13206,6.44551,-352.786</position>
             <positionOrigin>"WORLD"</positionOrigin>
             <positionReferenceFrame>"WORLD"</positionReferenceFrame>
             <positionUnits>"mm"</positionUnits>
@@ -246,11 +246,11 @@
             <orientationUnits>"rad"</orientationUnits>
             <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
           </Frame>
-          <Frame ref="11">
+          <Frame ref="34">
             <name>"CS3"</name>
             <displayName>""</displayName>
-            <nodeID>"65:-:67::65(AUTOGEN)"</nodeID>
-            <position>-36.15,0,-180.858</position>
+            <nodeID>"61:-:65::65(AUTOGEN)"</nodeID>
+            <position>0.05,-34.6,-253.358</position>
             <positionOrigin>"WORLD"</positionOrigin>
             <positionReferenceFrame>"WORLD"</positionReferenceFrame>
             <positionUnits>"mm"</positionUnits>
@@ -259,11 +259,11 @@
             <orientationUnits>"rad"</orientationUnits>
             <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
           </Frame>
-          <Frame ref="14">
+          <Frame ref="45">
             <name>"CS4"</name>
             <displayName>""</displayName>
-            <nodeID>"61:-:65::65(AUTOGEN)"</nodeID>
-            <position>0.05,-34.6,-253.358</position>
+            <nodeID>"65:-:67::65(AUTOGEN)"</nodeID>
+            <position>-36.15,0,-180.858</position>
             <positionOrigin>"WORLD"</positionOrigin>
             <positionReferenceFrame>"WORLD"</positionReferenceFrame>
             <positionUnits>"mm"</positionUnits>
@@ -327,11 +327,11 @@
             <orientationUnits>"rad"</orientationUnits>
             <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
           </Frame>
-          <Frame ref="12">
+          <Frame ref="29">
             <name>"CS3"</name>
             <displayName>""</displayName>
-            <nodeID>"65:-:67::67(AUTOGEN)"</nodeID>
-            <position>-36.15,0,-180.858</position>
+            <nodeID>"136:-:67::67(AUTOGEN)"</nodeID>
+            <position>0,0,-141.388</position>
             <positionOrigin>"WORLD"</positionOrigin>
             <positionReferenceFrame>"WORLD"</positionReferenceFrame>
             <positionUnits>"mm"</positionUnits>
@@ -340,11 +340,11 @@
             <orientationUnits>"rad"</orientationUnits>
             <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
           </Frame>
-          <Frame ref="29">
+          <Frame ref="46">
             <name>"CS4"</name>
             <displayName>""</displayName>
-            <nodeID>"67:-:69::67(AUTOGEN)"</nodeID>
-            <position>0,0,-141.388</position>
+            <nodeID>"65:-:67::67(AUTOGEN)"</nodeID>
+            <position>-36.15,0,-180.858</position>
             <positionOrigin>"WORLD"</positionOrigin>
             <positionReferenceFrame>"WORLD"</positionReferenceFrame>
             <positionUnits>"mm"</positionUnits>
@@ -358,22 +358,22 @@
       </Body>
       <Body>
         <name>"SIM_ICUB3_CHEST"</name>
-        <nodeID>"69"</nodeID>
+        <nodeID>"136"</nodeID>
         <status>""</status>
-        <mass>5.75757</mass>
+        <mass>6.10196</mass>
         <massUnits>"kg"</massUnits>
-        <inertia>0.0255632,-5.31274e-005,9.38021e-005,-5.31274e-005,0.0261369,-0.000610637,9.38021e-005,-0.000610637,0.0222276</inertia>
+        <inertia>0.029959,5.54026e-005,0.000153956,5.54026e-005,0.0260511,-0.00267421,0.000153956,-0.00267421,0.0261044</inertia>
         <inertiaUnits>"kg*m^2"</inertiaUnits>
-        <volume>2.00733e+006</volume>
+        <volume>2.00728e+006</volume>
         <volumeUnits>"mm^3"</volumeUnits>
-        <surfaceArea>1.19625e+006</surfaceArea>
+        <surfaceArea>1.19622e+006</surfaceArea>
         <surfaceAreaUnits>"mm^2"</surfaceAreaUnits>
         <frames>
           <Frame>
             <name>"CG"</name>
             <displayName>""</displayName>
-            <nodeID>"69::CG(AUTOGEN)"</nodeID>
-            <position>0.262139,-13.3964,-61.2543</position>
+            <nodeID>"136::CG(AUTOGEN)"</nodeID>
+            <position>0.0607081,-4.33942,-55.5868</position>
             <positionOrigin>"WORLD"</positionOrigin>
             <positionReferenceFrame>"WORLD"</positionReferenceFrame>
             <positionUnits>"mm"</positionUnits>
@@ -385,7 +385,7 @@
           <Frame>
             <name>"CS1"</name>
             <displayName>""</displayName>
-            <nodeID>"69::CS1(AUTOGEN)"</nodeID>
+            <nodeID>"136::CS1(AUTOGEN)"</nodeID>
             <position>1.55437e-016,-1.2278e-013,1.21683e-013</position>
             <positionOrigin>"WORLD"</positionOrigin>
             <positionReferenceFrame>"WORLD"</positionReferenceFrame>
@@ -397,13 +397,13 @@
           </Frame>
           <Frame>
             <name>"CS2"</name>
-            <displayName>"SCSYS_CHEST_RGB"</displayName>
-            <nodeID>"1795(USERADDED)"</nodeID>
-            <position>11.5,89.4115,-17.0885</position>
+            <displayName>"SCSYS_CHEST"</displayName>
+            <nodeID>"1782(USERADDED)"</nodeID>
+            <position>0,0,-116.388</position>
             <positionOrigin>"WORLD"</positionOrigin>
             <positionReferenceFrame>"WORLD"</positionReferenceFrame>
             <positionUnits>"mm"</positionUnits>
-            <orientation>1,0,0,0,0,-1,0,1,0</orientation>
+            <orientation>0,1,0,-1,0,0,0,0,1</orientation>
             <orientationType>"3x3 Transform"</orientationType>
             <orientationUnits>"rad"</orientationUnits>
             <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
@@ -411,7 +411,7 @@
           <Frame>
             <name>"CS3"</name>
             <displayName>"SCSYS_CHEST_DEPTH"</displayName>
-            <nodeID>"1796(USERADDED)"</nodeID>
+            <nodeID>"1784(USERADDED)"</nodeID>
             <position>-17.5,89.4115,-17.0885</position>
             <positionOrigin>"WORLD"</positionOrigin>
             <positionReferenceFrame>"WORLD"</positionReferenceFrame>
@@ -423,21 +423,47 @@
           </Frame>
           <Frame>
             <name>"CS4"</name>
-            <displayName>"SCSYS_CHEST"</displayName>
-            <nodeID>"1798(USERADDED)"</nodeID>
-            <position>0,0,-116.388</position>
+            <displayName>"SCSYS_CHEST_RGB"</displayName>
+            <nodeID>"1785(USERADDED)"</nodeID>
+            <position>11.5,89.4115,-17.0885</position>
             <positionOrigin>"WORLD"</positionOrigin>
             <positionReferenceFrame>"WORLD"</positionReferenceFrame>
             <positionUnits>"mm"</positionUnits>
-            <orientation>0,1,0,-1,0,0,0,0,1</orientation>
+            <orientation>1,0,0,0,0,-1,0,1,0</orientation>
             <orientationType>"3x3 Transform"</orientationType>
             <orientationUnits>"rad"</orientationUnits>
             <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
           </Frame>
-          <Frame ref="23">
+          <Frame ref="19">
             <name>"CS5"</name>
             <displayName>""</displayName>
-            <nodeID>"69:-:73::69(AUTOGEN)"</nodeID>
+            <nodeID>"120:-:136::136(AUTOGEN)"</nodeID>
+            <position>0.0607081,-4.33942,-55.5868</position>
+            <positionOrigin>"WORLD"</positionOrigin>
+            <positionReferenceFrame>"WORLD"</positionReferenceFrame>
+            <positionUnits>"mm"</positionUnits>
+            <orientation>1,0,0,0,1,0,0,0,1</orientation>
+            <orientationType>"3x3 Transform"</orientationType>
+            <orientationUnits>"rad"</orientationUnits>
+            <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
+          </Frame>
+          <Frame ref="25">
+            <name>"CS6"</name>
+            <displayName>""</displayName>
+            <nodeID>"136:-:71::136(AUTOGEN)"</nodeID>
+            <position>-95.101,-6.00179,3.64821</position>
+            <positionOrigin>"WORLD"</positionOrigin>
+            <positionReferenceFrame>"WORLD"</positionReferenceFrame>
+            <positionUnits>"mm"</positionUnits>
+            <orientation>1,0,0,0,1,0,0,0,1</orientation>
+            <orientationType>"3x3 Transform"</orientationType>
+            <orientationUnits>"rad"</orientationUnits>
+            <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
+          </Frame>
+          <Frame ref="27">
+            <name>"CS7"</name>
+            <displayName>""</displayName>
+            <nodeID>"136:-:73::136(AUTOGEN)"</nodeID>
             <position>95.101,-6.00179,3.64821</position>
             <positionOrigin>"WORLD"</positionOrigin>
             <positionReferenceFrame>"WORLD"</positionReferenceFrame>
@@ -448,36 +474,10 @@
             <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
           </Frame>
           <Frame ref="30">
-            <name>"CS6"</name>
-            <displayName>""</displayName>
-            <nodeID>"67:-:69::69(AUTOGEN)"</nodeID>
-            <position>0,0,-141.388</position>
-            <positionOrigin>"WORLD"</positionOrigin>
-            <positionReferenceFrame>"WORLD"</positionReferenceFrame>
-            <positionUnits>"mm"</positionUnits>
-            <orientation>1,0,0,0,1,0,0,0,1</orientation>
-            <orientationType>"3x3 Transform"</orientationType>
-            <orientationUnits>"rad"</orientationUnits>
-            <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
-          </Frame>
-          <Frame ref="35">
-            <name>"CS7"</name>
-            <displayName>""</displayName>
-            <nodeID>"69:-:71::69(AUTOGEN)"</nodeID>
-            <position>-95.101,-6.00179,3.64821</position>
-            <positionOrigin>"WORLD"</positionOrigin>
-            <positionReferenceFrame>"WORLD"</positionReferenceFrame>
-            <positionUnits>"mm"</positionUnits>
-            <orientation>1,0,0,0,1,0,0,0,1</orientation>
-            <orientationType>"3x3 Transform"</orientationType>
-            <orientationUnits>"rad"</orientationUnits>
-            <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
-          </Frame>
-          <Frame ref="37">
             <name>"CS8"</name>
             <displayName>""</displayName>
-            <nodeID>"120:-:69::69(AUTOGEN)"</nodeID>
-            <position>0.262139,-13.3964,-61.2543</position>
+            <nodeID>"136:-:67::136(AUTOGEN)"</nodeID>
+            <position>0,0,-141.388</position>
             <positionOrigin>"WORLD"</positionOrigin>
             <positionReferenceFrame>"WORLD"</positionReferenceFrame>
             <positionUnits>"mm"</positionUnits>
@@ -541,11 +541,11 @@
             <orientationUnits>"rad"</orientationUnits>
             <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
           </Frame>
-          <Frame ref="17">
+          <Frame ref="26">
             <name>"CS3"</name>
             <displayName>""</displayName>
-            <nodeID>"71:-:75::71(AUTOGEN)"</nodeID>
-            <position>-132.607,47.4666,18.937</position>
+            <nodeID>"136:-:71::71(AUTOGEN)"</nodeID>
+            <position>-95.101,-6.00179,3.64821</position>
             <positionOrigin>"WORLD"</positionOrigin>
             <positionReferenceFrame>"WORLD"</positionReferenceFrame>
             <positionUnits>"mm"</positionUnits>
@@ -554,11 +554,11 @@
             <orientationUnits>"rad"</orientationUnits>
             <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
           </Frame>
-          <Frame ref="36">
+          <Frame ref="31">
             <name>"CS4"</name>
             <displayName>""</displayName>
-            <nodeID>"69:-:71::71(AUTOGEN)"</nodeID>
-            <position>-95.101,-6.00179,3.64821</position>
+            <nodeID>"71:-:75::71(AUTOGEN)"</nodeID>
+            <position>-132.607,47.4666,18.937</position>
             <positionOrigin>"WORLD"</positionOrigin>
             <positionReferenceFrame>"WORLD"</positionReferenceFrame>
             <positionUnits>"mm"</positionUnits>
@@ -622,11 +622,11 @@
             <orientationUnits>"rad"</orientationUnits>
             <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
           </Frame>
-          <Frame ref="19">
+          <Frame ref="28">
             <name>"CS3"</name>
             <displayName>""</displayName>
-            <nodeID>"73:-:77::73(AUTOGEN)"</nodeID>
-            <position>132.878,46.5056,18.885</position>
+            <nodeID>"136:-:73::73(AUTOGEN)"</nodeID>
+            <position>95.101,-6.00179,3.64821</position>
             <positionOrigin>"WORLD"</positionOrigin>
             <positionReferenceFrame>"WORLD"</positionReferenceFrame>
             <positionUnits>"mm"</positionUnits>
@@ -635,11 +635,11 @@
             <orientationUnits>"rad"</orientationUnits>
             <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
           </Frame>
-          <Frame ref="24">
+          <Frame ref="39">
             <name>"CS4"</name>
             <displayName>""</displayName>
-            <nodeID>"69:-:73::73(AUTOGEN)"</nodeID>
-            <position>95.101,-6.00179,3.64821</position>
+            <nodeID>"73:-:77::73(AUTOGEN)"</nodeID>
+            <position>132.878,46.5056,18.885</position>
             <positionOrigin>"WORLD"</positionOrigin>
             <positionReferenceFrame>"WORLD"</positionReferenceFrame>
             <positionUnits>"mm"</positionUnits>
@@ -716,11 +716,11 @@
             <orientationUnits>"rad"</orientationUnits>
             <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
           </Frame>
-          <Frame ref="15">
+          <Frame ref="32">
             <name>"CS4"</name>
             <displayName>""</displayName>
-            <nodeID>"75:-:81::75(AUTOGEN)"</nodeID>
-            <position>-143.728,17.1301,-10.5368</position>
+            <nodeID>"71:-:75::75(AUTOGEN)"</nodeID>
+            <position>-132.607,47.4666,18.937</position>
             <positionOrigin>"WORLD"</positionOrigin>
             <positionReferenceFrame>"WORLD"</positionReferenceFrame>
             <positionUnits>"mm"</positionUnits>
@@ -729,11 +729,11 @@
             <orientationUnits>"rad"</orientationUnits>
             <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
           </Frame>
-          <Frame ref="18">
+          <Frame ref="41">
             <name>"CS5"</name>
             <displayName>""</displayName>
-            <nodeID>"71:-:75::75(AUTOGEN)"</nodeID>
-            <position>-132.607,47.4666,18.937</position>
+            <nodeID>"75:-:81::75(AUTOGEN)"</nodeID>
+            <position>-143.728,17.1301,-10.5368</position>
             <positionOrigin>"WORLD"</positionOrigin>
             <positionReferenceFrame>"WORLD"</positionReferenceFrame>
             <positionUnits>"mm"</positionUnits>
@@ -810,11 +810,11 @@
             <orientationUnits>"rad"</orientationUnits>
             <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
           </Frame>
-          <Frame ref="20">
+          <Frame ref="21">
             <name>"CS4"</name>
             <displayName>""</displayName>
-            <nodeID>"73:-:77::77(AUTOGEN)"</nodeID>
-            <position>132.878,46.5056,18.885</position>
+            <nodeID>"77:-:79::77(AUTOGEN)"</nodeID>
+            <position>143.783,17.0607,-10.5383</position>
             <positionOrigin>"WORLD"</positionOrigin>
             <positionReferenceFrame>"WORLD"</positionReferenceFrame>
             <positionUnits>"mm"</positionUnits>
@@ -823,11 +823,11 @@
             <orientationUnits>"rad"</orientationUnits>
             <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
           </Frame>
-          <Frame ref="21">
+          <Frame ref="40">
             <name>"CS5"</name>
             <displayName>""</displayName>
-            <nodeID>"77:-:79::77(AUTOGEN)"</nodeID>
-            <position>143.783,17.0607,-10.5383</position>
+            <nodeID>"73:-:77::77(AUTOGEN)"</nodeID>
+            <position>132.878,46.5056,18.885</position>
             <positionOrigin>"WORLD"</positionOrigin>
             <positionReferenceFrame>"WORLD"</positionReferenceFrame>
             <positionUnits>"mm"</positionUnits>
@@ -904,7 +904,7 @@
             <orientationUnits>"rad"</orientationUnits>
             <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
           </Frame>
-          <Frame ref="25">
+          <Frame ref="23">
             <name>"CS4"</name>
             <displayName>""</displayName>
             <nodeID>"126:-:79::79(AUTOGEN)"</nodeID>
@@ -972,7 +972,7 @@
             <orientationUnits>"rad"</orientationUnits>
             <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
           </Frame>
-          <Frame ref="16">
+          <Frame ref="42">
             <name>"CS3"</name>
             <displayName>""</displayName>
             <nodeID>"75:-:81::81(AUTOGEN)"</nodeID>
@@ -985,7 +985,7 @@
             <orientationUnits>"rad"</orientationUnits>
             <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
           </Frame>
-          <Frame ref="27">
+          <Frame ref="43">
             <name>"CS4"</name>
             <displayName>""</displayName>
             <nodeID>"129:-:81::81(AUTOGEN)"</nodeID>
@@ -1053,7 +1053,7 @@
             <orientationUnits>"rad"</orientationUnits>
             <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
           </Frame>
-          <Frame ref="28">
+          <Frame ref="44">
             <name>"CS3"</name>
             <displayName>""</displayName>
             <nodeID>"129:-:81::129(AUTOGEN)"</nodeID>
@@ -1066,7 +1066,7 @@
             <orientationUnits>"rad"</orientationUnits>
             <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
           </Frame>
-          <Frame ref="57">
+          <Frame ref="47">
             <name>"CS4"</name>
             <displayName>""</displayName>
             <nodeID>"110:-:129::129(AUTOGEN)"</nodeID>
@@ -1134,7 +1134,7 @@
             <orientationUnits>"rad"</orientationUnits>
             <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
           </Frame>
-          <Frame ref="26">
+          <Frame ref="24">
             <name>"CS3"</name>
             <displayName>""</displayName>
             <nodeID>"126:-:79::126(AUTOGEN)"</nodeID>
@@ -1147,10 +1147,10 @@
             <orientationUnits>"rad"</orientationUnits>
             <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
           </Frame>
-          <Frame ref="77">
+          <Frame ref="79">
             <name>"CS4"</name>
             <displayName>""</displayName>
-            <nodeID>"111:-:126::126(AUTOGEN)"</nodeID>
+            <nodeID>"126:-:137::126(AUTOGEN)"</nodeID>
             <position>174.568,37.4943,-180.569</position>
             <positionOrigin>"WORLD"</positionOrigin>
             <positionReferenceFrame>"WORLD"</positionReferenceFrame>
@@ -1165,11 +1165,11 @@
       </Body>
       <Body>
         <name>"SIM_ICUB3_R_HIP_1"</name>
-        <nodeID>"88"</nodeID>
+        <nodeID>"134"</nodeID>
         <status>""</status>
-        <mass>2.50002</mass>
+        <mass>2.25666</mass>
         <massUnits>"kg"</massUnits>
-        <inertia>0.00297897,2.5017e-005,-6.41747e-006,2.5017e-005,0.00239087,1.70293e-005,-6.41747e-006,1.70293e-005,0.00250378</inertia>
+        <inertia>0.00279511,4.03052e-005,-3.82938e-006,4.03052e-005,0.00216006,1.16556e-005,-3.82938e-006,1.16556e-005,0.00229648</inertia>
         <inertiaUnits>"kg*m^2"</inertiaUnits>
         <volume>461243</volume>
         <volumeUnits>"mm^3"</volumeUnits>
@@ -1179,8 +1179,8 @@
           <Frame>
             <name>"CG"</name>
             <displayName>""</displayName>
-            <nodeID>"88::CG(AUTOGEN)"</nodeID>
-            <position>71.6772,19.3156,-314.39</position>
+            <nodeID>"134::CG(AUTOGEN)"</nodeID>
+            <position>69.3954,18.7851,-314.486</position>
             <positionOrigin>"WORLD"</positionOrigin>
             <positionReferenceFrame>"WORLD"</positionReferenceFrame>
             <positionUnits>"mm"</positionUnits>
@@ -1192,7 +1192,7 @@
           <Frame>
             <name>"CS1"</name>
             <displayName>""</displayName>
-            <nodeID>"88::CS1(AUTOGEN)"</nodeID>
+            <nodeID>"134::CS1(AUTOGEN)"</nodeID>
             <position>1.35313e-013,0,0</position>
             <positionOrigin>"WORLD"</positionOrigin>
             <positionReferenceFrame>"WORLD"</positionReferenceFrame>
@@ -1205,7 +1205,7 @@
           <Frame>
             <name>"CS2"</name>
             <displayName>"SCSYS_R_HIP_1"</displayName>
-            <nodeID>"1299(USERADDED)"</nodeID>
+            <nodeID>"1271(USERADDED)"</nodeID>
             <position>40.55,21.6,-313.858</position>
             <positionOrigin>"WORLD"</positionOrigin>
             <positionReferenceFrame>"WORLD"</positionReferenceFrame>
@@ -1215,10 +1215,10 @@
             <orientationUnits>"rad"</orientationUnits>
             <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
           </Frame>
-          <Frame ref="32">
+          <Frame ref="36">
             <name>"CS3"</name>
             <displayName>""</displayName>
-            <nodeID>"61:-:88::88(AUTOGEN)"</nodeID>
+            <nodeID>"134:-:61::134(AUTOGEN)"</nodeID>
             <position>0.05,21.6,-313.858</position>
             <positionOrigin>"WORLD"</positionOrigin>
             <positionReferenceFrame>"WORLD"</positionReferenceFrame>
@@ -1228,10 +1228,10 @@
             <orientationUnits>"rad"</orientationUnits>
             <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
           </Frame>
-          <Frame ref="53">
+          <Frame ref="49">
             <name>"CS4"</name>
             <displayName>""</displayName>
-            <nodeID>"88:-:89::88(AUTOGEN)"</nodeID>
+            <nodeID>"134:-:89::134(AUTOGEN)"</nodeID>
             <position>73.65,-32.45,-322.858</position>
             <positionOrigin>"WORLD"</positionOrigin>
             <positionReferenceFrame>"WORLD"</positionReferenceFrame>
@@ -1309,10 +1309,10 @@
             <orientationUnits>"rad"</orientationUnits>
             <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
           </Frame>
-          <Frame ref="54">
+          <Frame ref="50">
             <name>"CS4"</name>
             <displayName>""</displayName>
-            <nodeID>"88:-:89::89(AUTOGEN)"</nodeID>
+            <nodeID>"134:-:89::89(AUTOGEN)"</nodeID>
             <position>73.65,-32.45,-322.858</position>
             <positionOrigin>"WORLD"</positionOrigin>
             <positionReferenceFrame>"WORLD"</positionReferenceFrame>
@@ -1322,7 +1322,7 @@
             <orientationUnits>"rad"</orientationUnits>
             <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
           </Frame>
-          <Frame ref="55">
+          <Frame ref="73">
             <name>"CS5"</name>
             <displayName>""</displayName>
             <nodeID>"89:-:90::89(AUTOGEN)"</nodeID>
@@ -1403,7 +1403,7 @@
             <orientationUnits>"rad"</orientationUnits>
             <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
           </Frame>
-          <Frame ref="56">
+          <Frame ref="74">
             <name>"CS4"</name>
             <displayName>""</displayName>
             <nodeID>"89:-:90::90(AUTOGEN)"</nodeID>
@@ -1416,10 +1416,10 @@
             <orientationUnits>"rad"</orientationUnits>
             <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
           </Frame>
-          <Frame ref="59">
+          <Frame ref="75">
             <name>"CS5"</name>
             <displayName>""</displayName>
-            <nodeID>"90:-:91::90(AUTOGEN)"</nodeID>
+            <nodeID>"132:-:90::90(AUTOGEN)"</nodeID>
             <position>58.65,11,-496.058</position>
             <positionOrigin>"WORLD"</positionOrigin>
             <positionReferenceFrame>"WORLD"</positionReferenceFrame>
@@ -1434,22 +1434,22 @@
       </Body>
       <Body>
         <name>"SIM_ICUB3_R_UPPER_LEG"</name>
-        <nodeID>"91"</nodeID>
+        <nodeID>"132"</nodeID>
         <status>""</status>
-        <mass>2.2571</mass>
+        <mass>1.03692</mass>
         <massUnits>"kg"</massUnits>
-        <inertia>0.00483819,-6.66159e-005,0.000338676,-6.66159e-005,0.0048635,0.000517774,0.000338676,0.000517774,0.00195808</inertia>
+        <inertia>0.00230797,-5.20176e-005,0.000257843,-5.20176e-005,0.00284743,0.000287678,0.000257843,0.000287678,0.00118211</inertia>
         <inertiaUnits>"kg*m^2"</inertiaUnits>
-        <volume>401292</volume>
+        <volume>230178</volume>
         <volumeUnits>"mm^3"</volumeUnits>
-        <surfaceArea>170606</surfaceArea>
+        <surfaceArea>117792</surfaceArea>
         <surfaceAreaUnits>"mm^2"</surfaceAreaUnits>
         <frames>
           <Frame>
             <name>"CG"</name>
             <displayName>""</displayName>
-            <nodeID>"91::CG(AUTOGEN)"</nodeID>
-            <position>64.7686,22.0731,-567.744</position>
+            <nodeID>"132::CG(AUTOGEN)"</nodeID>
+            <position>63.027,17.2675,-540.787</position>
             <positionOrigin>"WORLD"</positionOrigin>
             <positionReferenceFrame>"WORLD"</positionReferenceFrame>
             <positionUnits>"mm"</positionUnits>
@@ -1461,7 +1461,7 @@
           <Frame>
             <name>"CS1"</name>
             <displayName>""</displayName>
-            <nodeID>"91::CS1(AUTOGEN)"</nodeID>
+            <nodeID>"132::CS1(AUTOGEN)"</nodeID>
             <position>1.59236e-013,-1.22489e-014,0</position>
             <positionOrigin>"WORLD"</positionOrigin>
             <positionReferenceFrame>"WORLD"</positionReferenceFrame>
@@ -1474,7 +1474,7 @@
           <Frame>
             <name>"CS2"</name>
             <displayName>"SCSYS_R_UPPER_LEG"</displayName>
-            <nodeID>"2541(USERADDED)"</nodeID>
+            <nodeID>"2304(USERADDED)"</nodeID>
             <position>58.65,11,-483.458</position>
             <positionOrigin>"WORLD"</positionOrigin>
             <positionReferenceFrame>"WORLD"</positionReferenceFrame>
@@ -1484,11 +1484,11 @@
             <orientationUnits>"rad"</orientationUnits>
             <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
           </Frame>
-          <Frame ref="60">
+          <Frame ref="57">
             <name>"CS3"</name>
             <displayName>""</displayName>
-            <nodeID>"90:-:91::91(AUTOGEN)"</nodeID>
-            <position>58.65,11,-496.058</position>
+            <nodeID>"132:-:138::132(AUTOGEN)"</nodeID>
+            <position>83.35,26,-589.658</position>
             <positionOrigin>"WORLD"</positionOrigin>
             <positionReferenceFrame>"WORLD"</positionReferenceFrame>
             <positionUnits>"mm"</positionUnits>
@@ -1497,11 +1497,11 @@
             <orientationUnits>"rad"</orientationUnits>
             <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
           </Frame>
-          <Frame ref="61">
+          <Frame ref="76">
             <name>"CS4"</name>
             <displayName>""</displayName>
-            <nodeID>"91:-:92::91(AUTOGEN)"</nodeID>
-            <position>83.35,26,-589.658</position>
+            <nodeID>"132:-:90::132(AUTOGEN)"</nodeID>
+            <position>58.65,11,-496.058</position>
             <positionOrigin>"WORLD"</positionOrigin>
             <positionReferenceFrame>"WORLD"</positionReferenceFrame>
             <positionUnits>"mm"</positionUnits>
@@ -1515,22 +1515,22 @@
       </Body>
       <Body>
         <name>"SIM_ICUB3_R_LOWER_LEG"</name>
-        <nodeID>"92"</nodeID>
+        <nodeID>"138"</nodeID>
         <status>""</status>
-        <mass>5.89871</mass>
+        <mass>5.36503</mass>
         <massUnits>"kg"</massUnits>
-        <inertia>0.0621727,-6.99688e-005,4.01089e-005,-6.99688e-005,0.0591797,-6.8275e-006,4.01089e-005,-6.8275e-006,0.00642096</inertia>
+        <inertia>0.0603533,-8.09408e-005,0.000104015,-8.09408e-005,0.0576924,2.07085e-005,0.000104015,2.07085e-005,0.00600123</inertia>
         <inertiaUnits>"kg*m^2"</inertiaUnits>
-        <volume>1.27452e+006</volume>
+        <volume>1.27186e+006</volume>
         <volumeUnits>"mm^3"</volumeUnits>
-        <surfaceArea>707118</surfaceArea>
+        <surfaceArea>702533</surfaceArea>
         <surfaceAreaUnits>"mm^2"</surfaceAreaUnits>
         <frames>
           <Frame>
             <name>"CG"</name>
             <displayName>""</displayName>
-            <nodeID>"92::CG(AUTOGEN)"</nodeID>
-            <position>61.4325,11.9118,-718.498</position>
+            <nodeID>"138::CG(AUTOGEN)"</nodeID>
+            <position>61.1456,13.3616,-719.085</position>
             <positionOrigin>"WORLD"</positionOrigin>
             <positionReferenceFrame>"WORLD"</positionReferenceFrame>
             <positionUnits>"mm"</positionUnits>
@@ -1542,7 +1542,7 @@
           <Frame>
             <name>"CS1"</name>
             <displayName>""</displayName>
-            <nodeID>"92::CS1(AUTOGEN)"</nodeID>
+            <nodeID>"138::CS1(AUTOGEN)"</nodeID>
             <position>1.9415e-013,-3.33695e-014,0</position>
             <positionOrigin>"WORLD"</positionOrigin>
             <positionReferenceFrame>"WORLD"</positionReferenceFrame>
@@ -1555,7 +1555,7 @@
           <Frame>
             <name>"CS2"</name>
             <displayName>"SCSYS_R_LOWER_LEG"</displayName>
-            <nodeID>"14359(USERADDED)"</nodeID>
+            <nodeID>"14357(USERADDED)"</nodeID>
             <position>83.55,26,-589.658</position>
             <positionOrigin>"WORLD"</positionOrigin>
             <positionReferenceFrame>"WORLD"</positionReferenceFrame>
@@ -1565,11 +1565,11 @@
             <orientationUnits>"rad"</orientationUnits>
             <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
           </Frame>
-          <Frame ref="62">
+          <Frame ref="55">
             <name>"CS3"</name>
             <displayName>""</displayName>
-            <nodeID>"91:-:92::92(AUTOGEN)"</nodeID>
-            <position>83.35,26,-589.658</position>
+            <nodeID>"138:-:93::138(AUTOGEN)"</nodeID>
+            <position>114.95,26,-845.647</position>
             <positionOrigin>"WORLD"</positionOrigin>
             <positionReferenceFrame>"WORLD"</positionReferenceFrame>
             <positionUnits>"mm"</positionUnits>
@@ -1578,11 +1578,11 @@
             <orientationUnits>"rad"</orientationUnits>
             <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
           </Frame>
-          <Frame ref="63">
+          <Frame ref="58">
             <name>"CS4"</name>
             <displayName>""</displayName>
-            <nodeID>"92:-:93::92(AUTOGEN)"</nodeID>
-            <position>114.95,26,-845.647</position>
+            <nodeID>"132:-:138::138(AUTOGEN)"</nodeID>
+            <position>83.35,26,-589.658</position>
             <positionOrigin>"WORLD"</positionOrigin>
             <positionReferenceFrame>"WORLD"</positionReferenceFrame>
             <positionUnits>"mm"</positionUnits>
@@ -1646,10 +1646,10 @@
             <orientationUnits>"rad"</orientationUnits>
             <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
           </Frame>
-          <Frame ref="64">
+          <Frame ref="56">
             <name>"CS3"</name>
             <displayName>""</displayName>
-            <nodeID>"92:-:93::93(AUTOGEN)"</nodeID>
+            <nodeID>"138:-:93::93(AUTOGEN)"</nodeID>
             <position>114.95,26,-845.647</position>
             <positionOrigin>"WORLD"</positionOrigin>
             <positionReferenceFrame>"WORLD"</positionReferenceFrame>
@@ -1659,7 +1659,7 @@
             <orientationUnits>"rad"</orientationUnits>
             <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
           </Frame>
-          <Frame ref="79">
+          <Frame ref="63">
             <name>"CS4"</name>
             <displayName>""</displayName>
             <nodeID>"93:-:94::93(AUTOGEN)"</nodeID>
@@ -1753,7 +1753,7 @@
             <orientationUnits>"rad"</orientationUnits>
             <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
           </Frame>
-          <Frame ref="80">
+          <Frame ref="64">
             <name>"CS5"</name>
             <displayName>""</displayName>
             <nodeID>"93:-:94::94(AUTOGEN)"</nodeID>
@@ -1766,7 +1766,7 @@
             <orientationUnits>"rad"</orientationUnits>
             <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
           </Frame>
-          <Frame ref="81">
+          <Frame ref="77">
             <name>"CS6"</name>
             <displayName>""</displayName>
             <nodeID>"94:-:96::94(AUTOGEN)"</nodeID>
@@ -1779,7 +1779,7 @@
             <orientationUnits>"rad"</orientationUnits>
             <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
           </Frame>
-          <Frame ref="83">
+          <Frame ref="81">
             <name>"CS7"</name>
             <displayName>""</displayName>
             <nodeID>"94:-:95::94(AUTOGEN)"</nodeID>
@@ -1860,7 +1860,7 @@
             <orientationUnits>"rad"</orientationUnits>
             <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
           </Frame>
-          <Frame ref="84">
+          <Frame ref="82">
             <name>"CS4"</name>
             <displayName>""</displayName>
             <nodeID>"94:-:95::95(AUTOGEN)"</nodeID>
@@ -1954,7 +1954,7 @@
             <orientationUnits>"rad"</orientationUnits>
             <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
           </Frame>
-          <Frame ref="82">
+          <Frame ref="78">
             <name>"CS5"</name>
             <displayName>""</displayName>
             <nodeID>"94:-:96::96(AUTOGEN)"</nodeID>
@@ -1972,22 +1972,22 @@
       </Body>
       <Body>
         <name>"SIM_ICUB3_L_HIP_1"</name>
-        <nodeID>"97"</nodeID>
+        <nodeID>"135"</nodeID>
         <status>""</status>
-        <mass>2.48546</mass>
+        <mass>2.22935</mass>
         <massUnits>"kg"</massUnits>
-        <inertia>0.00285629,-2.13955e-005,3.35338e-006,-2.13955e-005,0.00230094,1.79278e-005,3.35338e-006,1.79278e-005,0.00246343</inertia>
+        <inertia>0.00263718,-3.3299e-005,-6.53982e-008,-3.3299e-005,0.00206052,1.78225e-005,-6.53982e-008,1.78225e-005,0.00222144</inertia>
         <inertiaUnits>"kg*m^2"</inertiaUnits>
-        <volume>455755</volume>
+        <volume>455756</volume>
         <volumeUnits>"mm^3"</volumeUnits>
-        <surfaceArea>174715</surfaceArea>
+        <surfaceArea>174718</surfaceArea>
         <surfaceAreaUnits>"mm^2"</surfaceAreaUnits>
         <frames>
           <Frame>
             <name>"CG"</name>
             <displayName>""</displayName>
-            <nodeID>"97::CG(AUTOGEN)"</nodeID>
-            <position>-71.5694,19.6298,-314.29</position>
+            <nodeID>"135::CG(AUTOGEN)"</nodeID>
+            <position>-69.2477,19.3965,-314.351</position>
             <positionOrigin>"WORLD"</positionOrigin>
             <positionReferenceFrame>"WORLD"</positionReferenceFrame>
             <positionUnits>"mm"</positionUnits>
@@ -1999,7 +1999,7 @@
           <Frame>
             <name>"CS1"</name>
             <displayName>""</displayName>
-            <nodeID>"97::CS1(AUTOGEN)"</nodeID>
+            <nodeID>"135::CS1(AUTOGEN)"</nodeID>
             <position>-3.3562e-013,2.06083e-014,1.88418e-013</position>
             <positionOrigin>"WORLD"</positionOrigin>
             <positionReferenceFrame>"WORLD"</positionReferenceFrame>
@@ -2012,7 +2012,7 @@
           <Frame>
             <name>"CS2"</name>
             <displayName>"SCSYS_L_HIP_1"</displayName>
-            <nodeID>"10508(USERADDED)"</nodeID>
+            <nodeID>"10608(USERADDED)"</nodeID>
             <position>-40.45,21.6,-313.858</position>
             <positionOrigin>"WORLD"</positionOrigin>
             <positionReferenceFrame>"WORLD"</positionReferenceFrame>
@@ -2022,10 +2022,10 @@
             <orientationUnits>"rad"</orientationUnits>
             <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
           </Frame>
-          <Frame ref="34">
+          <Frame ref="38">
             <name>"CS3"</name>
             <displayName>""</displayName>
-            <nodeID>"61:-:97::97(AUTOGEN)"</nodeID>
+            <nodeID>"135:-:61::135(AUTOGEN)"</nodeID>
             <position>-46.75,21.6,-313.858</position>
             <positionOrigin>"WORLD"</positionOrigin>
             <positionReferenceFrame>"WORLD"</positionReferenceFrame>
@@ -2035,10 +2035,10 @@
             <orientationUnits>"rad"</orientationUnits>
             <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
           </Frame>
-          <Frame ref="65">
+          <Frame ref="51">
             <name>"CS4"</name>
             <displayName>""</displayName>
-            <nodeID>"97:-:98::97(AUTOGEN)"</nodeID>
+            <nodeID>"135:-:98::135(AUTOGEN)"</nodeID>
             <position>-73.55,-32.4,-322.858</position>
             <positionOrigin>"WORLD"</positionOrigin>
             <positionReferenceFrame>"WORLD"</positionReferenceFrame>
@@ -2116,10 +2116,10 @@
             <orientationUnits>"rad"</orientationUnits>
             <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
           </Frame>
-          <Frame ref="66">
+          <Frame ref="52">
             <name>"CS4"</name>
             <displayName>""</displayName>
-            <nodeID>"97:-:98::98(AUTOGEN)"</nodeID>
+            <nodeID>"135:-:98::98(AUTOGEN)"</nodeID>
             <position>-73.55,-32.4,-322.858</position>
             <positionOrigin>"WORLD"</positionOrigin>
             <positionReferenceFrame>"WORLD"</positionReferenceFrame>
@@ -2129,7 +2129,7 @@
             <orientationUnits>"rad"</orientationUnits>
             <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
           </Frame>
-          <Frame ref="71">
+          <Frame ref="53">
             <name>"CS5"</name>
             <displayName>""</displayName>
             <nodeID>"98:-:99::98(AUTOGEN)"</nodeID>
@@ -2197,11 +2197,11 @@
             <orientationUnits>"rad"</orientationUnits>
             <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
           </Frame>
-          <Frame ref="67">
+          <Frame ref="54">
             <name>"CS3"</name>
             <displayName>""</displayName>
-            <nodeID>"100:-:99::99(AUTOGEN)"</nodeID>
-            <position>-58.55,11.05,-496.058</position>
+            <nodeID>"98:-:99::99(AUTOGEN)"</nodeID>
+            <position>-73.6305,-31.5986,-359.511</position>
             <positionOrigin>"WORLD"</positionOrigin>
             <positionReferenceFrame>"WORLD"</positionReferenceFrame>
             <positionUnits>"mm"</positionUnits>
@@ -2210,11 +2210,11 @@
             <orientationUnits>"rad"</orientationUnits>
             <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
           </Frame>
-          <Frame ref="72">
+          <Frame ref="61">
             <name>"CS4"</name>
             <displayName>""</displayName>
-            <nodeID>"98:-:99::99(AUTOGEN)"</nodeID>
-            <position>-73.6305,-31.5986,-359.511</position>
+            <nodeID>"133:-:99::99(AUTOGEN)"</nodeID>
+            <position>-58.55,11.05,-496.058</position>
             <positionOrigin>"WORLD"</positionOrigin>
             <positionReferenceFrame>"WORLD"</positionReferenceFrame>
             <positionUnits>"mm"</positionUnits>
@@ -2228,22 +2228,22 @@
       </Body>
       <Body>
         <name>"SIM_ICUB3_L_UPPER_LEG"</name>
-        <nodeID>"100"</nodeID>
+        <nodeID>"133"</nodeID>
         <status>""</status>
-        <mass>2.24396</mass>
+        <mass>1.02378</mass>
         <massUnits>"kg"</massUnits>
-        <inertia>0.00476284,6.71293e-005,-0.00033784,6.71293e-005,0.00479384,0.000493564,-0.00033784,0.000493564,0.00194527</inertia>
+        <inertia>0.00225969,5.34936e-005,-0.000261515,5.34936e-005,0.00280359,0.000270526,-0.000261515,0.000270526,0.00117148</inertia>
         <inertiaUnits>"kg*m^2"</inertiaUnits>
-        <volume>399662</volume>
+        <volume>228547</volume>
         <volumeUnits>"mm^3"</volumeUnits>
-        <surfaceArea>169020</surfaceArea>
+        <surfaceArea>116207</surfaceArea>
         <surfaceAreaUnits>"mm^2"</surfaceAreaUnits>
         <frames>
           <Frame>
             <name>"CG"</name>
             <displayName>""</displayName>
-            <nodeID>"100::CG(AUTOGEN)"</nodeID>
-            <position>-64.7347,22.2163,-568.032</position>
+            <nodeID>"133::CG(AUTOGEN)"</nodeID>
+            <position>-63.0495,17.4601,-541.072</position>
             <positionOrigin>"WORLD"</positionOrigin>
             <positionReferenceFrame>"WORLD"</positionReferenceFrame>
             <positionUnits>"mm"</positionUnits>
@@ -2255,7 +2255,7 @@
           <Frame>
             <name>"CS1"</name>
             <displayName>""</displayName>
-            <nodeID>"100::CS1(AUTOGEN)"</nodeID>
+            <nodeID>"133::CS1(AUTOGEN)"</nodeID>
             <position>-2.22826e-013,0,3.96135e-013</position>
             <positionOrigin>"WORLD"</positionOrigin>
             <positionReferenceFrame>"WORLD"</positionReferenceFrame>
@@ -2268,7 +2268,7 @@
           <Frame>
             <name>"CS2"</name>
             <displayName>"SCSYS_L_UPPER_LEG"</displayName>
-            <nodeID>"2223(USERADDED)"</nodeID>
+            <nodeID>"2444(USERADDED)"</nodeID>
             <position>-58.55,11.05,-483.458</position>
             <positionOrigin>"WORLD"</positionOrigin>
             <positionReferenceFrame>"WORLD"</positionReferenceFrame>
@@ -2278,11 +2278,11 @@
             <orientationUnits>"rad"</orientationUnits>
             <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
           </Frame>
-          <Frame ref="68">
+          <Frame ref="59">
             <name>"CS3"</name>
             <displayName>""</displayName>
-            <nodeID>"100:-:99::100(AUTOGEN)"</nodeID>
-            <position>-58.55,11.05,-496.058</position>
+            <nodeID>"133:-:139::133(AUTOGEN)"</nodeID>
+            <position>-83.25,26.05,-589.658</position>
             <positionOrigin>"WORLD"</positionOrigin>
             <positionReferenceFrame>"WORLD"</positionReferenceFrame>
             <positionUnits>"mm"</positionUnits>
@@ -2291,11 +2291,11 @@
             <orientationUnits>"rad"</orientationUnits>
             <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
           </Frame>
-          <Frame ref="69">
+          <Frame ref="62">
             <name>"CS4"</name>
             <displayName>""</displayName>
-            <nodeID>"100:-:101::100(AUTOGEN)"</nodeID>
-            <position>-83.25,26.05,-589.658</position>
+            <nodeID>"133:-:99::133(AUTOGEN)"</nodeID>
+            <position>-58.55,11.05,-496.058</position>
             <positionOrigin>"WORLD"</positionOrigin>
             <positionReferenceFrame>"WORLD"</positionReferenceFrame>
             <positionUnits>"mm"</positionUnits>
@@ -2309,22 +2309,22 @@
       </Body>
       <Body>
         <name>"SIM_ICUB3_L_LOWER_LEG"</name>
-        <nodeID>"101"</nodeID>
+        <nodeID>"139"</nodeID>
         <status>""</status>
-        <mass>5.66584</mass>
+        <mass>5.35334</mass>
         <massUnits>"kg"</massUnits>
-        <inertia>0.0578975,6.56617e-005,3.07278e-005,6.56617e-005,0.0550335,0.000320278,3.07278e-005,0.000320278,0.00624087</inertia>
+        <inertia>0.0600412,6.70826e-005,-0.000133621,6.70826e-005,0.0574191,-5.78783e-005,-0.000133621,-5.78783e-005,0.0059967</inertia>
         <inertiaUnits>"kg*m^2"</inertiaUnits>
-        <volume>1.239e+006</volume>
+        <volume>1.27154e+006</volume>
         <volumeUnits>"mm^3"</volumeUnits>
-        <surfaceArea>679374</surfaceArea>
+        <surfaceArea>700240</surfaceArea>
         <surfaceAreaUnits>"mm^2"</surfaceAreaUnits>
         <frames>
           <Frame>
             <name>"CG"</name>
             <displayName>""</displayName>
-            <nodeID>"101::CG(AUTOGEN)"</nodeID>
-            <position>-61.2826,11.3358,-722.336</position>
+            <nodeID>"139::CG(AUTOGEN)"</nodeID>
+            <position>-60.8426,13.3358,-717.834</position>
             <positionOrigin>"WORLD"</positionOrigin>
             <positionReferenceFrame>"WORLD"</positionReferenceFrame>
             <positionUnits>"mm"</positionUnits>
@@ -2336,7 +2336,7 @@
           <Frame>
             <name>"CS1"</name>
             <displayName>""</displayName>
-            <nodeID>"101::CS1(AUTOGEN)"</nodeID>
+            <nodeID>"139::CS1(AUTOGEN)"</nodeID>
             <position>-1.41404e-013,-9.22197e-014,2.95103e-013</position>
             <positionOrigin>"WORLD"</positionOrigin>
             <positionReferenceFrame>"WORLD"</positionReferenceFrame>
@@ -2349,7 +2349,7 @@
           <Frame>
             <name>"CS2"</name>
             <displayName>"SCSYS_L_LOWER_LEG"</displayName>
-            <nodeID>"15514(USERADDED)"</nodeID>
+            <nodeID>"15781(USERADDED)"</nodeID>
             <position>-83.45,26.05,-589.658</position>
             <positionOrigin>"WORLD"</positionOrigin>
             <positionReferenceFrame>"WORLD"</positionReferenceFrame>
@@ -2359,11 +2359,11 @@
             <orientationUnits>"rad"</orientationUnits>
             <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
           </Frame>
-          <Frame ref="47">
+          <Frame ref="60">
             <name>"CS3"</name>
             <displayName>""</displayName>
-            <nodeID>"101:-:102::101(AUTOGEN)"</nodeID>
-            <position>-83.25,26.05,-845.647</position>
+            <nodeID>"133:-:139::139(AUTOGEN)"</nodeID>
+            <position>-83.25,26.05,-589.658</position>
             <positionOrigin>"WORLD"</positionOrigin>
             <positionReferenceFrame>"WORLD"</positionReferenceFrame>
             <positionUnits>"mm"</positionUnits>
@@ -2372,11 +2372,11 @@
             <orientationUnits>"rad"</orientationUnits>
             <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
           </Frame>
-          <Frame ref="70">
+          <Frame ref="83">
             <name>"CS4"</name>
             <displayName>""</displayName>
-            <nodeID>"100:-:101::101(AUTOGEN)"</nodeID>
-            <position>-83.25,26.05,-589.658</position>
+            <nodeID>"102:-:139::139(AUTOGEN)"</nodeID>
+            <position>-83.25,26.05,-845.647</position>
             <positionOrigin>"WORLD"</positionOrigin>
             <positionReferenceFrame>"WORLD"</positionReferenceFrame>
             <positionUnits>"mm"</positionUnits>
@@ -2440,7 +2440,7 @@
             <orientationUnits>"rad"</orientationUnits>
             <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
           </Frame>
-          <Frame ref="45">
+          <Frame ref="67">
             <name>"CS3"</name>
             <displayName>""</displayName>
             <nodeID>"102:-:103::102(AUTOGEN)"</nodeID>
@@ -2453,10 +2453,10 @@
             <orientationUnits>"rad"</orientationUnits>
             <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
           </Frame>
-          <Frame ref="48">
+          <Frame ref="84">
             <name>"CS4"</name>
             <displayName>""</displayName>
-            <nodeID>"101:-:102::102(AUTOGEN)"</nodeID>
+            <nodeID>"102:-:139::102(AUTOGEN)"</nodeID>
             <position>-83.25,26.05,-845.647</position>
             <positionOrigin>"WORLD"</positionOrigin>
             <positionReferenceFrame>"WORLD"</positionReferenceFrame>
@@ -2547,21 +2547,8 @@
             <orientationUnits>"rad"</orientationUnits>
             <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
           </Frame>
-          <Frame ref="46">
+          <Frame ref="65">
             <name>"CS5"</name>
-            <displayName>""</displayName>
-            <nodeID>"102:-:103::103(AUTOGEN)"</nodeID>
-            <position>-64.75,-66.85,-880.647</position>
-            <positionOrigin>"WORLD"</positionOrigin>
-            <positionReferenceFrame>"WORLD"</positionReferenceFrame>
-            <positionUnits>"mm"</positionUnits>
-            <orientation>1,0,0,0,1,0,0,0,1</orientation>
-            <orientationType>"3x3 Transform"</orientationType>
-            <orientationUnits>"rad"</orientationUnits>
-            <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
-          </Frame>
-          <Frame ref="49">
-            <name>"CS6"</name>
             <displayName>""</displayName>
             <nodeID>"103:-:104::103(AUTOGEN)"</nodeID>
             <position>-64.6632,12.8705,-906.104</position>
@@ -2573,7 +2560,20 @@
             <orientationUnits>"rad"</orientationUnits>
             <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
           </Frame>
-          <Frame ref="51">
+          <Frame ref="68">
+            <name>"CS6"</name>
+            <displayName>""</displayName>
+            <nodeID>"102:-:103::103(AUTOGEN)"</nodeID>
+            <position>-64.75,-66.85,-880.647</position>
+            <positionOrigin>"WORLD"</positionOrigin>
+            <positionReferenceFrame>"WORLD"</positionReferenceFrame>
+            <positionUnits>"mm"</positionUnits>
+            <orientation>1,0,0,0,1,0,0,0,1</orientation>
+            <orientationType>"3x3 Transform"</orientationType>
+            <orientationUnits>"rad"</orientationUnits>
+            <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
+          </Frame>
+          <Frame ref="69">
             <name>"CS7"</name>
             <displayName>""</displayName>
             <nodeID>"103:-:105::103(AUTOGEN)"</nodeID>
@@ -2654,7 +2654,7 @@
             <orientationUnits>"rad"</orientationUnits>
             <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
           </Frame>
-          <Frame ref="50">
+          <Frame ref="66">
             <name>"CS4"</name>
             <displayName>""</displayName>
             <nodeID>"103:-:104::104(AUTOGEN)"</nodeID>
@@ -2748,7 +2748,7 @@
             <orientationUnits>"rad"</orientationUnits>
             <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
           </Frame>
-          <Frame ref="52">
+          <Frame ref="70">
             <name>"CS5"</name>
             <displayName>""</displayName>
             <nodeID>"103:-:105::105(AUTOGEN)"</nodeID>
@@ -2816,7 +2816,7 @@
             <orientationUnits>"rad"</orientationUnits>
             <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
           </Frame>
-          <Frame ref="58">
+          <Frame ref="48">
             <name>"CS3"</name>
             <displayName>""</displayName>
             <nodeID>"110:-:129::110(AUTOGEN)"</nodeID>
@@ -2829,7 +2829,7 @@
             <orientationUnits>"rad"</orientationUnits>
             <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
           </Frame>
-          <Frame ref="73">
+          <Frame ref="71">
             <name>"CS4"</name>
             <displayName>""</displayName>
             <nodeID>"110:-:112::110(AUTOGEN)"</nodeID>
@@ -2847,26 +2847,26 @@
       </Body>
       <Body>
         <name>"SIM_ICUB3_R_ELBOW_1"</name>
-        <nodeID>"111"</nodeID>
+        <nodeID>"137"</nodeID>
         <status>""</status>
-        <mass>0.397478</mass>
+        <mass>0.230086</mass>
         <massUnits>"kg"</massUnits>
-        <inertia>0.00139406,5.80993e-006,5.27143e-005,5.80993e-006,0.00139077,6.49755e-005,5.27143e-005,6.49755e-005,0.000397127</inertia>
+        <inertia>0.000109579,2.48894e-008,2.06325e-005,2.48894e-008,0.000124425,-6.69718e-006,2.06325e-005,-6.69718e-006,4.81791e-005</inertia>
         <inertiaUnits>"kg*m^2"</inertiaUnits>
-        <volume>164525</volume>
+        <volume>30714.7</volume>
         <volumeUnits>"mm^3"</volumeUnits>
-        <surfaceArea>131527</surfaceArea>
+        <surfaceArea>20911.2</surfaceArea>
         <surfaceAreaUnits>"mm^2"</surfaceAreaUnits>
         <frames>
           <Frame>
             <name>"CG"</name>
             <displayName>""</displayName>
-            <nodeID>"111::CG(AUTOGEN)"</nodeID>
-            <position>155.599,18.9641,-160.677</position>
+            <nodeID>"137::CG(AUTOGEN)"</nodeID>
+            <position>157.569,22.9566,-197.79</position>
             <positionOrigin>"WORLD"</positionOrigin>
             <positionReferenceFrame>"WORLD"</positionReferenceFrame>
             <positionUnits>"mm"</positionUnits>
-            <orientation>1,0,0,0,1,0,0,0,1</orientation>
+            <orientation>0.985927,0.00506786,-0.167099,-0.0129944,0.998839,-0.046377,0.16667,0.0478957,0.984849</orientation>
             <orientationType>"3x3 Transform"</orientationType>
             <orientationUnits>"rad"</orientationUnits>
             <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
@@ -2874,12 +2874,12 @@
           <Frame>
             <name>"CS1"</name>
             <displayName>""</displayName>
-            <nodeID>"111::CS1(AUTOGEN)"</nodeID>
-            <position>-4.70245e-014,-2.05732e-013,2.1161e-013</position>
+            <nodeID>"137::CS1(AUTOGEN)"</nodeID>
+            <position>-0.67327,-1.52395,24.6467</position>
             <positionOrigin>"WORLD"</positionOrigin>
             <positionReferenceFrame>"WORLD"</positionReferenceFrame>
             <positionUnits>"mm"</positionUnits>
-            <orientation>1,0,0,0,1,0,0,0,1</orientation>
+            <orientation>0.985927,0.00506786,-0.167099,-0.0129944,0.998839,-0.046377,0.16667,0.0478957,0.984849</orientation>
             <orientationType>"3x3 Transform"</orientationType>
             <orientationUnits>"rad"</orientationUnits>
             <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
@@ -2887,7 +2887,7 @@
           <Frame>
             <name>"CS2"</name>
             <displayName>"SCSYS_R_ELBOW_1"</displayName>
-            <nodeID>"386(USERADDED)"</nodeID>
+            <nodeID>"2460(USERADDED)"</nodeID>
             <position>152.093,31.2462,-182.415</position>
             <positionOrigin>"WORLD"</positionOrigin>
             <positionReferenceFrame>"WORLD"</positionReferenceFrame>
@@ -2897,10 +2897,10 @@
             <orientationUnits>"rad"</orientationUnits>
             <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
           </Frame>
-          <Frame ref="75">
+          <Frame ref="5">
             <name>"CS3"</name>
             <displayName>""</displayName>
-            <nodeID>"111:-:113::111(AUTOGEN)"</nodeID>
+            <nodeID>"113:-:137::137(AUTOGEN)"</nodeID>
             <position>167.115,27.7697,-328.185</position>
             <positionOrigin>"WORLD"</positionOrigin>
             <positionReferenceFrame>"WORLD"</positionReferenceFrame>
@@ -2910,10 +2910,10 @@
             <orientationUnits>"rad"</orientationUnits>
             <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
           </Frame>
-          <Frame ref="78">
+          <Frame ref="80">
             <name>"CS4"</name>
             <displayName>""</displayName>
-            <nodeID>"111:-:126::111(AUTOGEN)"</nodeID>
+            <nodeID>"126:-:137::137(AUTOGEN)"</nodeID>
             <position>174.568,37.4943,-180.569</position>
             <positionOrigin>"WORLD"</positionOrigin>
             <positionReferenceFrame>"WORLD"</positionReferenceFrame>
@@ -2991,7 +2991,7 @@
             <orientationUnits>"rad"</orientationUnits>
             <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
           </Frame>
-          <Frame ref="74">
+          <Frame ref="72">
             <name>"CS4"</name>
             <displayName>""</displayName>
             <nodeID>"110:-:112::112(AUTOGEN)"</nodeID>
@@ -3037,7 +3037,7 @@
             <name>"CS1"</name>
             <displayName>""</displayName>
             <nodeID>"113::CS1(AUTOGEN)"</nodeID>
-            <position>6.78738e-014,-2.46043e-013,0</position>
+            <position>2.00764e-012,-4.01528e-013,4.01528e-012</position>
             <positionOrigin>"WORLD"</positionOrigin>
             <positionReferenceFrame>"WORLD"</positionReferenceFrame>
             <positionUnits>"mm"</positionUnits>
@@ -3059,7 +3059,7 @@
             <orientationUnits>"rad"</orientationUnits>
             <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
           </Frame>
-          <Frame ref="5">
+          <Frame ref="3">
             <name>"CS3"</name>
             <displayName>""</displayName>
             <nodeID>"113:-:116::113(AUTOGEN)"</nodeID>
@@ -3072,10 +3072,10 @@
             <orientationUnits>"rad"</orientationUnits>
             <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
           </Frame>
-          <Frame ref="76">
+          <Frame ref="6">
             <name>"CS4"</name>
             <displayName>""</displayName>
-            <nodeID>"111:-:113::113(AUTOGEN)"</nodeID>
+            <nodeID>"113:-:137::113(AUTOGEN)"</nodeID>
             <position>167.115,27.7697,-328.185</position>
             <positionOrigin>"WORLD"</positionOrigin>
             <positionReferenceFrame>"WORLD"</positionReferenceFrame>
@@ -3199,7 +3199,7 @@
             <name>"CS1"</name>
             <displayName>""</displayName>
             <nodeID>"116::CS1(AUTOGEN)"</nodeID>
-            <position>9.04984e-014,-1.92309e-013,2.26246e-013</position>
+            <position>2.18609e-012,-3.40183e-013,4.01528e-012</position>
             <positionOrigin>"WORLD"</positionOrigin>
             <positionReferenceFrame>"WORLD"</positionReferenceFrame>
             <positionUnits>"mm"</positionUnits>
@@ -3221,11 +3221,11 @@
             <orientationUnits>"rad"</orientationUnits>
             <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
           </Frame>
-          <Frame ref="3">
+          <Frame ref="4">
             <name>"CS3"</name>
             <displayName>""</displayName>
-            <nodeID>"116:-:119::116(AUTOGEN)"</nodeID>
-            <position>166.254,28.4509,-345.266</position>
+            <nodeID>"113:-:116::116(AUTOGEN)"</nodeID>
+            <position>175.796,9.33696,-346.042</position>
             <positionOrigin>"WORLD"</positionOrigin>
             <positionReferenceFrame>"WORLD"</positionReferenceFrame>
             <positionUnits>"mm"</positionUnits>
@@ -3234,11 +3234,11 @@
             <orientationUnits>"rad"</orientationUnits>
             <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
           </Frame>
-          <Frame ref="6">
+          <Frame ref="11">
             <name>"CS4"</name>
             <displayName>""</displayName>
-            <nodeID>"113:-:116::116(AUTOGEN)"</nodeID>
-            <position>175.796,9.33696,-346.042</position>
+            <nodeID>"116:-:119::116(AUTOGEN)"</nodeID>
+            <position>166.254,28.4509,-345.266</position>
             <positionOrigin>"WORLD"</positionOrigin>
             <positionReferenceFrame>"WORLD"</positionReferenceFrame>
             <positionUnits>"mm"</positionUnits>
@@ -3348,7 +3348,7 @@
             <name>"CS1"</name>
             <displayName>""</displayName>
             <nodeID>"119::CS1(AUTOGEN)"</nodeID>
-            <position>9.04984e-014,-1.86653e-013,2.28022e-013</position>
+            <position>2.14148e-012,-3.2903e-013,4.1045e-012</position>
             <positionOrigin>"WORLD"</positionOrigin>
             <positionReferenceFrame>"WORLD"</positionReferenceFrame>
             <positionUnits>"mm"</positionUnits>
@@ -3370,7 +3370,7 @@
             <orientationUnits>"rad"</orientationUnits>
             <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
           </Frame>
-          <Frame ref="4">
+          <Frame ref="12">
             <name>"CS3"</name>
             <displayName>""</displayName>
             <nodeID>"116:-:119::119(AUTOGEN)"</nodeID>
@@ -3438,11 +3438,11 @@
             <orientationUnits>"rad"</orientationUnits>
             <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
           </Frame>
-          <Frame ref="38">
+          <Frame ref="15">
             <name>"CS3"</name>
             <displayName>""</displayName>
-            <nodeID>"120:-:69::120(AUTOGEN)"</nodeID>
-            <position>0.262139,-13.3964,-61.2543</position>
+            <nodeID>"120:-:121::120(AUTOGEN)"</nodeID>
+            <position>-44.5,4.86151,97.9115</position>
             <positionOrigin>"WORLD"</positionOrigin>
             <positionReferenceFrame>"WORLD"</positionReferenceFrame>
             <positionUnits>"mm"</positionUnits>
@@ -3451,11 +3451,11 @@
             <orientationUnits>"rad"</orientationUnits>
             <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
           </Frame>
-          <Frame ref="43">
+          <Frame ref="20">
             <name>"CS4"</name>
             <displayName>""</displayName>
-            <nodeID>"120:-:121::120(AUTOGEN)"</nodeID>
-            <position>-44.5,4.86151,97.9115</position>
+            <nodeID>"120:-:136::120(AUTOGEN)"</nodeID>
+            <position>0.0607081,-4.33942,-55.5868</position>
             <positionOrigin>"WORLD"</positionOrigin>
             <positionReferenceFrame>"WORLD"</positionReferenceFrame>
             <positionUnits>"mm"</positionUnits>
@@ -3519,7 +3519,7 @@
             <orientationUnits>"rad"</orientationUnits>
             <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
           </Frame>
-          <Frame ref="41">
+          <Frame ref="13">
             <name>"CS3"</name>
             <displayName>""</displayName>
             <nodeID>"121:-:124::121(AUTOGEN)"</nodeID>
@@ -3532,7 +3532,7 @@
             <orientationUnits>"rad"</orientationUnits>
             <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
           </Frame>
-          <Frame ref="44">
+          <Frame ref="16">
             <name>"CS4"</name>
             <displayName>""</displayName>
             <nodeID>"120:-:121::121(AUTOGEN)"</nodeID>
@@ -3600,11 +3600,11 @@
             <orientationUnits>"rad"</orientationUnits>
             <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
           </Frame>
-          <Frame ref="39">
+          <Frame ref="14">
             <name>"CS3"</name>
             <displayName>""</displayName>
-            <nodeID>"124:-:125::124(AUTOGEN)"</nodeID>
-            <position>-6.30617e-009,4.86151,185.512</position>
+            <nodeID>"121:-:124::124(AUTOGEN)"</nodeID>
+            <position>0,20.1615,107.412</position>
             <positionOrigin>"WORLD"</positionOrigin>
             <positionReferenceFrame>"WORLD"</positionReferenceFrame>
             <positionUnits>"mm"</positionUnits>
@@ -3613,11 +3613,11 @@
             <orientationUnits>"rad"</orientationUnits>
             <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
           </Frame>
-          <Frame ref="42">
+          <Frame ref="17">
             <name>"CS4"</name>
             <displayName>""</displayName>
-            <nodeID>"121:-:124::124(AUTOGEN)"</nodeID>
-            <position>0,20.1615,107.412</position>
+            <nodeID>"124:-:125::124(AUTOGEN)"</nodeID>
+            <position>-6.30617e-009,4.86151,185.512</position>
             <positionOrigin>"WORLD"</positionOrigin>
             <positionReferenceFrame>"WORLD"</positionReferenceFrame>
             <positionUnits>"mm"</positionUnits>
@@ -3694,7 +3694,7 @@
             <orientationUnits>"rad"</orientationUnits>
             <orientationReferenceFrame>"WORLD"</orientationReferenceFrame>
           </Frame>
-          <Frame ref="40">
+          <Frame ref="18">
             <name>"CS4"</name>
             <displayName>""</displayName>
             <nodeID>"124:-:125::125(AUTOGEN)"</nodeID>
@@ -3742,8 +3742,8 @@
         </primitives>
       </SimpleJoint>
       <SimpleJoint>
-        <name>"SIM_ICUB3_R_WRIST_1--SIM_ICUB3_R_HAND"</name>
-        <nodeID>"116:-:119"</nodeID>
+        <name>"SIM_ICUB3_R_FOREARM--SIM_ICUB3_R_WRIST_1"</name>
+        <nodeID>"113:-:116"</nodeID>
         <status>""</status>
         <base>
           <JointSide>
@@ -3766,13 +3766,13 @@
             <name>"revolute"</name>
             <nodeID>""</nodeID>
             <referenceFrame>"WORLD"</referenceFrame>
-            <axis>-0.960459,-0.267012,-0.0788901</axis>
+            <axis>-0.271447,0.961047,0.0520081</axis>
           </Primitive>
         </primitives>
       </SimpleJoint>
       <SimpleJoint>
-        <name>"SIM_ICUB3_R_FOREARM--SIM_ICUB3_R_WRIST_1"</name>
-        <nodeID>"113:-:116"</nodeID>
+        <name>"SIM_ICUB3_R_ELBOW_1--SIM_ICUB3_R_FOREARM"</name>
+        <nodeID>"113:-:137"</nodeID>
         <status>""</status>
         <base>
           <JointSide>
@@ -3795,7 +3795,7 @@
             <name>"revolute"</name>
             <nodeID>""</nodeID>
             <referenceFrame>"WORLD"</referenceFrame>
-            <axis>-0.271447,0.961047,0.0520081</axis>
+            <axis>-0.0619303,-0.0713662,0.995526</axis>
           </Primitive>
         </primitives>
       </SimpleJoint>
@@ -3858,8 +3858,8 @@
         </primitives>
       </SimpleJoint>
       <SimpleJoint>
-        <name>"SIM_ICUB3_TORSO_1--SIM_ICUB3_TORSO_2"</name>
-        <nodeID>"65:-:67"</nodeID>
+        <name>"SIM_ICUB3_R_WRIST_1--SIM_ICUB3_R_HAND"</name>
+        <nodeID>"116:-:119"</nodeID>
         <status>""</status>
         <base>
           <JointSide>
@@ -3882,13 +3882,13 @@
             <name>"revolute"</name>
             <nodeID>""</nodeID>
             <referenceFrame>"WORLD"</referenceFrame>
-            <axis>1,0,0</axis>
+            <axis>-0.960459,-0.267012,-0.0788901</axis>
           </Primitive>
         </primitives>
       </SimpleJoint>
       <SimpleJoint>
-        <name>"SIM_ICUB3_ROOT_LINK--SIM_ICUB3_TORSO_1"</name>
-        <nodeID>"61:-:65"</nodeID>
+        <name>"SIM_HEAD_NECK_2--SIM_HEAD_NECK_3"</name>
+        <nodeID>"121:-:124"</nodeID>
         <status>""</status>
         <base>
           <JointSide>
@@ -3916,9 +3916,9 @@
         </primitives>
       </SimpleJoint>
       <SimpleJoint>
-        <name>"SIM_ICUB3_L_SHOULDER_2--SIM_ICUB3_L_SHOULDER_3"</name>
-        <nodeID>"75:-:81"</nodeID>
-        <status>"Could not solve for constraint between SIM_ICUB3_L_SHOULDER_2 and SIM_ICUB3_L_SHOULDER_3 because of CAD constraint "</status>
+        <name>"SIM_HEAD_NECK_1--SIM_HEAD_NECK_2"</name>
+        <nodeID>"120:-:121"</nodeID>
+        <status>""</status>
         <base>
           <JointSide>
             <name>""</name>
@@ -3937,16 +3937,16 @@
         </follower>
         <primitives>
           <Primitive>
-            <name>"weld"</name>
+            <name>"revolute"</name>
             <nodeID>""</nodeID>
             <referenceFrame>"WORLD"</referenceFrame>
-            <axis>0.57735,0.57735,0.57735</axis>
+            <axis>1,0,0</axis>
           </Primitive>
         </primitives>
       </SimpleJoint>
       <SimpleJoint>
-        <name>"SIM_ICUB3_L_SHOULDER_1--SIM_ICUB3_L_SHOULDER_2"</name>
-        <nodeID>"71:-:75"</nodeID>
+        <name>"SIM_HEAD_NECK_3--SIM_HEAD_HEAD"</name>
+        <nodeID>"124:-:125"</nodeID>
         <status>""</status>
         <base>
           <JointSide>
@@ -3969,14 +3969,14 @@
             <name>"revolute"</name>
             <nodeID>""</nodeID>
             <referenceFrame>"WORLD"</referenceFrame>
-            <axis>-0.271447,-0.961047,-0.0520081</axis>
+            <axis>8.0745e-011,0,-1</axis>
           </Primitive>
         </primitives>
       </SimpleJoint>
       <SimpleJoint>
-        <name>"SIM_ICUB3_R_SHOULDER_1--SIM_ICUB3_R_SHOULDER_2"</name>
-        <nodeID>"73:-:77"</nodeID>
-        <status>""</status>
+        <name>"SIM_ICUB3_CHEST--SIM_HEAD_NECK_1"</name>
+        <nodeID>"120:-:136"</nodeID>
+        <status>"Could not solve for constraint between SIM_ICUB3_CHEST and SIM_HEAD_NECK_1 because of CAD constraint "</status>
         <base>
           <JointSide>
             <name>""</name>
@@ -3995,10 +3995,10 @@
         </follower>
         <primitives>
           <Primitive>
-            <name>"revolute"</name>
+            <name>"weld"</name>
             <nodeID>""</nodeID>
             <referenceFrame>"WORLD"</referenceFrame>
-            <axis>0.271447,-0.961047,-0.0520081</axis>
+            <axis>0.57735,0.57735,0.57735</axis>
           </Primitive>
         </primitives>
       </SimpleJoint>
@@ -4032,8 +4032,8 @@
         </primitives>
       </SimpleJoint>
       <SimpleJoint>
-        <name>"SIM_ICUB3_CHEST--SIM_ICUB3_R_SHOULDER_1"</name>
-        <nodeID>"69:-:73"</nodeID>
+        <name>"SIM_ICUB3_R_SHOULDER_3--SIM_ICUB3_R_UPPERARM"</name>
+        <nodeID>"126:-:79"</nodeID>
         <status>""</status>
         <base>
           <JointSide>
@@ -4056,13 +4056,13 @@
             <name>"revolute"</name>
             <nodeID>""</nodeID>
             <referenceFrame>"WORLD"</referenceFrame>
-            <axis>-0.935113,-0.250563,-0.250563</axis>
+            <axis>-0.0619303,-0.0713662,0.995526</axis>
           </Primitive>
         </primitives>
       </SimpleJoint>
       <SimpleJoint>
-        <name>"SIM_ICUB3_R_SHOULDER_3--SIM_ICUB3_R_UPPERARM"</name>
-        <nodeID>"126:-:79"</nodeID>
+        <name>"SIM_ICUB3_CHEST--SIM_ICUB3_L_SHOULDER_1"</name>
+        <nodeID>"136:-:71"</nodeID>
         <status>""</status>
         <base>
           <JointSide>
@@ -4085,13 +4085,13 @@
             <name>"revolute"</name>
             <nodeID>""</nodeID>
             <referenceFrame>"WORLD"</referenceFrame>
-            <axis>-0.0619303,-0.0713662,0.995526</axis>
+            <axis>0.935113,-0.250563,-0.250563</axis>
           </Primitive>
         </primitives>
       </SimpleJoint>
       <SimpleJoint>
-        <name>"SIM_ICUB3_L_SHOULDER_3--SIM_ICUB3_L_UPPERARM"</name>
-        <nodeID>"129:-:81"</nodeID>
+        <name>"SIM_ICUB3_CHEST--SIM_ICUB3_R_SHOULDER_1"</name>
+        <nodeID>"136:-:73"</nodeID>
         <status>""</status>
         <base>
           <JointSide>
@@ -4114,13 +4114,13 @@
             <name>"revolute"</name>
             <nodeID>""</nodeID>
             <referenceFrame>"WORLD"</referenceFrame>
-            <axis>0.0619303,-0.0713662,0.995526</axis>
+            <axis>-0.935113,-0.250563,-0.250563</axis>
           </Primitive>
         </primitives>
       </SimpleJoint>
       <SimpleJoint>
         <name>"SIM_ICUB3_TORSO_2--SIM_ICUB3_CHEST"</name>
-        <nodeID>"67:-:69"</nodeID>
+        <nodeID>"136:-:67"</nodeID>
         <status>""</status>
         <base>
           <JointSide>
@@ -4148,8 +4148,8 @@
         </primitives>
       </SimpleJoint>
       <SimpleJoint>
-        <name>"SIM_ICUB3_ROOT_LINK--SIM_ICUB3_R_HIP_1"</name>
-        <nodeID>"61:-:88"</nodeID>
+        <name>"SIM_ICUB3_L_SHOULDER_1--SIM_ICUB3_L_SHOULDER_2"</name>
+        <nodeID>"71:-:75"</nodeID>
         <status>""</status>
         <base>
           <JointSide>
@@ -4172,13 +4172,13 @@
             <name>"revolute"</name>
             <nodeID>""</nodeID>
             <referenceFrame>"WORLD"</referenceFrame>
-            <axis>1,0,0</axis>
+            <axis>-0.271447,-0.961047,-0.0520081</axis>
           </Primitive>
         </primitives>
       </SimpleJoint>
       <SimpleJoint>
-        <name>"SIM_ICUB3_ROOT_LINK--SIM_ICUB3_L_HIP_1"</name>
-        <nodeID>"61:-:97"</nodeID>
+        <name>"SIM_ICUB3_ROOT_LINK--SIM_ICUB3_TORSO_1"</name>
+        <nodeID>"61:-:65"</nodeID>
         <status>""</status>
         <base>
           <JointSide>
@@ -4201,13 +4201,13 @@
             <name>"revolute"</name>
             <nodeID>""</nodeID>
             <referenceFrame>"WORLD"</referenceFrame>
-            <axis>1,0,0</axis>
+            <axis>0,1,0</axis>
           </Primitive>
         </primitives>
       </SimpleJoint>
       <SimpleJoint>
-        <name>"SIM_ICUB3_CHEST--SIM_ICUB3_L_SHOULDER_1"</name>
-        <nodeID>"69:-:71"</nodeID>
+        <name>"SIM_ICUB3_ROOT_LINK--SIM_ICUB3_R_HIP_1"</name>
+        <nodeID>"134:-:61"</nodeID>
         <status>""</status>
         <base>
           <JointSide>
@@ -4230,14 +4230,14 @@
             <name>"revolute"</name>
             <nodeID>""</nodeID>
             <referenceFrame>"WORLD"</referenceFrame>
-            <axis>0.935113,-0.250563,-0.250563</axis>
+            <axis>1,0,0</axis>
           </Primitive>
         </primitives>
       </SimpleJoint>
       <SimpleJoint>
-        <name>"SIM_ICUB3_CHEST--SIM_HEAD_NECK_1"</name>
-        <nodeID>"120:-:69"</nodeID>
-        <status>"Could not solve for constraint between SIM_ICUB3_CHEST and SIM_HEAD_NECK_1 because of CAD constraint "</status>
+        <name>"SIM_ICUB3_ROOT_LINK--SIM_ICUB3_L_HIP_1"</name>
+        <nodeID>"135:-:61"</nodeID>
+        <status>""</status>
         <base>
           <JointSide>
             <name>""</name>
@@ -4256,16 +4256,16 @@
         </follower>
         <primitives>
           <Primitive>
-            <name>"weld"</name>
+            <name>"revolute"</name>
             <nodeID>""</nodeID>
             <referenceFrame>"WORLD"</referenceFrame>
-            <axis>0.57735,0.57735,0.57735</axis>
+            <axis>1,0,0</axis>
           </Primitive>
         </primitives>
       </SimpleJoint>
       <SimpleJoint>
-        <name>"SIM_HEAD_NECK_3--SIM_HEAD_HEAD"</name>
-        <nodeID>"124:-:125"</nodeID>
+        <name>"SIM_ICUB3_R_SHOULDER_1--SIM_ICUB3_R_SHOULDER_2"</name>
+        <nodeID>"73:-:77"</nodeID>
         <status>""</status>
         <base>
           <JointSide>
@@ -4288,14 +4288,14 @@
             <name>"revolute"</name>
             <nodeID>""</nodeID>
             <referenceFrame>"WORLD"</referenceFrame>
-            <axis>8.0745e-011,0,-1</axis>
+            <axis>0.271447,-0.961047,-0.0520081</axis>
           </Primitive>
         </primitives>
       </SimpleJoint>
       <SimpleJoint>
-        <name>"SIM_HEAD_NECK_2--SIM_HEAD_NECK_3"</name>
-        <nodeID>"121:-:124"</nodeID>
-        <status>""</status>
+        <name>"SIM_ICUB3_L_SHOULDER_2--SIM_ICUB3_L_SHOULDER_3"</name>
+        <nodeID>"75:-:81"</nodeID>
+        <status>"Could not solve for constraint between SIM_ICUB3_L_SHOULDER_2 and SIM_ICUB3_L_SHOULDER_3 because of CAD constraint "</status>
         <base>
           <JointSide>
             <name>""</name>
@@ -4314,16 +4314,16 @@
         </follower>
         <primitives>
           <Primitive>
-            <name>"revolute"</name>
+            <name>"weld"</name>
             <nodeID>""</nodeID>
             <referenceFrame>"WORLD"</referenceFrame>
-            <axis>0,1,0</axis>
+            <axis>0.57735,0.57735,0.57735</axis>
           </Primitive>
         </primitives>
       </SimpleJoint>
       <SimpleJoint>
-        <name>"SIM_HEAD_NECK_1--SIM_HEAD_NECK_2"</name>
-        <nodeID>"120:-:121"</nodeID>
+        <name>"SIM_ICUB3_L_SHOULDER_3--SIM_ICUB3_L_UPPERARM"</name>
+        <nodeID>"129:-:81"</nodeID>
         <status>""</status>
         <base>
           <JointSide>
@@ -4346,13 +4346,13 @@
             <name>"revolute"</name>
             <nodeID>""</nodeID>
             <referenceFrame>"WORLD"</referenceFrame>
-            <axis>1,0,0</axis>
+            <axis>0.0619303,-0.0713662,0.995526</axis>
           </Primitive>
         </primitives>
       </SimpleJoint>
       <SimpleJoint>
-        <name>"SIM_ICUB3_L_ANKLE_1--SIM_ICUB3_L_ANKLE_2"</name>
-        <nodeID>"102:-:103"</nodeID>
+        <name>"SIM_ICUB3_TORSO_1--SIM_ICUB3_TORSO_2"</name>
+        <nodeID>"65:-:67"</nodeID>
         <status>""</status>
         <base>
           <JointSide>
@@ -4375,13 +4375,13 @@
             <name>"revolute"</name>
             <nodeID>""</nodeID>
             <referenceFrame>"WORLD"</referenceFrame>
-            <axis>0,1,0</axis>
+            <axis>1,0,0</axis>
           </Primitive>
         </primitives>
       </SimpleJoint>
       <SimpleJoint>
-        <name>"SIM_ICUB3_L_LOWER_LEG--SIM_ICUB3_L_ANKLE_1"</name>
-        <nodeID>"101:-:102"</nodeID>
+        <name>"SIM_ICUB3_L_UPPERARM--SIM_ICUB3_L_ELBOW_1"</name>
+        <nodeID>"110:-:129"</nodeID>
         <status>""</status>
         <base>
           <JointSide>
@@ -4404,14 +4404,14 @@
             <name>"revolute"</name>
             <nodeID>""</nodeID>
             <referenceFrame>"WORLD"</referenceFrame>
-            <axis>1,0,0</axis>
+            <axis>0.960459,-0.267012,-0.0788901</axis>
           </Primitive>
         </primitives>
       </SimpleJoint>
       <SimpleJoint>
-        <name>"SIM_ICUB3_L_ANKLE_2--SIM_ICUB3_L_FOOT_FRONT"</name>
-        <nodeID>"103:-:104"</nodeID>
-        <status>"Could not solve for constraint between SIM_ICUB3_L_ANKLE_2 and SIM_ICUB3_L_FOOT_FRONT because of CAD constraint "</status>
+        <name>"SIM_ICUB3_R_HIP_1--SIM_ICUB3_R_HIP_2"</name>
+        <nodeID>"134:-:89"</nodeID>
+        <status>""</status>
         <base>
           <JointSide>
             <name>""</name>
@@ -4430,17 +4430,17 @@
         </follower>
         <primitives>
           <Primitive>
-            <name>"weld"</name>
+            <name>"revolute"</name>
             <nodeID>""</nodeID>
             <referenceFrame>"WORLD"</referenceFrame>
-            <axis>0.57735,0.57735,0.57735</axis>
+            <axis>0,1,0</axis>
           </Primitive>
         </primitives>
       </SimpleJoint>
       <SimpleJoint>
-        <name>"SIM_ICUB3_L_ANKLE_2--SIM_ICUB3_L_FOOT_REAR"</name>
-        <nodeID>"103:-:105"</nodeID>
-        <status>"Could not solve for constraint between SIM_ICUB3_L_ANKLE_2 and SIM_ICUB3_L_FOOT_REAR because of CAD constraint "</status>
+        <name>"SIM_ICUB3_L_HIP_1--SIM_ICUB3_L_HIP_2"</name>
+        <nodeID>"135:-:98"</nodeID>
+        <status>""</status>
         <base>
           <JointSide>
             <name>""</name>
@@ -4459,17 +4459,17 @@
         </follower>
         <primitives>
           <Primitive>
-            <name>"weld"</name>
+            <name>"revolute"</name>
             <nodeID>""</nodeID>
             <referenceFrame>"WORLD"</referenceFrame>
-            <axis>0.57735,0.57735,0.57735</axis>
+            <axis>0,1,0</axis>
           </Primitive>
         </primitives>
       </SimpleJoint>
       <SimpleJoint>
-        <name>"SIM_ICUB3_R_HIP_1--SIM_ICUB3_R_HIP_2"</name>
-        <nodeID>"88:-:89"</nodeID>
-        <status>""</status>
+        <name>"SIM_ICUB3_L_HIP_2--SIM_ICUB3_L_HIP_3"</name>
+        <nodeID>"98:-:99"</nodeID>
+        <status>"Could not solve for constraint between SIM_ICUB3_L_HIP_2 and SIM_ICUB3_L_HIP_3 because of CAD constraint "</status>
         <base>
           <JointSide>
             <name>""</name>
@@ -4488,17 +4488,17 @@
         </follower>
         <primitives>
           <Primitive>
-            <name>"revolute"</name>
+            <name>"weld"</name>
             <nodeID>""</nodeID>
             <referenceFrame>"WORLD"</referenceFrame>
-            <axis>0,1,0</axis>
+            <axis>0.57735,0.57735,0.57735</axis>
           </Primitive>
         </primitives>
       </SimpleJoint>
       <SimpleJoint>
-        <name>"SIM_ICUB3_R_HIP_2--SIM_ICUB3_R_HIP_3"</name>
-        <nodeID>"89:-:90"</nodeID>
-        <status>"Could not solve for constraint between SIM_ICUB3_R_HIP_2 and SIM_ICUB3_R_HIP_3 because of CAD constraint "</status>
+        <name>"SIM_ICUB3_R_LOWER_LEG--SIM_ICUB3_R_ANKLE_1"</name>
+        <nodeID>"138:-:93"</nodeID>
+        <status>""</status>
         <base>
           <JointSide>
             <name>""</name>
@@ -4517,16 +4517,16 @@
         </follower>
         <primitives>
           <Primitive>
-            <name>"weld"</name>
+            <name>"revolute"</name>
             <nodeID>""</nodeID>
             <referenceFrame>"WORLD"</referenceFrame>
-            <axis>0.57735,0.57735,0.57735</axis>
+            <axis>-1,0,0</axis>
           </Primitive>
         </primitives>
       </SimpleJoint>
       <SimpleJoint>
-        <name>"SIM_ICUB3_L_UPPERARM--SIM_ICUB3_L_ELBOW_1"</name>
-        <nodeID>"110:-:129"</nodeID>
+        <name>"SIM_ICUB3_R_UPPER_LEG--SIM_ICUB3_R_LOWER_LEG"</name>
+        <nodeID>"132:-:138"</nodeID>
         <status>""</status>
         <base>
           <JointSide>
@@ -4549,13 +4549,13 @@
             <name>"revolute"</name>
             <nodeID>""</nodeID>
             <referenceFrame>"WORLD"</referenceFrame>
-            <axis>0.960459,-0.267012,-0.0788901</axis>
+            <axis>-1,0,0</axis>
           </Primitive>
         </primitives>
       </SimpleJoint>
       <SimpleJoint>
-        <name>"SIM_ICUB3_R_HIP_3--SIM_ICUB3_R_UPPER_LEG"</name>
-        <nodeID>"90:-:91"</nodeID>
+        <name>"SIM_ICUB3_L_UPPER_LEG--SIM_ICUB3_L_LOWER_LEG"</name>
+        <nodeID>"133:-:139"</nodeID>
         <status>""</status>
         <base>
           <JointSide>
@@ -4578,13 +4578,13 @@
             <name>"revolute"</name>
             <nodeID>""</nodeID>
             <referenceFrame>"WORLD"</referenceFrame>
-            <axis>0,0,1</axis>
+            <axis>1,0,0</axis>
           </Primitive>
         </primitives>
       </SimpleJoint>
       <SimpleJoint>
-        <name>"SIM_ICUB3_R_UPPER_LEG--SIM_ICUB3_R_LOWER_LEG"</name>
-        <nodeID>"91:-:92"</nodeID>
+        <name>"SIM_ICUB3_L_HIP_3--SIM_ICUB3_L_UPPER_LEG"</name>
+        <nodeID>"133:-:99"</nodeID>
         <status>""</status>
         <base>
           <JointSide>
@@ -4607,13 +4607,13 @@
             <name>"revolute"</name>
             <nodeID>""</nodeID>
             <referenceFrame>"WORLD"</referenceFrame>
-            <axis>-1,0,0</axis>
+            <axis>0,0,1</axis>
           </Primitive>
         </primitives>
       </SimpleJoint>
       <SimpleJoint>
-        <name>"SIM_ICUB3_R_LOWER_LEG--SIM_ICUB3_R_ANKLE_1"</name>
-        <nodeID>"92:-:93"</nodeID>
+        <name>"SIM_ICUB3_R_ANKLE_1--SIM_ICUB3_R_ANKLE_2"</name>
+        <nodeID>"93:-:94"</nodeID>
         <status>""</status>
         <base>
           <JointSide>
@@ -4636,14 +4636,14 @@
             <name>"revolute"</name>
             <nodeID>""</nodeID>
             <referenceFrame>"WORLD"</referenceFrame>
-            <axis>-1,0,0</axis>
+            <axis>0,1,0</axis>
           </Primitive>
         </primitives>
       </SimpleJoint>
       <SimpleJoint>
-        <name>"SIM_ICUB3_L_HIP_1--SIM_ICUB3_L_HIP_2"</name>
-        <nodeID>"97:-:98"</nodeID>
-        <status>""</status>
+        <name>"SIM_ICUB3_L_ANKLE_2--SIM_ICUB3_L_FOOT_FRONT"</name>
+        <nodeID>"103:-:104"</nodeID>
+        <status>"Could not solve for constraint between SIM_ICUB3_L_ANKLE_2 and SIM_ICUB3_L_FOOT_FRONT because of CAD constraint "</status>
         <base>
           <JointSide>
             <name>""</name>
@@ -4662,16 +4662,16 @@
         </follower>
         <primitives>
           <Primitive>
-            <name>"revolute"</name>
+            <name>"weld"</name>
             <nodeID>""</nodeID>
             <referenceFrame>"WORLD"</referenceFrame>
-            <axis>0,1,0</axis>
+            <axis>0.57735,0.57735,0.57735</axis>
           </Primitive>
         </primitives>
       </SimpleJoint>
       <SimpleJoint>
-        <name>"SIM_ICUB3_L_HIP_3--SIM_ICUB3_L_UPPER_LEG"</name>
-        <nodeID>"100:-:99"</nodeID>
+        <name>"SIM_ICUB3_L_ANKLE_1--SIM_ICUB3_L_ANKLE_2"</name>
+        <nodeID>"102:-:103"</nodeID>
         <status>""</status>
         <base>
           <JointSide>
@@ -4694,14 +4694,14 @@
             <name>"revolute"</name>
             <nodeID>""</nodeID>
             <referenceFrame>"WORLD"</referenceFrame>
-            <axis>0,0,1</axis>
+            <axis>0,1,0</axis>
           </Primitive>
         </primitives>
       </SimpleJoint>
       <SimpleJoint>
-        <name>"SIM_ICUB3_L_UPPER_LEG--SIM_ICUB3_L_LOWER_LEG"</name>
-        <nodeID>"100:-:101"</nodeID>
-        <status>""</status>
+        <name>"SIM_ICUB3_L_ANKLE_2--SIM_ICUB3_L_FOOT_REAR"</name>
+        <nodeID>"103:-:105"</nodeID>
+        <status>"Could not solve for constraint between SIM_ICUB3_L_ANKLE_2 and SIM_ICUB3_L_FOOT_REAR because of CAD constraint "</status>
         <base>
           <JointSide>
             <name>""</name>
@@ -4715,35 +4715,6 @@
             <name>""</name>
             <connection>
               <Frame ref="70"></Frame>
-            </connection>
-          </JointSide>
-        </follower>
-        <primitives>
-          <Primitive>
-            <name>"revolute"</name>
-            <nodeID>""</nodeID>
-            <referenceFrame>"WORLD"</referenceFrame>
-            <axis>1,0,0</axis>
-          </Primitive>
-        </primitives>
-      </SimpleJoint>
-      <SimpleJoint>
-        <name>"SIM_ICUB3_L_HIP_2--SIM_ICUB3_L_HIP_3"</name>
-        <nodeID>"98:-:99"</nodeID>
-        <status>"Could not solve for constraint between SIM_ICUB3_L_HIP_2 and SIM_ICUB3_L_HIP_3 because of CAD constraint "</status>
-        <base>
-          <JointSide>
-            <name>""</name>
-            <connection>
-              <Frame ref="71"></Frame>
-            </connection>
-          </JointSide>
-        </base>
-        <follower>
-          <JointSide>
-            <name>""</name>
-            <connection>
-              <Frame ref="72"></Frame>
             </connection>
           </JointSide>
         </follower>
@@ -4764,6 +4735,35 @@
           <JointSide>
             <name>""</name>
             <connection>
+              <Frame ref="71"></Frame>
+            </connection>
+          </JointSide>
+        </base>
+        <follower>
+          <JointSide>
+            <name>""</name>
+            <connection>
+              <Frame ref="72"></Frame>
+            </connection>
+          </JointSide>
+        </follower>
+        <primitives>
+          <Primitive>
+            <name>"revolute"</name>
+            <nodeID>""</nodeID>
+            <referenceFrame>"WORLD"</referenceFrame>
+            <axis>0.0619303,-0.0713662,0.995526</axis>
+          </Primitive>
+        </primitives>
+      </SimpleJoint>
+      <SimpleJoint>
+        <name>"SIM_ICUB3_R_HIP_2--SIM_ICUB3_R_HIP_3"</name>
+        <nodeID>"89:-:90"</nodeID>
+        <status>"Could not solve for constraint between SIM_ICUB3_R_HIP_2 and SIM_ICUB3_R_HIP_3 because of CAD constraint "</status>
+        <base>
+          <JointSide>
+            <name>""</name>
+            <connection>
               <Frame ref="73"></Frame>
             </connection>
           </JointSide>
@@ -4778,16 +4778,16 @@
         </follower>
         <primitives>
           <Primitive>
-            <name>"revolute"</name>
+            <name>"weld"</name>
             <nodeID>""</nodeID>
             <referenceFrame>"WORLD"</referenceFrame>
-            <axis>0.0619303,-0.0713662,0.995526</axis>
+            <axis>0.57735,0.57735,0.57735</axis>
           </Primitive>
         </primitives>
       </SimpleJoint>
       <SimpleJoint>
-        <name>"SIM_ICUB3_R_ELBOW_1--SIM_ICUB3_R_FOREARM"</name>
-        <nodeID>"111:-:113"</nodeID>
+        <name>"SIM_ICUB3_R_HIP_3--SIM_ICUB3_R_UPPER_LEG"</name>
+        <nodeID>"132:-:90"</nodeID>
         <status>""</status>
         <base>
           <JointSide>
@@ -4810,14 +4810,14 @@
             <name>"revolute"</name>
             <nodeID>""</nodeID>
             <referenceFrame>"WORLD"</referenceFrame>
-            <axis>-0.0619303,-0.0713662,0.995526</axis>
+            <axis>0,0,1</axis>
           </Primitive>
         </primitives>
       </SimpleJoint>
       <SimpleJoint>
-        <name>"SIM_ICUB3_R_UPPERARM--SIM_ICUB3_R_ELBOW_1"</name>
-        <nodeID>"111:-:126"</nodeID>
-        <status>""</status>
+        <name>"SIM_ICUB3_R_ANKLE_2--SIM_ICUB3_R_FOOT_REAR"</name>
+        <nodeID>"94:-:96"</nodeID>
+        <status>"Could not solve for constraint between SIM_ICUB3_R_ANKLE_2 and SIM_ICUB3_R_FOOT_REAR because of CAD constraint "</status>
         <base>
           <JointSide>
             <name>""</name>
@@ -4836,16 +4836,16 @@
         </follower>
         <primitives>
           <Primitive>
-            <name>"revolute"</name>
+            <name>"weld"</name>
             <nodeID>""</nodeID>
             <referenceFrame>"WORLD"</referenceFrame>
-            <axis>-0.960459,-0.267012,-0.0788901</axis>
+            <axis>0.57735,0.57735,0.57735</axis>
           </Primitive>
         </primitives>
       </SimpleJoint>
       <SimpleJoint>
-        <name>"SIM_ICUB3_R_ANKLE_1--SIM_ICUB3_R_ANKLE_2"</name>
-        <nodeID>"93:-:94"</nodeID>
+        <name>"SIM_ICUB3_R_UPPERARM--SIM_ICUB3_R_ELBOW_1"</name>
+        <nodeID>"126:-:137"</nodeID>
         <status>""</status>
         <base>
           <JointSide>
@@ -4868,14 +4868,14 @@
             <name>"revolute"</name>
             <nodeID>""</nodeID>
             <referenceFrame>"WORLD"</referenceFrame>
-            <axis>0,1,0</axis>
+            <axis>-0.960459,-0.267012,-0.0788901</axis>
           </Primitive>
         </primitives>
       </SimpleJoint>
       <SimpleJoint>
-        <name>"SIM_ICUB3_R_ANKLE_2--SIM_ICUB3_R_FOOT_REAR"</name>
-        <nodeID>"94:-:96"</nodeID>
-        <status>"Could not solve for constraint between SIM_ICUB3_R_ANKLE_2 and SIM_ICUB3_R_FOOT_REAR because of CAD constraint "</status>
+        <name>"SIM_ICUB3_R_ANKLE_2--SIM_ICUB3_R_FOOT_FRONT"</name>
+        <nodeID>"94:-:95"</nodeID>
+        <status>"Could not solve for constraint between SIM_ICUB3_R_ANKLE_2 and SIM_ICUB3_R_FOOT_FRONT because of CAD constraint "</status>
         <base>
           <JointSide>
             <name>""</name>
@@ -4902,9 +4902,9 @@
         </primitives>
       </SimpleJoint>
       <SimpleJoint>
-        <name>"SIM_ICUB3_R_ANKLE_2--SIM_ICUB3_R_FOOT_FRONT"</name>
-        <nodeID>"94:-:95"</nodeID>
-        <status>"Could not solve for constraint between SIM_ICUB3_R_ANKLE_2 and SIM_ICUB3_R_FOOT_FRONT because of CAD constraint "</status>
+        <name>"SIM_ICUB3_L_LOWER_LEG--SIM_ICUB3_L_ANKLE_1"</name>
+        <nodeID>"102:-:139"</nodeID>
+        <status>""</status>
         <base>
           <JointSide>
             <name>""</name>
@@ -4923,10 +4923,10 @@
         </follower>
         <primitives>
           <Primitive>
-            <name>"weld"</name>
+            <name>"revolute"</name>
             <nodeID>""</nodeID>
             <referenceFrame>"WORLD"</referenceFrame>
-            <axis>0.57735,0.57735,0.57735</axis>
+            <axis>1,0,0</axis>
           </Primitive>
         </primitives>
       </SimpleJoint>
@@ -4970,7 +4970,7 @@
             <name>"CS1"</name>
             <displayName>""</displayName>
             <nodeID>"RootGround:-:SIM_ICUB3/RootPart::RootGround(AUTOGEN)"</nodeID>
-            <position>1.72376,6.36182,-369.626</position>
+            <position>1.13206,6.44551,-352.786</position>
             <positionOrigin>"WORLD"</positionOrigin>
             <positionReferenceFrame>"WORLD"</positionReferenceFrame>
             <positionUnits>"mm"</positionUnits>

--- a/simmechanics/data/icub3/ICUB_3_all_options.yaml
+++ b/simmechanics/data/icub3/ICUB_3_all_options.yaml
@@ -408,6 +408,50 @@ sensors:
             <yarpConfigurationFile>model://iCub/conf_icub3/gazebo_icub_chest_inertial.ini</yarpConfigurationFile>
         </plugin>
 
+assignedMasses:
+  root_link   : 2.52649319
+  torso_1     : 1.714262538
+  torso_2     : 1.374672951
+  chest       : 5.771074695
+  l_shoulder_1: 1.376687449
+  r_shoulder_1: 1.380716446
+  l_shoulder_2: 0.304658373
+  r_shoulder_2: 0.304658373
+  r_shoulder_3: 0.24467077
+  l_shoulder_3: 0.242239185
+  l_upper_arm : 1.968325789
+  r_upper_arm : 1.960447492
+  r_hip_1     : 2.134290199
+  r_hip_2     : 1.779000764
+  r_hip_3     : 2.1678368
+  r_upper_leg : 0.980691904
+  r_lower_leg : 5.074105512
+  r_ankle_1   : 0.346176903
+  r_ankle_2   : 1.00828013
+  r_foot_front: 0.17569926
+  r_foot_rear : 0.174817799
+  l_hip_1     : 2.108461113
+  l_hip_2     : 1.781270621
+  l_hip_3     : 2.169151426
+  l_upper_leg : 0.968264435
+  l_lower_leg : 5.063049414
+  l_ankle_1   : 0.346176903
+  l_ankle_2   : 1.011533592
+  l_foot_front: 0.175038164
+  l_foot_rear : 0.174597434
+  l_elbow_1   : 0.217768231
+  r_elbow_1   : 0.217609341
+  l_forearm   : 0.858696525
+  r_forearm   : 0.854281652
+  l_wrist_1   : 0.032535096
+  r_wrist_1   : 0.032535096
+  l_hand      : 0.249250207
+  r_hand      : 0.2499009
+  neck_1      : 0.359964395
+  neck_2      : 0.118740971
+  neck_3      : 0.179822835
+  head        : 1.831737118
+
 reverseRotationAxis:
     r_hip_yaw
     r_hip_roll

--- a/simmechanics/data/icub3/ICUB_3_all_options_gazebo.yaml.in
+++ b/simmechanics/data/icub3/ICUB_3_all_options_gazebo.yaml.in
@@ -407,7 +407,50 @@ sensors:
 
 @ASSIGNED_COLLISION_GEOMETRIES@
 
-
+assignedMasses:
+  root_link   : 2.52649319
+  torso_1     : 1.714262538
+  torso_2     : 1.374672951
+  chest       : 5.771074695
+  l_shoulder_1: 1.376687449
+  r_shoulder_1: 1.380716446
+  l_shoulder_2: 0.304658373
+  r_shoulder_2: 0.304658373
+  r_shoulder_3: 0.24467077
+  l_shoulder_3: 0.242239185
+  l_upper_arm : 1.968325789
+  r_upper_arm : 1.960447492
+  r_hip_1     : 2.134290199
+  r_hip_2     : 1.779000764
+  r_hip_3     : 2.1678368
+  r_upper_leg : 0.980691904
+  r_lower_leg : 5.074105512
+  r_ankle_1   : 0.346176903
+  r_ankle_2   : 1.00828013
+  r_foot_front: 0.17569926
+  r_foot_rear : 0.174817799
+  l_hip_1     : 2.108461113
+  l_hip_2     : 1.781270621
+  l_hip_3     : 2.169151426
+  l_upper_leg : 0.968264435
+  l_lower_leg : 5.063049414
+  l_ankle_1   : 0.346176903
+  l_ankle_2   : 1.011533592
+  l_foot_front: 0.175038164
+  l_foot_rear : 0.174597434
+  l_elbow_1   : 0.217768231
+  r_elbow_1   : 0.217609341
+  l_forearm   : 0.858696525
+  r_forearm   : 0.854281652
+  l_wrist_1   : 0.032535096
+  r_wrist_1   : 0.032535096
+  l_hand      : 0.249250207
+  r_hand      : 0.2499009
+  neck_1      : 0.359964395
+  neck_2      : 0.118740971
+  neck_3      : 0.179822835
+  head        : 1.831737118
+  
 assignedInertias:
   # This is due to https://github.com/robotology/icub-models/issues/33
   - linkName: r_shoulder_1


### PR DESCRIPTION
This PR solves the real iCub3 Vs. iCub3 URDF model mass discrepancy. The real robot weights about 52 kg on the scale, while the mass calculated by the CAD - and thus exported in the model - is about 54.5 kg after the last debugging (hidden stray component removed, other missing component added).

Thus, the ICUB_3_all_options_gazebo.yaml.in has been modified in order to assign the part masses rescaled by a 52.010/54.992 factor.

![image](https://user-images.githubusercontent.com/4729270/128481327-c2c9043f-2960-44a5-a5c9-6113cf5b3694.png)

![image](https://user-images.githubusercontent.com/4729270/128481376-41327043-0eb3-4a40-a52d-5555f5e31212.png)
 