### PR TITLE
Fix location of collisions element in iCubGazeboV3 model

### DIFF
--- a/simmechanics/CMakeLists.txt
+++ b/simmechanics/CMakeLists.txt
@@ -143,22 +143,22 @@ macro(generate_icub_simmechanics)
     geometricShape:
       shape: box
       size: 0.117 0.100 0.006
-      origin: \"0.0 0.0 0.003 0.0 0.0 0.0\"
+      origin: \"0.0 0.0 -0.0193 0.0 0.0 0.0\"
   - linkName: r_foot_rear
     geometricShape:
       shape: box
       size: 0.117 0.100 0.006
-      origin: \"0.0 0.0 0.003 0.0 0.0 0.0\"
+      origin: \"0.0 0.0 -0.0193 0.0 0.0 0.0\"
   - linkName: l_foot_front
     geometricShape:
       shape: box
       size: 0.117 0.100 0.006
-      origin: \"0.0 0.0 0.003 0.0 0.0 0.0\"
+      origin: \"0.0 0.0 -0.0193 0.0 0.0 0.0\"
   - linkName: l_foot_rear
     geometricShape:
       shape: box
       size: 0.117 0.100 0.006
-      origin: \"0.0 0.0 0.003 0.0 0.0 0.0\"
+      origin: \"0.0 0.0 -0.0193 0.0 0.0 0.0\"
 ")
     endif()
 


### PR DESCRIPTION
Fix https://github.com/robotology/icub-models/issues/209 .

In https://github.com/robotology/icub-models-generator/pull/243 the location of the frames of the links of the soles ( with names like `(r|l)_foot_(front|back)` ) have been moved to the origin of the FT sensors that connect them with the `(r|l)_ankle_2` link. All the quantities expressed in this frame have been automatically modified to account for its new location by the simmechanics-to-urdf script, except for the location of the assigned collision, that are hardcoded in the .yaml file . This created a regression, has it effectly moved the sole assigned collisions up, so the robot was actually touching the ground with the (r|l)_ankle_2 links, that do not have any contact parameter assigned.

This commit fixes the situation by taking the existing z value of the assigned collision origin, and adding the offset with which the other elements (visual, inertial) have been modified  (see https://github.com/robotology/icub-models/commit/799ae070b9289e0db5b690b78dc14be34d6d9223#diff-9d811d6ae4a80f936a2466cdc3b852ac4fb6d6e3a4cd40d2c42e794f42d6415aL260), to obtain:

newCollisionZ = oldCollisionZ + (newVisualZ - oldVisualZ)
              = 0.003         + (0.9241470000000105     - 0.9464470000000105    )
              = -0.0193