### PR TITLE
Fix FT sensors name after some tests

### DIFF
--- a/simmechanics/data/icub2_5/conf/wrappers/FT/left_leg-FT_remapper.xml
+++ b/simmechanics/data/icub2_5/conf/wrappers/FT/left_leg-FT_remapper.xml
@@ -4,10 +4,7 @@
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg-FT_remapper" type="multipleanalogsensorsremapper">
         <param name="SixAxisForceTorqueSensorsNames">
-          (l_leg_ft_sensor l_foot_ft_sensor)
-        </param>
-        <param name="TemperatureSensorsNames">
-          (l_leg_ft_sensor l_foot_ft_sensor)
+          (l_leg_ft l_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/simmechanics/data/icub2_5/conf/wrappers/FT/right_leg-FT_remapper.xml
+++ b/simmechanics/data/icub2_5/conf/wrappers/FT/right_leg-FT_remapper.xml
@@ -4,10 +4,7 @@
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg-FT_remapper" type="multipleanalogsensorsremapper">
         <param name="SixAxisForceTorqueSensorsNames">
-          (r_leg_ft_sensor r_foot_ft_sensor)
-        </param>
-        <param name="TemperatureSensorsNames">
-          (r_leg_ft_sensor r_foot_ft_sensor)
+          (r_leg_ft r_foot_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/simmechanics/data/icub3/conf/wrappers/FT/left_leg-FT_remapper.xml
+++ b/simmechanics/data/icub3/conf/wrappers/FT/left_leg-FT_remapper.xml
@@ -4,10 +4,7 @@
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg-FT_remapper" type="multipleanalogsensorsremapper">
         <param name="SixAxisForceTorqueSensorsNames">
-          (l_leg_ft_sensor l_foot_rear_ft_sensor l_foot_front_ft_sensor)
-        </param>
-        <param name="TemperatureSensorsNames">
-          (l_leg_ft_sensor l_foot_rear_ft_sensor l_foot_front_ft_sensor)
+          (l_leg_ft l_foot_rear_ft l_foot_front_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">

--- a/simmechanics/data/icub3/conf/wrappers/FT/right_leg-FT_remapper.xml
+++ b/simmechanics/data/icub3/conf/wrappers/FT/right_leg-FT_remapper.xml
@@ -4,10 +4,7 @@
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg-FT_remapper" type="multipleanalogsensorsremapper">
         <param name="SixAxisForceTorqueSensorsNames">
-          (r_leg_ft_sensor r_foot_rear_ft_sensor r_foot_front_ft_sensor)
-        </param>
-        <param name="TemperatureSensorsNames">
-          (r_leg_ft_sensor r_foot_rear_ft_sensor r_foot_front_ft_sensor)
+          (r_leg_ft r_foot_rear_ft r_foot_front_ft)
         </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">


### PR DESCRIPTION
Today I tried to import both `iCubV2.5` and `iCubV3` models in gazebo for the first time after updating `icub-models` to `v2.1.0` release (hence after https://github.com/robotology/icub-models-generator/pull/239) and I obtained the same errors for both, resulting in gazebo crashing:

```
[ERROR] |yarp.device.multipleanalogsensorsremapper| Impossible to find sensor name l_leg_ft_sensor , exiting.
[ERROR] |yarp.device.multipleanalogsensorsremapper|     Names of available sensors are:
[ERROR] Device left_leg-FT_remapper cannot execute attach
[ERROR] Cannot run attach action on device left_leg-FT_remapper
[INFO] Executing attach action, level 5 on device right_leg-FT_remapper with parameters [("networks" = "(right_leg_ft_sensor right_foot_ft_sensor)"), ("right_leg_ft_sensor" = "icub_right_leg_ft"), ("right_foot_ft_sensor" = "icub_right_foot_ft")]
[ERROR] |yarp.device.multipleanalogsensorsremapper| Impossible to find sensor name r_leg_ft_sensor , exiting.
[ERROR] |yarp.device.multipleanalogsensorsremapper|     Names of available sensors are:
[ERROR] Device right_leg-FT_remapper cannot execute attach
[ERROR] Cannot run attach action on device right_leg-FT_remapper
```

Inspecting the changes introduced after the refactoring of FT sensors, I found out that [`sensorName` ](https://github.com/robotology/icub-models-generator/blob/3d663757cad9459579328b79f750c25e95df1597/simmechanics/data/icub3/ICUB_3_all_options.yaml#L2520) does not contain the suffix `_sensor` for both the left and right legs and the FT does not stream temperature data.
After the changes introduced with this PR, I managed to make the yarprobotinterface run. 

cc @Nicogene @traversaro @pattacini 