### PR TITLE
Update xsens root_link imu configuration file in order to publish correctly with iCubGazeboV2_7

### DIFF
--- a/simmechanics/data/icub2_5/conf/gazebo_icub_xsens_inertial.ini
+++ b/simmechanics/data/icub2_5/conf/gazebo_icub_xsens_inertial.ini
@@ -1,7 +1,3 @@
-[include "gazebo_icub_robotname.ini"]
-
-name /${gazeboYarpPluginsRobotName}/xsens_inertial
+disableImplicitNetworkWrapper
+yarpDeviceName waist_inertial_hardware_device
 period 0.0025
-
-device inertial
-subdevice gazebo_imu

--- a/simmechanics/data/icub2_5/conf/gazebo_icub_xsens_inertial.ini
+++ b/simmechanics/data/icub2_5/conf/gazebo_icub_xsens_inertial.ini
@@ -1,3 +1,7 @@
-disableImplicitNetworkWrapper
-yarpDeviceName waist_inertial_hardware_device
-period 0.0025
+[include "gazebo_icub_robotname.ini"]
+
+name /${gazeboYarpPluginsRobotName}/xsens_inertial
+period 2
+
+device multipleanalogsensorsserver
+subdevice gazebo_imu

--- a/simmechanics/data/icub2_5/conf/icub.xml
+++ b/simmechanics/data/icub2_5/conf/icub.xml
@@ -30,6 +30,6 @@
     <!-- INERTIAL SENSOR-->
     <xi:include href="wrappers/inertials/head-inertials_wrapper.xml" />
 <!--  NOT USED RIGHT NOW
-    <xi:include href="wrappers/inertials/waist-inertials_wrapper.xml" /> -->
+    <xi:include href="wrappers/inertials/waist-inertials_wrapper.xml" /> -->    
     </devices>
 </robot>


### PR DESCRIPTION
This PR fixes https://github.com/robotology/icub-models-generator/issues/245

The updates introduced with https://github.com/robotology/icub-models-generator/pull/231 don't affect the xsens on the root link. This causes errors when iCubGazeboV2_7 model is loaded on gazebo:

```
[ERROR] |yarp.os.YarpPluginSettings| Cannot find "inertial" plugin (not built in, and no .ini file found for it)Check that YARP_DATA_DIRS leads to at least one directory with plugins/inertial.ini or share/yarp/plugins/inertial.ini in it
[ERROR] |yarp.dev.PolyDriver|inertial| Could not find device <inertial>
[ERROR] GazeboYarpIMU Plugin Load failed: error in opening yarp driver
```