### PR TITLE
iCubGenova09: Add FT sensor to right upper leg

### DIFF
--- a/simmechanics/data/icub3/ICUB_3_all_options.yaml
+++ b/simmechanics/data/icub3/ICUB_3_all_options.yaml
@@ -267,15 +267,15 @@ forceTorqueSensors:
             <yarpConfigurationFile>model://iCub/conf_icub3/FT/gazebo_icub_left_foot_rear_ft.ini</yarpConfigurationFile>
           </plugin>
     # right leg
-    #- jointName: r_leg_ft_sensor
-    #  directionChildToParent: Yes
-    #  frame: sensor
-    #  frameName: SCSYS_R_HIP_2_FT
-    #  sensorBlobs:
-    #  - |
-    #      <plugin name="right_leg_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
-    #        <yarpConfigurationFile>model://iCub/conf_icub3/FT/gazebo_icub_right_leg_ft.ini</yarpConfigurationFile>
-    #      </plugin>
+    - jointName: r_leg_ft_sensor
+      directionChildToParent: Yes
+      frame: sensor
+      frameName: SCSYS_R_HIP_2_FT
+      sensorBlobs:
+      - |
+          <plugin name="right_leg_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
+            <yarpConfigurationFile>model://iCub/conf_icub3/FT/gazebo_icub_right_leg_ft.ini</yarpConfigurationFile>
+          </plugin>
     - jointName: r_foot_front_ft_sensor
       directionChildToParent: No
       frame: sensor
@@ -831,5 +831,3 @@ XMLBlobs:
             <gazebo reference="r_wrist_yaw">
               <implicitSpringDamper>1</implicitSpringDamper>
             </gazebo>
-
-

--- a/simmechanics/data/icub3/ICUB_3_all_options_gazebo.yaml.in
+++ b/simmechanics/data/icub3/ICUB_3_all_options_gazebo.yaml.in
@@ -264,15 +264,15 @@ forceTorqueSensors:
             <yarpConfigurationFile>model://iCub/conf_icub3/FT/gazebo_icub_left_foot_rear_ft.ini</yarpConfigurationFile>
           </plugin>
     # right leg
-    #- jointName: r_leg_ft_sensor
-    #  directionChildToParent: Yes
-    #  frame: sensor
-    #  frameName: SCSYS_R_HIP_2_FT
-    #  sensorBlobs:
-    #  - |
-    #      <plugin name="right_leg_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
-    #        <yarpConfigurationFile>model://iCub/conf_icub3/FT/gazebo_icub_right_leg_ft.ini</yarpConfigurationFile>
-    #      </plugin>
+    - jointName: r_leg_ft_sensor
+      directionChildToParent: Yes
+      frame: sensor
+      frameName: SCSYS_R_HIP_2_FT
+      sensorBlobs:
+      - |
+          <plugin name="right_leg_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
+            <yarpConfigurationFile>model://iCub/conf_icub3/FT/gazebo_icub_right_leg_ft.ini</yarpConfigurationFile>
+          </plugin>
     - jointName: r_foot_front_ft_sensor
       directionChildToParent: No
       frame: sensor
@@ -919,6 +919,3 @@ XMLBlobs:
             <gazebo reference="r_wrist_yaw">
               <implicitSpringDamper>1</implicitSpringDamper>
             </gazebo>
-
-
-

--- a/tests/icub-model-test.cpp
+++ b/tests/icub-model-test.cpp
@@ -382,6 +382,30 @@ bool checkFTSensorsAreOddAndNotNull(iDynTree::ModelLoader & mdlLoader)
     return true;
 }
 
+/**
+ * All the iCub have a even and not null number of F/T sensors.
+ */
+bool checkFTSensorsAreEvenAndNotNull(iDynTree::ModelLoader & mdlLoader)
+{
+    int nrOfFTSensors = mdlLoader.sensors().getNrOfSensors(iDynTree::SIX_AXIS_FORCE_TORQUE);
+
+    if( nrOfFTSensors == 0 )
+    {
+        std::cerr << "icub-model-test error: no F/T sensor found in the model" << std::endl;
+        return false;
+    }
+
+    if( nrOfFTSensors % 2 == 1 )
+    {
+        std::cerr << "icub-model-test : odd number of F/T sensor found in the model" << std::endl;
+        return false;
+    }
+
+
+    return true;
+}
+
+
 bool checkFTSensorIsCorrectlyOriented(iDynTree::KinDynComputations & comp,
                                       const iDynTree::Rotation& expected,
                                       const std::string& sensorName)
@@ -535,14 +559,15 @@ int main(int argc, char ** argv)
     }
 
     // Now some test that test the sensors
-    if( !checkFTSensorsAreOddAndNotNull(mdlLoader) )
-    {
-        return EXIT_FAILURE;
-    }
-
     // The ft sensors orientation respect to the root_link are different to iCubV2 and they are under investigation.
     if (modelPath.find("Genova09") != std::string::npos ||
         modelPath.find("GazeboV3") != std::string::npos) {
+
+        if( !checkFTSensorsAreOddAndNotNull(mdlLoader) )
+        {
+            return EXIT_FAILURE;
+        }
+
         if (!checkFTSensorsAreCorrectlyOrientedV3(comp))
         {
             return EXIT_FAILURE;
@@ -550,6 +575,11 @@ int main(int argc, char ** argv)
     }
     else
     {
+        if( !checkFTSensorsAreEvenAndNotNull(mdlLoader) )
+        {
+            return EXIT_FAILURE;
+        }
+
         if (!checkFTSensorsAreCorrectlyOrientedV2(comp))
         {
             return EXIT_FAILURE;

--- a/tests/icub-model-test.cpp
+++ b/tests/icub-model-test.cpp
@@ -478,9 +478,14 @@ bool checkFTSensorsAreCorrectlyOrientedV3(iDynTree::KinDynComputations & comp)
                            -0.866025, -0.5, 0,
                             0, 0, 1);
 
+    iDynTree::Rotation rootLink_R_sensorFrameExpectedLeg = 
+        iDynTree::Rotation(-0.866025, -0.5, 0,
+                           -0.5, 0.866025, 0,
+                            0, 0, -1);
+
     bool ok = checkFTSensorIsCorrectlyOriented(comp, rootLink_R_sensorFrameLeftArmExpected, "l_arm_ft_sensor");
     ok = checkFTSensorIsCorrectlyOriented(comp, rootLink_R_sensorFrameRightArmExpected, "r_arm_ft_sensor") && ok;
-    // l_leg_ft_sensor and r_leg_ft_sensor frames seems to be wrong(see https://github.com/robotology/icub-models/issues/71)
+    ok = checkFTSensorIsCorrectlyOriented(comp, rootLink_R_sensorFrameExpectedLeg, "r_leg_ft_sensor") && ok;
     ok = checkFTSensorIsCorrectlyOriented(comp, rootLink_R_sensorFrameExpectedFoot, "l_foot_rear_ft_sensor") && ok;
     ok = checkFTSensorIsCorrectlyOriented(comp, rootLink_R_sensorFrameExpectedFoot, "r_foot_rear_ft_sensor") && ok;
     ok = checkFTSensorIsCorrectlyOriented(comp, rootLink_R_sensorFrameExpectedFoot, "l_foot_front_ft_sensor") && ok;

--- a/tests/icub-model-test.cpp
+++ b/tests/icub-model-test.cpp
@@ -360,9 +360,9 @@ bool checkAxisDirectionsV3(iDynTree::KinDynComputations & comp)
 }
 
 /**
- * All the iCub have a even and not null number of F/T sensors.
+ * All the iCub have a odd and not null number of F/T sensors.
  */
-bool checkFTSensorsAreEvenAndNotNull(iDynTree::ModelLoader & mdlLoader)
+bool checkFTSensorsAreOddAndNotNull(iDynTree::ModelLoader & mdlLoader)
 {
     int nrOfFTSensors = mdlLoader.sensors().getNrOfSensors(iDynTree::SIX_AXIS_FORCE_TORQUE);
 
@@ -372,9 +372,9 @@ bool checkFTSensorsAreEvenAndNotNull(iDynTree::ModelLoader & mdlLoader)
         return false;
     }
 
-    if( nrOfFTSensors % 2 == 1 )
+    if( nrOfFTSensors % 2 == 0 )
     {
-        std::cerr << "icub-model-test : odd number of F/T sensor found in the model" << std::endl;
+        std::cerr << "icub-model-test : even number of F/T sensor found in the model" << std::endl;
         return false;
     }
 
@@ -535,7 +535,7 @@ int main(int argc, char ** argv)
     }
 
     // Now some test that test the sensors
-    if( !checkFTSensorsAreEvenAndNotNull(mdlLoader) )
+    if( !checkFTSensorsAreOddAndNotNull(mdlLoader) )
     {
         return EXIT_FAILURE;
     }


### PR DESCRIPTION
As per title, this PR adds the FT sensor on the right leg of iCub3 to reflect the addition on the real robot.

Its transformation relative to the root link is the following:
```
-0.866025  -0.5        0
-0.5        0.866025   0
 0          0         -1
```
Which corresponds to the transform in the CAD, and therefore it corresponds to the way it is mounted:
![MicrosoftTeams-image](https://user-images.githubusercontent.com/38140169/153882543-d98f5110-b6a1-4244-bbcc-81b4ae01be79.png)

cc @S-Dafarra @pattacini 