### PR TITLE
icub3: add xml files for running mc and ft ros2 nws

### DIFF
--- a/simmechanics/data/icub2_5/ICUB_2-5_BB_simmechanics_options.yaml.in
+++ b/simmechanics/data/icub2_5/ICUB_2-5_BB_simmechanics_options.yaml.in
@@ -595,7 +595,6 @@ linkFrames:
 forceTorqueSensors:
   - jointName: l_leg_ft_sensor
     directionChildToParent: Yes
-    exportFrameInURDF: Yes
     sensorBlobs:
     - |
         <plugin name="left_leg_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
@@ -603,7 +602,6 @@ forceTorqueSensors:
         </plugin>
   - jointName: r_leg_ft_sensor
     directionChildToParent: Yes
-    exportFrameInURDF: Yes
     sensorBlobs:
     - |
         <plugin name="right_leg_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
@@ -611,7 +609,6 @@ forceTorqueSensors:
         </plugin>
   - jointName: l_foot_ft_sensor
     directionChildToParent: Yes
-    exportFrameInURDF: Yes
     sensorBlobs:
     - |
         <plugin name="left_foot_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
@@ -619,7 +616,6 @@ forceTorqueSensors:
         </plugin>
   - jointName: r_foot_ft_sensor
     directionChildToParent: Yes
-    exportFrameInURDF: Yes
     sensorBlobs:
     - |
         <plugin name="right_foot_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
@@ -627,7 +623,6 @@ forceTorqueSensors:
         </plugin>
   - jointName: l_arm_ft_sensor
     directionChildToParent: Yes
-    exportFrameInURDF: Yes
     sensorBlobs:
     - |
         <plugin name="left_arm_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
@@ -635,7 +630,6 @@ forceTorqueSensors:
         </plugin>
   - jointName: r_arm_ft_sensor
     directionChildToParent: Yes
-    exportFrameInURDF: Yes
     sensorBlobs:
     - |
         <plugin name="right_arm_ft_plugin" filename="libgazebo_yarp_forcetorque.so">

--- a/simmechanics/data/icub3/ICUB_3_all_options.yaml
+++ b/simmechanics/data/icub3/ICUB_3_all_options.yaml
@@ -120,8 +120,6 @@ linkFrames:
     frameName: SCSYS_L_SHOULDER_3
   - linkName: l_upper_arm
     frameName: SCSYS_L_UPPERARM
-  - linkName: r_shoulder_2
-    frameName: SCSYS_R_SHOULDER_2_FT
   - linkName: r_shoulder_1
     frameName: SCSYS_R_SHOULDER_1
   - linkName: r_shoulder_2
@@ -225,6 +223,8 @@ forceTorqueSensors:
       exportFrameInURDF: Yes
       frame: sensor
       frameName: SCSYS_L_SHOULDER_2_FT
+      linkName: l_shoulder_2
+      sensorName: l_arm_ft
       sensorBlobs:
       - |
           <plugin name="left_arm_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
@@ -235,6 +235,8 @@ forceTorqueSensors:
       exportFrameInURDF: Yes
       frame: sensor
       frameName: SCSYS_R_SHOULDER_2_FT
+      linkName: r_shoulder_2
+      sensorName: r_arm_ft
       sensorBlobs:
       - |
           <plugin name="right_arm_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
@@ -245,7 +247,9 @@ forceTorqueSensors:
       directionChildToParent: Yes
       exportFrameInURDF: Yes
       frame: sensor
+      linkName: l_hip_2
       frameName: SCSYS_L_HIP_2_FT
+      sensorName: l_leg_ft
       sensorBlobs:
       - |
           <plugin name="left_leg_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
@@ -255,7 +259,9 @@ forceTorqueSensors:
       directionChildToParent: No
       exportFrameInURDF: Yes
       frame: sensor
+      linkName: l_ankle_2
       frameName: SCSYS_L_ANKLE_2_FT_FRONT
+      sensorName: l_foot_front_ft
       sensorBlobs:
       - |
           <plugin name="left_foot_front_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
@@ -265,7 +271,9 @@ forceTorqueSensors:
       directionChildToParent: No
       exportFrameInURDF: Yes
       frame: sensor
+      linkName: l_ankle_2
       frameName: SCSYS_L_ANKLE_2_FT_REAR
+      sensorName: l_foot_rear_ft
       sensorBlobs:
       - |
           <plugin name="left_foot_rear_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
@@ -276,7 +284,9 @@ forceTorqueSensors:
       directionChildToParent: Yes
       exportFrameInURDF: Yes
       frame: sensor
+      linkName: r_hip_2
       frameName: SCSYS_R_HIP_2_FT
+      sensorName: r_leg_ft
       sensorBlobs:
       - |
           <plugin name="right_leg_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
@@ -286,7 +296,9 @@ forceTorqueSensors:
       directionChildToParent: No
       exportFrameInURDF: Yes
       frame: sensor
+      linkName: r_ankle_2
       frameName: SCSYS_R_ANKLE_2_FT_FRONT
+      sensorName: r_foot_front_ft
       sensorBlobs:
       - |
           <plugin name="right_foot_front_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
@@ -296,7 +308,9 @@ forceTorqueSensors:
       directionChildToParent: No
       exportFrameInURDF: Yes
       frame: sensor
+      linkName: r_ankle_2
       frameName: SCSYS_R_ANKLE_2_FT_REAR
+      sensorName: r_foot_rear_ft
       sensorBlobs:
       - |
           <plugin name="right_foot_rear_ft_plugin" filename="libgazebo_yarp_forcetorque.so">

--- a/simmechanics/data/icub3/ICUB_3_all_options_gazebo.yaml.in
+++ b/simmechanics/data/icub3/ICUB_3_all_options_gazebo.yaml.in
@@ -947,6 +947,6 @@ XMLBlobs:
     - |
             <gazebo>
               <plugin name="robotinterface" filename="libgazebo_yarp_robotinterface.so">
-                <yarpRobotInterfaceConfigurationFile>model://iCub/conf_icub3/icub_ROS2.xml</yarpRobotInterfaceConfigurationFile>
+                <yarpRobotInterfaceConfigurationFile>model://iCub/conf_icub3/icub.xml</yarpRobotInterfaceConfigurationFile>
               </plugin>
             </gazebo>

--- a/simmechanics/data/icub3/ICUB_3_all_options_gazebo.yaml.in
+++ b/simmechanics/data/icub3/ICUB_3_all_options_gazebo.yaml.in
@@ -219,9 +219,11 @@ forceTorqueSensors:
     # upperbody
     - jointName: l_arm_ft_sensor
       directionChildToParent: Yes
+      exportFrameInURDF: Yes
       frame: sensor
       frameName: SCSYS_L_SHOULDER_2_FT
-      exportFrameInURDF: Yes
+      linkName: l_shoulder_2
+      sensorName: l_arm_ft
       sensorBlobs:
       - |
           <plugin name="left_arm_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
@@ -229,9 +231,11 @@ forceTorqueSensors:
           </plugin>
     - jointName: r_arm_ft_sensor
       directionChildToParent: Yes
+      exportFrameInURDF: Yes
       frame: sensor
       frameName: SCSYS_R_SHOULDER_2_FT
-      exportFrameInURDF: Yes
+      linkName: r_shoulder_2
+      sensorName: r_arm_ft
       sensorBlobs:
       - |
           <plugin name="right_arm_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
@@ -240,9 +244,11 @@ forceTorqueSensors:
     # left leg
     - jointName: l_leg_ft_sensor
       directionChildToParent: Yes
-      frame: sensor
-      frameName: SCSYS_L_HIP_2_FT
       exportFrameInURDF: Yes
+      frame: sensor
+      linkName: l_hip_2
+      frameName: SCSYS_L_HIP_2_FT
+      sensorName: l_leg_ft
       sensorBlobs:
       - |
           <plugin name="left_leg_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
@@ -250,9 +256,11 @@ forceTorqueSensors:
           </plugin>
     - jointName: l_foot_front_ft_sensor
       directionChildToParent: No
-      frame: sensor
-      frameName: SCSYS_L_ANKLE_2_FT_FRONT
       exportFrameInURDF: Yes
+      frame: sensor
+      linkName: l_ankle_2
+      frameName: SCSYS_L_ANKLE_2_FT_FRONT
+      sensorName: l_foot_front_ft
       sensorBlobs:
       - |
           <plugin name="left_foot_front_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
@@ -260,9 +268,11 @@ forceTorqueSensors:
           </plugin>
     - jointName: l_foot_rear_ft_sensor
       directionChildToParent: No
-      frame: sensor
-      frameName: SCSYS_L_ANKLE_2_FT_REAR
       exportFrameInURDF: Yes
+      frame: sensor
+      linkName: l_ankle_2
+      frameName: SCSYS_L_ANKLE_2_FT_REAR
+      sensorName: l_foot_rear_ft
       sensorBlobs:
       - |
           <plugin name="left_foot_rear_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
@@ -271,9 +281,11 @@ forceTorqueSensors:
     # right leg
     - jointName: r_leg_ft_sensor
       directionChildToParent: Yes
-      frame: sensor
-      frameName: SCSYS_R_HIP_2_FT
       exportFrameInURDF: Yes
+      frame: sensor
+      linkName: r_hip_2
+      frameName: SCSYS_R_HIP_2_FT
+      sensorName: r_leg_ft
       sensorBlobs:
       - |
           <plugin name="right_leg_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
@@ -281,9 +293,11 @@ forceTorqueSensors:
           </plugin>
     - jointName: r_foot_front_ft_sensor
       directionChildToParent: No
-      frame: sensor
-      frameName: SCSYS_R_ANKLE_2_FT_FRONT
       exportFrameInURDF: Yes
+      frame: sensor
+      linkName: r_ankle_2
+      frameName: SCSYS_R_ANKLE_2_FT_FRONT
+      sensorName: r_foot_front_ft
       sensorBlobs:
       - |
           <plugin name="right_foot_front_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
@@ -291,9 +305,11 @@ forceTorqueSensors:
           </plugin>
     - jointName: r_foot_rear_ft_sensor
       directionChildToParent: No
-      frame: sensor
-      frameName: SCSYS_R_ANKLE_2_FT_REAR
       exportFrameInURDF: Yes
+      frame: sensor
+      linkName: r_ankle_2
+      frameName: SCSYS_R_ANKLE_2_FT_REAR
+      sensorName: r_foot_rear_ft
       sensorBlobs:
       - |
           <plugin name="right_foot_rear_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
@@ -459,7 +475,7 @@ assignedMasses:
   neck_2      : 0.1214
   neck_3      : 0.18386
   head        : 1.8728
-  
+
 assignedInertias:
   # This is due to https://github.com/robotology/icub-models/issues/33
   - linkName: r_shoulder_1
@@ -931,6 +947,6 @@ XMLBlobs:
     - |
             <gazebo>
               <plugin name="robotinterface" filename="libgazebo_yarp_robotinterface.so">
-                <yarpRobotInterfaceConfigurationFile>model://iCub/conf_icub3/icub.xml</yarpRobotInterfaceConfigurationFile>
+                <yarpRobotInterfaceConfigurationFile>model://iCub/conf_icub3/icub_ROS2.xml</yarpRobotInterfaceConfigurationFile>
               </plugin>
             </gazebo>

--- a/simmechanics/data/icub3/conf/icub_ROS2.xml
+++ b/simmechanics/data/icub3/conf/icub_ROS2.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<robot name="iCubGazeboV3" build="1" portprefix="/icubSim" xmlns:xi="http://www.w3.org/2001/XInclude">
+
+    <devices>
+
+    <!-- motor controllers wrappers -->
+    <xi:include href="wrappers/motorControl/left_arm-mc_wrapper.xml" />
+    <xi:include href="wrappers/motorControl/right_arm-mc_wrapper.xml" />
+    <xi:include href="wrappers/motorControl/left_leg-mc_wrapper.xml" />
+    <xi:include href="wrappers/motorControl/right_leg-mc_wrapper.xml" />
+    <xi:include href="wrappers/motorControl/head-mc_wrapper.xml" />
+    <xi:include href="wrappers/motorControl/torso-mc_wrapper.xml" />
+
+    <xi:include href="wrappers/motorControl/left_arm-mc_remapper.xml" />
+    <xi:include href="wrappers/motorControl/right_arm-mc_remapper.xml" />
+    <xi:include href="wrappers/motorControl/left_leg-mc_remapper.xml" />
+    <xi:include href="wrappers/motorControl/right_leg-mc_remapper.xml" />
+    <xi:include href="wrappers/motorControl/head-mc_remapper.xml" />
+    <xi:include href="wrappers/motorControl/torso-mc_remapper.xml" />
+    <!--  ANALOG SENSORS FT -->
+    <xi:include href="wrappers/FT/left_foot-FT_remapper.xml" />
+    <xi:include href="wrappers/FT/right_foot-FT_remapper.xml" />
+    <xi:include href="wrappers/FT/left_foot-FT_wrapper.xml" />
+    <xi:include href="wrappers/FT/right_foot-FT_wrapper.xml" />
+    <xi:include href="wrappers/FT/left_arm-FT_wrapper.xml" />
+    <xi:include href="wrappers/FT/right_arm-FT_wrapper.xml" />
+    <xi:include href="wrappers/FT/right_leg_hip-FT_wrapper.xml" />
+    <xi:include href="wrappers/FT/left_leg_hip-FT_wrapper.xml" />
+
+    <!-- INERTIAL SENSOR-->
+    <xi:include href="wrappers/inertials/head-inertials_wrapper.xml" />
+
+    <!-- all joints remapper -->
+    <xi:include href="./wrappers/motorControl/alljoints-mc_remapper.xml"/>
+    <xi:include href="./wrappers/motorControl/alljoints-mc_nws_ros2.xml"/>
+    </devices>
+</robot>

--- a/simmechanics/data/icub3/conf/icub_ROS2.xml
+++ b/simmechanics/data/icub3/conf/icub_ROS2.xml
@@ -35,5 +35,13 @@
     <!-- all joints remapper -->
     <xi:include href="./wrappers/motorControl/alljoints-mc_remapper.xml"/>
     <xi:include href="./wrappers/motorControl/alljoints-mc_nws_ros2.xml"/>
+
+    <!-- ft sensors  ROS2 -->
+    <xi:include href="wrappers/FT/left_foot-FT_nws_ros2.xml" />
+    <xi:include href="wrappers/FT/right_foot-FT_nws_ros2.xml" />
+    <xi:include href="wrappers/FT/left_leg_hip-FT_nws_ros2.xml" />
+    <xi:include href="wrappers/FT/right_leg_hip-FT_nws_ros2.xml" />
+    <xi:include href="wrappers/FT/left_arm-FT_nws_ros2.xml" /> -->
+    <xi:include href="wrappers/FT/right_arm-FT_nws_ros2.xml" />
     </devices>
 </robot>

--- a/simmechanics/data/icub3/conf/wrappers/FT/left_arm-FT_nws_ros2.xml
+++ b/simmechanics/data/icub3/conf/wrappers/FT/left_arm-FT_nws_ros2.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-FT_wrapper_ros2" type="wrenchStamped_nws_ros2">
+        <param name="topic_name">      /left_arm_ft                      </param>
+        <param name="node_name">      icub_left_arm_ft          </param>
+        <param name="period">      0.1                          </param>
+
+        <action phase="startup" level="10" type="attach">
+            <paramlist name="networks">
+        <!-- The param value must match the device name in the corresponding body_part-ebX-jA_B-strain.xml file -->
+                <elem name="FirstStrain">  icub_left_arm_ft </elem>
+            </paramlist>
+        </action>
+
+        <action phase="shutdown" level="15" type="detach" />
+    </device>

--- a/simmechanics/data/icub3/conf/wrappers/FT/left_foot-FT_nws_ros2.xml
+++ b/simmechanics/data/icub3/conf/wrappers/FT/left_foot-FT_nws_ros2.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_foot-FT_wrapper_ros2" type="wrenchStamped_nws_ros2">
+        <param name="topic_name">      /left_foot_ft                      </param>
+        <param name="node_name">      icub_left_foot_ft          </param>
+        <param name="period">      0.1                          </param>
+
+        <action phase="startup" level="10" type="attach">
+            <paramlist name="networks">
+        <!-- The param value must match the device name in the corresponding body_part-ebX-jA_B-strain.xml file -->
+                <elem name="FirstStrain">  left_foot-FT_remapper </elem>
+            </paramlist>
+        </action>
+
+        <action phase="shutdown" level="15" type="detach" />
+    </device>

--- a/simmechanics/data/icub3/conf/wrappers/FT/left_foot-FT_remapper.xml
+++ b/simmechanics/data/icub3/conf/wrappers/FT/left_foot-FT_remapper.xml
@@ -3,8 +3,8 @@
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_foot-FT_remapper" type="multipleanalogsensorsremapper">
     <param name="SixAxisForceTorqueSensorsNames">
-          (l_foot_rear_ft_sensor
-           l_foot_front_ft_sensor)
+          (l_foot_rear_ft
+           l_foot_front_ft)
     </param>
     <action phase="startup" level="5" type="attach">
          <paramlist name="networks">

--- a/simmechanics/data/icub3/conf/wrappers/FT/left_leg_hip-FT_nws_ros2.xml
+++ b/simmechanics/data/icub3/conf/wrappers/FT/left_leg_hip-FT_nws_ros2.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg_hip-FT_wrapper_ros2" type="wrenchStamped_nws_ros2">
+        <param name="topic_name">      /left_leg_hip_ft                      </param>
+        <param name="node_name">      icub_left_leg_hip_ft          </param>
+        <param name="period">      0.1                          </param>
+
+        <action phase="startup" level="10" type="attach">
+            <paramlist name="networks">
+        <!-- The param value must match the device name in the corresponding body_part-ebX-jA_B-strain.xml file -->
+                <elem name="FirstStrain">  icub_left_leg_ft </elem>
+            </paramlist>
+        </action>
+
+        <action phase="shutdown" level="15" type="detach" />
+    </device>

--- a/simmechanics/data/icub3/conf/wrappers/FT/left_leg_hip-FT_wrapper.xml
+++ b/simmechanics/data/icub3/conf/wrappers/FT/left_leg_hip-FT_wrapper.xml
@@ -5,7 +5,7 @@
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg_hip-FT_wrapper" type="multipleanalogsensorsserver">
         <param name="period">      10                          </param>
         <param name="name">       ${portprefix}/left_leg_hip     </param>
-        
+
         <action phase="startup" level="10" type="attach">
             <paramlist name="networks">
                 <elem name="FirstStrain">  icub_left_leg_ft </elem>

--- a/simmechanics/data/icub3/conf/wrappers/FT/right_arm-FT_nws_ros2.xml
+++ b/simmechanics/data/icub3/conf/wrappers/FT/right_arm-FT_nws_ros2.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-FT_wrapper_ros2" type="wrenchStamped_nws_ros2">
+        <param name="topic_name">      /right_arm_ft                      </param>
+        <param name="node_name">      icub_right_arm_ft          </param>
+        <param name="period">      0.1                          </param>
+
+        <action phase="startup" level="10" type="attach">
+            <paramlist name="networks">
+        <!-- The param value must match the device name in the corresponding body_part-ebX-jA_B-strain.xml file -->
+                <elem name="FirstStrain">  icub_right_arm_ft </elem>
+            </paramlist>
+        </action>
+
+        <action phase="shutdown" level="15" type="detach" />
+    </device>

--- a/simmechanics/data/icub3/conf/wrappers/FT/right_arm-FT_wrapper.xml
+++ b/simmechanics/data/icub3/conf/wrappers/FT/right_arm-FT_wrapper.xml
@@ -5,7 +5,7 @@
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-FT_wrapper" type="multipleanalogsensorsserver">
         <param name="period">      10                           </param>
         <param name="name">       ${portprefix}/right_arm      </param>
-        
+
         <action phase="startup" level="10" type="attach">
             <paramlist name="networks">
                 <elem name="FirstStrain">  icub_right_arm_ft </elem>

--- a/simmechanics/data/icub3/conf/wrappers/FT/right_foot-FT_nws_ros2.xml
+++ b/simmechanics/data/icub3/conf/wrappers/FT/right_foot-FT_nws_ros2.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_foot-FT_wrapper_ros2" type="wrenchStamped_nws_ros2">
+        <param name="topic_name">      /right_foot_ft                      </param>
+        <param name="node_name">      icub_right_foot_ft          </param>
+        <param name="period">      0.1                          </param>
+
+        <action phase="startup" level="10" type="attach">
+            <paramlist name="networks">
+        <!-- The param value must match the device name in the corresponding body_part-ebX-jA_B-strain.xml file -->
+                <elem name="FirstStrain">  right_foot-FT_remapper </elem>
+            </paramlist>
+        </action>
+
+        <action phase="shutdown" level="15" type="detach" />
+    </device>

--- a/simmechanics/data/icub3/conf/wrappers/FT/right_foot-FT_remapper.xml
+++ b/simmechanics/data/icub3/conf/wrappers/FT/right_foot-FT_remapper.xml
@@ -3,8 +3,8 @@
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_foot-FT_remapper" type="multipleanalogsensorsremapper">
     <param name="SixAxisForceTorqueSensorsNames">
-          (r_foot_rear_ft_sensor
-           r_foot_front_ft_sensor)
+          (r_foot_rear_ft
+           r_foot_front_ft)
     </param>
     <action phase="startup" level="5" type="attach">
          <paramlist name="networks">

--- a/simmechanics/data/icub3/conf/wrappers/FT/right_foot-FT_wrapper.xml
+++ b/simmechanics/data/icub3/conf/wrappers/FT/right_foot-FT_wrapper.xml
@@ -5,7 +5,7 @@
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_foot-FT_wrapper" type="multipleanalogsensorsserver">
         <param name="period">      10                          </param>
         <param name="name">       ${portprefix}/right_foot_heel_tiptoe     </param>
-        
+
         <action phase="startup" level="10" type="attach">
             <paramlist name="networks">
                 <elem name="FirstStrain"> right_foot-FT_remapper </elem>

--- a/simmechanics/data/icub3/conf/wrappers/FT/right_leg_hip-FT_nws_ros2.xml
+++ b/simmechanics/data/icub3/conf/wrappers/FT/right_leg_hip-FT_nws_ros2.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg_hip-FT_wrapper_ros2" type="wrenchStamped_nws_ros2">
+        <param name="topic_name">      /right_leg_hip_ft                      </param>
+        <param name="node_name">      icub_right_leg_hip_ft          </param>
+        <param name="period">      0.1                          </param>
+
+        <action phase="startup" level="10" type="attach">
+            <paramlist name="networks">
+        <!-- The param value must match the device name in the corresponding body_part-ebX-jA_B-strain.xml file -->
+                <elem name="FirstStrain">  icub_right_leg_ft </elem>
+            </paramlist>
+        </action>
+
+        <action phase="shutdown" level="15" type="detach" />
+    </device>

--- a/simmechanics/data/icub3/conf/wrappers/FT/right_leg_hip-FT_wrapper.xml
+++ b/simmechanics/data/icub3/conf/wrappers/FT/right_leg_hip-FT_wrapper.xml
@@ -5,7 +5,7 @@
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg_hip-FT_wrapper" type="multipleanalogsensorsserver">
         <param name="period">      10                          </param>
         <param name="name">       ${portprefix}/right_leg_hip     </param>
-        
+
         <action phase="startup" level="10" type="attach">
             <paramlist name="networks">
                 <elem name="FirstStrain">  icub_right_leg_ft </elem>

--- a/simmechanics/data/icub3/conf/wrappers/motorControl/alljoints-mc_nws_ros2.xml
+++ b/simmechanics/data/icub3/conf/wrappers/motorControl/alljoints-mc_nws_ros2.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="cbw_ros2" type="controlBoard_nws_ros2">
+    <param name="node_name"> icub_cb_node </param>
+    <param name="topic_name"> /joint_states </param>
+    <action phase="startup" level="15" type="attach">
+        <param name="device"> alljoints-mc_remapper </param>
+    </action>
+    <action phase="shutdown" level="20" type="detach" />
+</device>

--- a/simmechanics/data/icub3/conf/wrappers/motorControl/alljoints-mc_remapper.xml
+++ b/simmechanics/data/icub3/conf/wrappers/motorControl/alljoints-mc_remapper.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="alljoints-mc_remapper" type="controlboardremapper">
+    <paramlist name="networks">
+        <elem name="head_joints">       (  0   2   0  2  )</elem>
+        <elem name="left_arm_joints">   (  3   9   0  6 )</elem>
+        <elem name="right_arm_joints">  ( 10  16   0  6 )</elem>
+        <elem name="torso_joints">      ( 17  19   0  2  )</elem>
+        <elem name="left_leg_joints">   ( 20  25   0  5  )</elem>
+        <elem name="right_leg_joints">  ( 26  31   0  5  )</elem>
+    </paramlist>
+    <param name="joints"> 32 </param>
+    <action phase="startup" level="10" type="attach">
+        <paramlist name="networks">
+            <elem name="head_joints">       head-mc_remapper </elem>
+            <elem name="left_arm_joints">   left_arm-mc_remapper </elem>
+            <elem name="right_arm_joints">  right_arm-mc_remapper </elem>
+            <elem name="torso_joints">      torso-mc_remapper </elem>
+            <elem name="left_leg_joints">   left_leg-mc_remapper </elem>
+            <elem name="right_leg_joints">  right_leg-mc_remapper </elem>
+        </paramlist>
+    </action>
+    <action phase="shutdown" level="20" type="detach" />
+</device>


### PR DESCRIPTION
This PR adds the xml files for running the controlboard ros2 nws for icub3.
 
I edited the urdf in order to use `icub_ROS2.xml` file and I run:

```
ros2 launch robot_state_publisher.py
```
Where `robot_state_publisher.py` is

```python
import os
from launch import LaunchDescription
from launch.actions import DeclareLaunchArgument
from launch.substitutions import LaunchConfiguration
from launch_ros.actions import Node

def generate_launch_description():

    use_sim_time = LaunchConfiguration('use_sim_time', default='false')

    #urdf = os.path.abspath("/home/ngenesio/icub-tech-iit/ergocub-gazebo-simulations/models/stickBot/model.urdf")
    urdf = os.path.abspath("/home/ngenesio/robotology/icub-models-generator/build/iCub/robots/iCubGazeboV3/model.urdf")
    with open(urdf, 'r') as infp:
        robot_desc = infp.read()

    return LaunchDescription([
        DeclareLaunchArgument(
            'use_sim_time',
            default_value='false',
            description='Use simulation (Gazebo) clock if true'),
        Node(
            package='robot_state_publisher',
            executable='robot_state_publisher',
            name='robot_state_publisher',
            output='screen',
            parameters=[{'use_sim_time': use_sim_time, 'robot_description': robot_desc}],
            arguments=[urdf])
    ])

```

Then we can decide how to run the `robot_state_publisher` in a more elegant way.


![immagine](https://user-images.githubusercontent.com/19152494/206218846-faf4375f-f1d2-4e24-a05d-234ca2e848a5.png)


cc @traversaro @maggia80 @randaz81 @elandini84 @pattacini 
