### PR TITLE
new tuned `pidParams` for icub3 gazebo model for walking simulations

### DIFF
--- a/simmechanics/data/icub3/conf/gazebo_icub_left_leg.ini
+++ b/simmechanics/data/icub3/conf/gazebo_icub_left_leg.ini
@@ -37,15 +37,15 @@ max_damping   100.0  100.0  100.0  100.0  100.0  100.0
 [POSITION_CONTROL]
 controlUnits  metric_units
 controlLaw    joint_pid_gazebo_v1
-kp            40.0   40.0   40.0   40.0   40.0   40.0
-kd            0.35   0.35   0.35   0.35   0.35   0.35
-ki            0.35   0.35   0.35   0.35   0.35   0.35
-maxInt        9999   9999   9999   9999   9999   9999
-maxOutput     9999   9999   9999   9999   9999   9999
-shift         0.0    0.0    0.0    0.0    0.0    0.0
-ko            0.0    0.0    0.0    0.0    0.0    0.0
-stictionUp    0.0    0.0    0.0    0.0    0.0    0.0
-stictionDwn   0.0    0.0    0.0    0.0    0.0    0.0
+kp            70.0   70.0   40.0   100.0   100.0   100.0
+kd            0.15   0.15   0.35   0.15    0.15     0.15
+ki            0.17   0.17   0.35   0.35    0.35     0.35
+maxInt        9999   9999   9999   9999    9999     9999
+maxOutput     9999   9999   9999   9999    9999     9999
+shift         0.0    0.0    0.0    0.0     0.0      0.0
+ko            0.0    0.0    0.0    0.0     0.0      0.0
+stictionUp    0.0    0.0    0.0    0.0     0.0      0.0
+stictionDwn   0.0    0.0    0.0    0.0     0.0      0.0
 
 [VELOCITY_CONTROL]
 velocityControlImplementationType integrator_and_position_pid

--- a/simmechanics/data/icub3/conf/gazebo_icub_right_leg.ini
+++ b/simmechanics/data/icub3/conf/gazebo_icub_right_leg.ini
@@ -37,15 +37,15 @@ max_damping   100.0  100.0  100.0  100.0  100.0  100.0
 [POSITION_CONTROL]
 controlUnits  metric_units
 controlLaw    joint_pid_gazebo_v1
-kp            40.0   40.0   40.0   40.0   40.0   40.0
-kd            0.35   0.35   0.35   0.35   0.35   0.35
-ki            0.35   0.35   0.35   0.35   0.35   0.35
-maxInt        9999   9999   9999   9999   9999   9999
-maxOutput     9999   9999   9999   9999   9999   9999
-shift         0.0    0.0    0.0    0.0    0.0    0.0
-ko            0.0    0.0    0.0    0.0    0.0    0.0
-stictionUp    0.0    0.0    0.0    0.0    0.0    0.0
-stictionDwn   0.0    0.0    0.0    0.0    0.0    0.0
+kp            70.0   70.0   40.0   100.0   100.0   100.0
+kd            0.15   0.15   0.35   0.15    0.15     0.15
+ki            0.17   0.17   0.35   0.35    0.35     0.35
+maxInt        9999   9999   9999   9999    9999     9999
+maxOutput     9999   9999   9999   9999    9999     9999
+shift         0.0    0.0    0.0    0.0     0.0      0.0
+ko            0.0    0.0    0.0    0.0     0.0      0.0
+stictionUp    0.0    0.0    0.0    0.0     0.0      0.0
+stictionDwn   0.0    0.0    0.0    0.0     0.0      0.0
 
 [VELOCITY_CONTROL]
 velocityControlImplementationType integrator_and_position_pid

--- a/simmechanics/data/icub3/conf/gazebo_icub_torso.ini
+++ b/simmechanics/data/icub3/conf/gazebo_icub_torso.ini
@@ -37,9 +37,9 @@ max_damping   100.0  100.0  100.0
 [POSITION_CONTROL]
 controlUnits  metric_units
 controlLaw    joint_pid_gazebo_v1
-kp            40.0  40.0  40.0
-kd            0.35  0.35  0.35
-ki            0.35  0.35  0.35
+kp            70.0  0.17   0.15
+kd            70.0  0.17   0.15
+ki            70.0  0.17   0.15
 maxInt        9999  9999  9999
 maxOutput     9999  9999  9999
 shift         0.0   0.0   0.0

--- a/simmechanics/data/icub3/conf/gazebo_icub_torso.ini
+++ b/simmechanics/data/icub3/conf/gazebo_icub_torso.ini
@@ -37,9 +37,9 @@ max_damping   100.0  100.0  100.0
 [POSITION_CONTROL]
 controlUnits  metric_units
 controlLaw    joint_pid_gazebo_v1
-kp            70.0  0.17   0.15
-kd            70.0  0.17   0.15
-ki            70.0  0.17   0.15
+kp            70.0  70.0   70.0
+kd            0.15  0.15   0.15
+ki            0.17  0.17   0.17
 maxInt        9999  9999  9999
 maxOutput     9999  9999  9999
 shift         0.0   0.0   0.0


### PR DESCRIPTION
With reference to [this pull request](https://github.com/robotology/icub-models/pull/126) and the corresponding one in the walking-controllers (i.e [this PR](https://github.com/robotology/walking-controllers/pull/106) ). I am updating the values of the low-level position-control pid gains. These new values seems to work on several machines and also for the `stickBot`. see also [this issue](https://github.com/robotology/walking-controllers/issues/107). 

P.S.
I opened the PR directly on master since the interested people are limited and the PR should not, in theory, break any other simulation related activity. Feel free to suggest a different approach.