### PR TITLE
Add left/right_arm FT IMU in iCubGazeboV2_* models

### DIFF
--- a/simmechanics/data/icub2_5/ICUB_2-5_BB_simmechanics_options.yaml.in
+++ b/simmechanics/data/icub2_5/ICUB_2-5_BB_simmechanics_options.yaml.in
@@ -688,6 +688,26 @@ sensors:
         <plugin name="iCub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
             <yarpConfigurationFile>model://iCub/conf/gazebo_icub_inertial.ini</yarpConfigurationFile>
         </plugin>
+  - frameName: SCSYS_L_UPPER_ARM_FT45
+    linkName: l_shoulder_3
+    sensorName: l_arm_ft
+    exportFrameInURDF: Yes
+    sensorType: "accelerometer"
+    sensorBlobs:
+    - |
+        <plugin name="iCub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
+            <yarpConfigurationFile>model://iCub/conf/gazebo_icub_inertial.ini</yarpConfigurationFile>
+        </plugin>
+  - frameName: SCSYS_R_UPPER_ARM_FT45
+    linkName: r_shoulder_3
+    sensorName: r_arm_ft
+    exportFrameInURDF: Yes
+    sensorType: "accelerometer"
+    sensorBlobs:
+    - |
+        <plugin name="iCub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
+            <yarpConfigurationFile>model://iCub/conf/gazebo_icub_inertial.ini</yarpConfigurationFile>
+        </plugin>
   - frameName: SCSYS_ROOT_LINK_EMS_ACC_EB5
     linkName: root_link
     sensorName: root_link_ems_acc_eb5

--- a/simmechanics/data/icub2_5/ICUB_2-5_BB_simmechanics_options.yaml.in
+++ b/simmechanics/data/icub2_5/ICUB_2-5_BB_simmechanics_options.yaml.in
@@ -696,7 +696,7 @@ sensors:
     sensorBlobs:
     - |
         <plugin name="iCub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
-            <yarpConfigurationFile>model://iCub/conf/gazebo_icub_inertial.ini</yarpConfigurationFile>
+            <yarpConfigurationFile>model://iCub/conf/gazebo_icub_left_arm_inertial.ini</yarpConfigurationFile>
         </plugin>
   - frameName: SCSYS_R_UPPER_ARM_FT45
     linkName: r_shoulder_3
@@ -706,7 +706,7 @@ sensors:
     sensorBlobs:
     - |
         <plugin name="iCub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
-            <yarpConfigurationFile>model://iCub/conf/gazebo_icub_inertial.ini</yarpConfigurationFile>
+            <yarpConfigurationFile>model://iCub/conf/gazebo_icub_right_arm_inertial.ini</yarpConfigurationFile>
         </plugin>
   - frameName: SCSYS_ROOT_LINK_EMS_ACC_EB5
     linkName: root_link

--- a/simmechanics/data/icub2_5/conf/gazebo_icub_left_arm_inertial.ini
+++ b/simmechanics/data/icub2_5/conf/gazebo_icub_left_arm_inertial.ini
@@ -1,0 +1,2 @@
+disableImplicitNetworkWrapper
+yarpDeviceName left_arm_inertial_hardware_device

--- a/simmechanics/data/icub2_5/conf/gazebo_icub_right_arm_inertial.ini
+++ b/simmechanics/data/icub2_5/conf/gazebo_icub_right_arm_inertial.ini
@@ -1,0 +1,2 @@
+disableImplicitNetworkWrapper
+yarpDeviceName right_arm_inertial_hardware_device

--- a/simmechanics/data/icub2_5/conf/icub.xml
+++ b/simmechanics/data/icub2_5/conf/icub.xml
@@ -29,7 +29,9 @@
 
     <!-- INERTIAL SENSOR-->
     <xi:include href="wrappers/inertials/head-inertials_wrapper.xml" />
-<!--  NOT USED RIGHT NOW
+    <xi:include href="wrappers/inertials/left_arm-inertials_wrapper.xml" />
+    <xi:include href="wrappers/inertials/right_arm-inertials_wrapper.xml" />
+    <!--  NOT USED RIGHT NOW
     <xi:include href="wrappers/inertials/waist-inertials_wrapper.xml" /> -->    
     </devices>
 </robot>

--- a/simmechanics/data/icub2_5/conf/wrappers/inertials/left_arm-inertials_wrapper.xml
+++ b/simmechanics/data/icub2_5/conf/wrappers/inertials/left_arm-inertials_wrapper.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-inertials_wrapper" type="multipleanalogsensorsserver">
+        <param name="period">       10                  </param>
+        <param name="name">     ${portprefix}/left_arm/imu   </param>
+
+        <action phase="startup" level="10" type="attach">
+            <paramlist name="networks">
+                <elem name="SetOfIMUs">left_arm_inertial_hardware_device</elem>
+            </paramlist>
+        </action>
+        <action phase="shutdown" level="15" type="detach" />
+    </device>

--- a/simmechanics/data/icub2_5/conf/wrappers/inertials/right_arm-inertials_wrapper.xml
+++ b/simmechanics/data/icub2_5/conf/wrappers/inertials/right_arm-inertials_wrapper.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-inertials_wrapper" type="multipleanalogsensorsserver">
+        <param name="period">       10                  </param>
+        <param name="name">     ${portprefix}/right_arm/imu   </param>
+
+        <action phase="startup" level="10" type="attach">
+            <paramlist name="networks">
+                <elem name="SetOfIMUs">right_arm_inertial_hardware_device</elem>
+            </paramlist>
+        </action>
+        <action phase="shutdown" level="15" type="detach" />
+    </device>


### PR DESCRIPTION
It would be nice to have the orientation data coming from the IMU mounted on the FT sensors also in simulation. So far, I added this feature only for the FT on the arms, but if it’s worth it, I could add also the ones on the legs and feet. 

cc @Nicogene @traversaro 
fyi @GiulioRomualdi 