### PR TITLE
Update torso PID gains of icub2.5

### DIFF
--- a/simmechanics/data/icub2_5/conf/gazebo_icub_torso.ini
+++ b/simmechanics/data/icub2_5/conf/gazebo_icub_torso.ini
@@ -15,8 +15,8 @@ max_damping   100.0  100.0  100.0
 [POSITION_CONTROL]
 controlUnits  metric_units
 controlLaw    joint_pid_gazebo_v1
-kp            1.745 1.745 1.745
-kd            0.174 0.174 0.174
+kp            1.745 20.0 20.0
+kd            1.0   0.174 0.174
 ki            0.174 0.174 0.174
 maxInt        9999  9999  9999
 maxOutput     9999  9999  9999


### PR DESCRIPTION
Tuned-up PID gains for torso.

These gains are those that makes icub-gazebo-grasping-sandbox work properly.
See https://github.com/robotology/icub-gazebo-grasping-sandbox/issues/45#issuecomment-1607312102.