### PR TITLE
removed collisions from upper_arms

### DIFF
--- a/simmechanics/data/icub3/ICUB_3_all_options.yaml
+++ b/simmechanics/data/icub3/ICUB_3_all_options.yaml
@@ -787,45 +787,5 @@ XMLBlobs:
             <gazebo reference="r_wrist_yaw">
               <implicitSpringDamper>1</implicitSpringDamper>
             </gazebo>
-    - |
-            <gazebo reference="r_upper_arm">
-              <selfCollide>true</selfCollide>
-              <collision>
-                <surface>
-                  <contact>
-                    <collide_without_contact>true</collide_without_contact>
-                    <ode/>
-                  </contact>
-                  <friction>
-                    <ode/>
-                  </friction>
-                </surface>
-              </collision>
-              <sensor name='r_upper_arm_collision_sensor' type='contact'>
-                <contact>
-                  <collision>collision_right</collision>
-                </contact>
-              </sensor>
-            </gazebo>
-    - |
-            <gazebo reference="l_upper_arm">
-              <selfCollide>true</selfCollide>
-              <collision>
-                <surface>
-                  <contact>
-                    <collide_without_contact>true</collide_without_contact>
-                    <ode/>
-                  </contact>
-                  <friction>
-                    <ode/>
-                  </friction>
-                </surface>
-              </collision>
-              <sensor name='l_upper_arm_collision_sensor' type='contact'>
-                <contact>
-                  <collision>collision_left</collision>
-                </contact>
-              </sensor>
-            </gazebo>
 
 

--- a/simmechanics/data/icub3/ICUB_3_all_options_gazebo.yaml.in
+++ b/simmechanics/data/icub3/ICUB_3_all_options_gazebo.yaml.in
@@ -875,46 +875,6 @@ XMLBlobs:
             <gazebo reference="r_wrist_yaw">
               <implicitSpringDamper>1</implicitSpringDamper>
             </gazebo>
-    - |
-            <gazebo reference="r_upper_arm">
-              <selfCollide>true</selfCollide>
-              <collision>
-                <surface>
-                  <contact>
-                    <collide_without_contact>true</collide_without_contact>
-                    <ode/>
-                  </contact>
-                  <friction>
-                    <ode/>
-                  </friction>
-                </surface>
-              </collision>
-              <sensor name='r_upper_arm_collision_sensor' type='contact'>
-                <contact>
-                  <collision>collision_right</collision>
-                </contact>
-              </sensor>
-            </gazebo>
-    - |
-            <gazebo reference="l_upper_arm">
-              <selfCollide>true</selfCollide>
-              <collision>
-                <surface>
-                  <contact>
-                    <collide_without_contact>true</collide_without_contact>
-                    <ode/>
-                  </contact>
-                  <friction>
-                    <ode/>
-                  </friction>
-                </surface>
-              </collision>
-              <sensor name='l_upper_arm_collision_sensor' type='contact'>
-                <contact>
-                  <collision>collision_left</collision>
-                </contact>
-              </sensor>
-            </gazebo>
 
 
 


### PR DESCRIPTION
This PR removes the collisions from the iCub3 upper arms, introduced in PR [robotology/icub-models-generator#202](https://github.com/robotology/icub-models-generator/pull/202)

These collision sensors were detecting collisions with shoulders and elbows, resulting in a much reduced real-time factor when running `gazebo` with the new version of `iCub3`. 

this PR addresses issue https://github.com/robotology/icub-models/issues/100.

This has been tested in gazebo and proven to eliminate the problematic sensors without otherwise affecting the model.