### PR TITLE
Add conda environment.yml to easily create an environment in which to run icub-models-generator

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,18 @@
+name: icubmodelgeneratorenv
+channels:
+  - conda-forge
+dependencies:
+  - yarp
+  - idyntree
+  - python
+  - pip
+  - compilers
+  - cmake
+  - ninja
+  - pkg-config
+  - pyyaml=5
+  - numpy
+  - catkin_pkg
+  - pip:
+    - git+https://github.com/ros/urdf_parser_py@31474b9baaf7c3845b40e5a9aa87d5900a2282c3
+    - git+https://github.com/robotology/simmechanics-to-urdf


### PR DESCRIPTION
icub-models-generator has some peculiar strict dependencies (a precise commit of urdf_parser_py, pyyaml <= 5). I created this environment to quickly install the required dependencies as I was working on https://github.com/robotology/icub-models-generator/pull/243 . 

I did not documented it for now, but even in this current form it could be useful for people working on this. In the future this can be used also in the CI to speed up the execution of the CI tests.