### PR TITLE
Increase metacarpus joint limit of MK3 left hand's thumb

### DIFF
--- a/simmechanics/data/components/left_hand_mk3/conf/left_hand_phys.ini
+++ b/simmechanics/data/components/left_hand_mk3/conf/left_hand_phys.ini
@@ -22,7 +22,7 @@ jointNames l_hand_metacarpus_joint l_hand_thumb_rotation_joint l_hand_thumb_prox
 
 [LIMITS]
 jntVelMax   180.0   180.0   180.0   180.0   180.0   180.0   180.0    0 0 0 0 
-jntPosMax    62.0     0.0   140.0    10.0   200.3   200.3   200.3    0 0 0 0  
+jntPosMax    80.0     0.0   140.0    10.0   200.3   200.3   200.3    0 0 0 0  
 jntPosMin     0.0   -70.0     0.0     0.0     0.0     0.0     0.0    0 0 0 0
 
 [POSITION_CONTROL]

--- a/simmechanics/data/components/left_hand_mk3/simmechanics2urdf_joints_configfile.csv
+++ b/simmechanics/data/components/left_hand_mk3/simmechanics2urdf_joints_configfile.csv
@@ -1,5 +1,5 @@
 joint_name,lower_limit,upper_limit,damping
-l_hand_metacarpus_joint,0.0,62.0,1.0
+l_hand_metacarpus_joint,0.0,80.0,1.0
 l_hand_thumb_rotation_joint,-70.0,0.0,1.0
 l_hand_thumb_proximal_joint,0.0,85.0,1.0
 l_hand_thumb_distal_joint,0.0,55.0,1.0


### PR DESCRIPTION
This PR aims to increase the angular limit of the metacarpus joint limit, associated to the thumb of the MK3 left hand. The modification is done according to this suggestion: https://github.com/robotology/icub-models/issues/104#issuecomment-922769905 . The main objective of this modification is to allow better contact between thumb and index fingertips. 