### PR TITLE
Fix missing velocityControlImplementationType parameter in left_wrist_mk2

### DIFF
--- a/simmechanics/data/components/left_wrist_mk2/conf/left_wrist.ini
+++ b/simmechanics/data/components/left_wrist_mk2/conf/left_wrist.ini
@@ -38,6 +38,7 @@ stictionUp   0     0     0
 stictionDwn  0     0     0     
 
 [VELOCITY_CONTROL]
+velocityControlImplementationType integrator_and_position_pid
 controlUnits  metric_units
 controlLaw    joint_pid_gazebo_v1
 kp           20.0  20.0  20.0  


### PR DESCRIPTION
As per the title. 