### PR TITLE
Export frames in urdf for the sensors (imu and Ft sensors)

### DIFF
--- a/simmechanics/CMakeLists.txt
+++ b/simmechanics/CMakeLists.txt
@@ -177,7 +177,7 @@ macro(generate_icub_simmechanics)
       set(XSENS_IMU_SENSOR
 "  - frameName: SCSYS_ROOT_LINK_XSENS_IMU
     linkName: root_link
-    exportFrameInURDF: No
+    exportFrameInURDF: Yes
     sensorName: root_link_imu_acc
     sensorType: \"accelerometer\"
     updateRate: \"400\"

--- a/simmechanics/data/icub2_5/ICUB_2-5_BB_simmechanics_options.yaml.in
+++ b/simmechanics/data/icub2_5/ICUB_2-5_BB_simmechanics_options.yaml.in
@@ -595,6 +595,7 @@ linkFrames:
 forceTorqueSensors:
   - jointName: l_leg_ft_sensor
     directionChildToParent: Yes
+    exportFrameInURDF: Yes
     sensorBlobs:
     - |
         <plugin name="left_leg_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
@@ -602,6 +603,7 @@ forceTorqueSensors:
         </plugin>
   - jointName: r_leg_ft_sensor
     directionChildToParent: Yes
+    exportFrameInURDF: Yes
     sensorBlobs:
     - |
         <plugin name="right_leg_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
@@ -609,6 +611,7 @@ forceTorqueSensors:
         </plugin>
   - jointName: l_foot_ft_sensor
     directionChildToParent: Yes
+    exportFrameInURDF: Yes
     sensorBlobs:
     - |
         <plugin name="left_foot_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
@@ -616,6 +619,7 @@ forceTorqueSensors:
         </plugin>
   - jointName: r_foot_ft_sensor
     directionChildToParent: Yes
+    exportFrameInURDF: Yes
     sensorBlobs:
     - |
         <plugin name="right_foot_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
@@ -623,6 +627,7 @@ forceTorqueSensors:
         </plugin>
   - jointName: l_arm_ft_sensor
     directionChildToParent: Yes
+    exportFrameInURDF: Yes
     sensorBlobs:
     - |
         <plugin name="left_arm_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
@@ -630,6 +635,7 @@ forceTorqueSensors:
         </plugin>
   - jointName: r_arm_ft_sensor
     directionChildToParent: Yes
+    exportFrameInURDF: Yes
     sensorBlobs:
     - |
         <plugin name="right_arm_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
@@ -645,7 +651,7 @@ sensors:
     - |
         <plugin name="iCub_yarp_gazebo_plugin_ACC" filename="libgazebo_yarp_inertial.so" />
   - sensorName: default
-    exportFrameInURDF: No
+    exportFrameInURDF: Yes
     sensorType: "gyroscope"
     updateRate: "100"
   - frameName: SCSYS_HEAD_MTX_IMU

--- a/simmechanics/data/icub3/ICUB_3_all_options.yaml
+++ b/simmechanics/data/icub3/ICUB_3_all_options.yaml
@@ -222,6 +222,7 @@ forceTorqueSensors:
     # upperbody
     - jointName: l_arm_ft_sensor
       directionChildToParent: Yes
+      exportFrameInURDF: Yes
       frame: sensor
       frameName: SCSYS_L_SHOULDER_2_FT
       sensorBlobs:
@@ -231,6 +232,7 @@ forceTorqueSensors:
           </plugin>
     - jointName: r_arm_ft_sensor
       directionChildToParent: Yes
+      exportFrameInURDF: Yes
       frame: sensor
       frameName: SCSYS_R_SHOULDER_2_FT
       sensorBlobs:
@@ -241,6 +243,7 @@ forceTorqueSensors:
     # left leg
     - jointName: l_leg_ft_sensor
       directionChildToParent: Yes
+      exportFrameInURDF: Yes
       frame: sensor
       frameName: SCSYS_L_HIP_2_FT
       sensorBlobs:
@@ -250,6 +253,7 @@ forceTorqueSensors:
           </plugin>
     - jointName: l_foot_front_ft_sensor
       directionChildToParent: No
+      exportFrameInURDF: Yes
       frame: sensor
       frameName: SCSYS_L_ANKLE_2_FT_FRONT
       sensorBlobs:
@@ -259,6 +263,7 @@ forceTorqueSensors:
           </plugin>
     - jointName: l_foot_rear_ft_sensor
       directionChildToParent: No
+      exportFrameInURDF: Yes
       frame: sensor
       frameName: SCSYS_L_ANKLE_2_FT_REAR
       sensorBlobs:
@@ -269,6 +274,7 @@ forceTorqueSensors:
     # right leg
     - jointName: r_leg_ft_sensor
       directionChildToParent: Yes
+      exportFrameInURDF: Yes
       frame: sensor
       frameName: SCSYS_R_HIP_2_FT
       sensorBlobs:
@@ -278,6 +284,7 @@ forceTorqueSensors:
           </plugin>
     - jointName: r_foot_front_ft_sensor
       directionChildToParent: No
+      exportFrameInURDF: Yes
       frame: sensor
       frameName: SCSYS_R_ANKLE_2_FT_FRONT
       sensorBlobs:
@@ -287,6 +294,7 @@ forceTorqueSensors:
           </plugin>
     - jointName: r_foot_rear_ft_sensor
       directionChildToParent: No
+      exportFrameInURDF: Yes
       frame: sensor
       frameName: SCSYS_R_ANKLE_2_FT_REAR
       sensorBlobs:
@@ -298,14 +306,14 @@ forceTorqueSensors:
 
 sensors:
   - sensorName: default
-    exportFrameInURDF: No
+    exportFrameInURDF: Yes
     sensorType: "accelerometer"
     updateRate: "100"
     sensorBlobs:
     - |
         <plugin name="iCub_yarp_gazebo_plugin_ACC" filename="libgazebo_yarp_inertial.so" />
   - sensorName: default
-    exportFrameInURDF: No
+    exportFrameInURDF: Yes
     sensorType: "gyroscope"
     updateRate: "100"
   - frameName: SCSYS_HEAD_IMU
@@ -402,6 +410,7 @@ sensors:
     linkName: chest
     sensorName: chest_imu_acc_1x1
     sensorType: "accelerometer"
+    exportFrameInURDF: Yes
     sensorBlobs:
     - |
         <plugin name="iCub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">

--- a/simmechanics/data/icub3/ICUB_3_all_options_gazebo.yaml.in
+++ b/simmechanics/data/icub3/ICUB_3_all_options_gazebo.yaml.in
@@ -221,6 +221,7 @@ forceTorqueSensors:
       directionChildToParent: Yes
       frame: sensor
       frameName: SCSYS_L_SHOULDER_2_FT
+      exportFrameInURDF: Yes
       sensorBlobs:
       - |
           <plugin name="left_arm_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
@@ -230,6 +231,7 @@ forceTorqueSensors:
       directionChildToParent: Yes
       frame: sensor
       frameName: SCSYS_R_SHOULDER_2_FT
+      exportFrameInURDF: Yes
       sensorBlobs:
       - |
           <plugin name="right_arm_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
@@ -240,6 +242,7 @@ forceTorqueSensors:
       directionChildToParent: Yes
       frame: sensor
       frameName: SCSYS_L_HIP_2_FT
+      exportFrameInURDF: Yes
       sensorBlobs:
       - |
           <plugin name="left_leg_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
@@ -249,6 +252,7 @@ forceTorqueSensors:
       directionChildToParent: No
       frame: sensor
       frameName: SCSYS_L_ANKLE_2_FT_FRONT
+      exportFrameInURDF: Yes
       sensorBlobs:
       - |
           <plugin name="left_foot_front_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
@@ -258,6 +262,7 @@ forceTorqueSensors:
       directionChildToParent: No
       frame: sensor
       frameName: SCSYS_L_ANKLE_2_FT_REAR
+      exportFrameInURDF: Yes
       sensorBlobs:
       - |
           <plugin name="left_foot_rear_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
@@ -268,6 +273,7 @@ forceTorqueSensors:
       directionChildToParent: Yes
       frame: sensor
       frameName: SCSYS_R_HIP_2_FT
+      exportFrameInURDF: Yes
       sensorBlobs:
       - |
           <plugin name="right_leg_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
@@ -277,6 +283,7 @@ forceTorqueSensors:
       directionChildToParent: No
       frame: sensor
       frameName: SCSYS_R_ANKLE_2_FT_FRONT
+      exportFrameInURDF: Yes
       sensorBlobs:
       - |
           <plugin name="right_foot_front_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
@@ -286,6 +293,7 @@ forceTorqueSensors:
       directionChildToParent: No
       frame: sensor
       frameName: SCSYS_R_ANKLE_2_FT_REAR
+      exportFrameInURDF: Yes
       sensorBlobs:
       - |
           <plugin name="right_foot_rear_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
@@ -297,11 +305,12 @@ sensors:
     exportFrameInURDF: No
     sensorType: "accelerometer"
     updateRate: "100"
+    exportFrameInURDF: Yes
     sensorBlobs:
     - |
         <plugin name="iCub_yarp_gazebo_plugin_ACC" filename="libgazebo_yarp_inertial.so" />
   - sensorName: default
-    exportFrameInURDF: No
+    exportFrameInURDF: Yes
     sensorType: "gyroscope"
     updateRate: "100"
   - frameName: SCSYS_HEAD_IMU


### PR DESCRIPTION
These frames are needed for visualizing correctly the sensors measurements from rviz.

Keeping in draft since I don't know if it is the best solution.

@traversaro @randaz81 @elandini84 