### PR TITLE
Uniform sensor name for IMU

### DIFF
--- a/simmechanics/data/icub2_5/ICUB_2-5_BB_simmechanics_options.yaml.in
+++ b/simmechanics/data/icub2_5/ICUB_2-5_BB_simmechanics_options.yaml.in
@@ -680,7 +680,8 @@ sensors:
     updateRate: "100"
   - frameName: SCSYS_HEAD_MTX_IMU
     linkName: head
-    sensorName: head_imu_acc_1x1
+    sensorName: head_imu_0
+    exportFrameInURDF: Yes
     sensorType: "accelerometer"
     sensorBlobs:
     - |

--- a/simmechanics/data/icub3/ICUB_3_all_options.yaml
+++ b/simmechanics/data/icub3/ICUB_3_all_options.yaml
@@ -332,7 +332,8 @@ sensors:
     updateRate: "100"
   - frameName: SCSYS_HEAD_IMU
     linkName: head
-    sensorName: head_imu_acc_1x1
+    sensorName: head_imu_0
+    exportFrameInURDF: Yes
     sensorType: "accelerometer"
     sensorBlobs:
     - |
@@ -422,7 +423,8 @@ sensors:
   # the imu measurements are referred to the depth frame.
   - frameName: SCSYS_CHEST_DEPTH
     linkName: chest
-    sensorName: chest_imu_acc_1x1
+    sensorName: chest_imu_0
+    exportFrameInURDF: Yes
     sensorType: "accelerometer"
     exportFrameInURDF: Yes
     sensorBlobs:

--- a/simmechanics/data/icub3/ICUB_3_all_options_gazebo.yaml.in
+++ b/simmechanics/data/icub3/ICUB_3_all_options_gazebo.yaml.in
@@ -331,7 +331,8 @@ sensors:
     updateRate: "100"
   - frameName: SCSYS_HEAD_IMU
     linkName: head
-    sensorName: head_imu_acc_1x1
+    sensorName: head_imu_0
+    exportFrameInURDF: Yes
     sensorType: "accelerometer"
     sensorBlobs:
     - |
@@ -420,7 +421,8 @@ sensors:
   # the imu measurements are referred to the depth frame.
   - frameName: SCSYS_CHEST_DEPTH
     linkName: chest
-    sensorName: chest_imu_acc_1x1
+    sensorName: chest_imu_0
+    exportFrameInURDF: Yes
     sensorType: "accelerometer"
     sensorBlobs:
     - |


### PR DESCRIPTION
It follows the convention <link>_imu_<nr> where  starts from 0. Now the names have been unifrmed with the real robot(https://github.com/robotology/robots-configuration/pull/422)

cc @pattacini 