### PR TITLE
Remove generated models table from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,23 +33,3 @@ Both generation pipelines are still in `a work in progress` state, and several i
 * [Meshes are not properly handled #28](https://github.com/robotology/icub-model-generator/issues/28)
 * [Hands and eyes are not generated #29](https://github.com/robotology/icub-model-generator/issues/29)
 
-## Generated models
-
-|  `YARP_ROBOT_NAME`   | Pipeline     | Notes                           |
-|:--------------------:|:------------:|:-------------------------------:|
-| `iCubDarmstadt01`    | simmechanics | v2.5 without backpack           |
-| `iCubErzelli02`      | simmechanics | v2.5   with backpack            |
-| `iCubGazeboV2_5`     | simmechanics | v2.5 with backpack, joint damping, and inertias of some links modified to run smoothly in Gazebo Classic (ODE). |
-| `iCubGazeboV2_5_KIT_007`| simmechanics | v2.5 + [KIT_007](https://icub-tech-iit.github.io/documentation/upgrade_kits/ankle_for_stairs/support/) with backpack, joint damping, and inertias of some links modified to run smoothly in Gazebo Classic (ODE). |
-| `iCubGazeboV2_6`     | simmechanics | v2.6 with  joint damping, and inertias of some links modified to run smoothly in Gazebo Classic (ODE). |
-| `iCubGazeboV2_7`     | simmechanics | v2.7 with  joint damping, and inertias of some links modified to run smoothly in Gazebo Classic (ODE). |
-| `iCubGazeboV3`       | simmechanics | v3 with  joint damping, and inertias of some links modified to run smoothly in Gazebo Classic (ODE). |
-| `iCubGenova01`       | simmechanics | v2.5 without backpack           |
-| `iCubGenova02`       | simmechanics | v2.5 + [KIT_007](https://icub-tech-iit.github.io/documentation/upgrade_kits/ankle_for_stairs/support/) with backpack           |
-| `iCubGenova03`       | dh           | v2 with legs v1 and feet v2.5   |
-| `iCubGenova04`       | simmechanics | v2.5   with backpack            |
-| `iCubGenova09`       | simmechanics | v3                              |
-| `iCubLisboa01`       | dh           | v1 with head v2                 |
-| `iCubNancy01`        | dh           | v2.5 with arms v1 and head v2   |
-| `iCubParis01`        | dh           | v1 with feet v2.5               |
-| `iCubParis02`        | dh           | v2 with feet v2.5               |


### PR DESCRIPTION
We now have a table in https://github.com/robotology/icub-models, let's not duplicate info that is tricky to keep updated.