### PR TITLE
ICUB_2-5_BB_simmechanics_options.yaml: Use the child link of the FT sensor fixed joint for linkName of l_arm_ft_sensor and r_arm_ft_sensor

### DIFF
--- a/simmechanics/data/icub2_5/ICUB_2-5_BB_simmechanics_options.yaml.in
+++ b/simmechanics/data/icub2_5/ICUB_2-5_BB_simmechanics_options.yaml.in
@@ -646,7 +646,7 @@ forceTorqueSensors:
     exportFrameInURDF: Yes
     frame: sensor
     frameName: SCSYS_L_UPPER_ARM_FT45
-    linkName: l_shoulder_3
+    linkName: l_upper_arm
     sensorName: l_arm_ft
     sensorBlobs:
     - |
@@ -658,7 +658,7 @@ forceTorqueSensors:
     exportFrameInURDF: Yes
     frame: sensor
     frameName: SCSYS_R_UPPER_ARM_FT45
-    linkName: r_shoulder_3
+    linkName: r_upper_arm
     sensorName: r_arm_ft
     sensorBlobs:
     - |

--- a/simmechanics/data/icub2_5/ICUB_2-5_BB_simmechanics_options.yaml.in
+++ b/simmechanics/data/icub2_5/ICUB_2-5_BB_simmechanics_options.yaml.in
@@ -689,7 +689,7 @@ sensors:
             <yarpConfigurationFile>model://iCub/conf/gazebo_icub_inertial.ini</yarpConfigurationFile>
         </plugin>
   - frameName: SCSYS_L_UPPER_ARM_FT45
-    linkName: l_shoulder_3
+    linkName: l_upper_arm
     sensorName: l_arm_ft
     exportFrameInURDF: Yes
     sensorType: "accelerometer"
@@ -699,7 +699,7 @@ sensors:
             <yarpConfigurationFile>model://iCub/conf/gazebo_icub_left_arm_inertial.ini</yarpConfigurationFile>
         </plugin>
   - frameName: SCSYS_R_UPPER_ARM_FT45
-    linkName: r_shoulder_3
+    linkName: r_upper_arm
     sensorName: r_arm_ft
     exportFrameInURDF: Yes
     sensorType: "accelerometer"


### PR DESCRIPTION
Attempt to fix https://github.com/robotology/icub-models-generator/issues/233, or at least debug it more easily. In URDF, when an FT sensor is modeled by a fixed joint, the origin frame of the FT sensor  must be coincident with the frame of the **child link** of the fixed joint. 

For the arm FT sensor, the joint is defined as in the following (see https://icub-tech-iit.github.io/documentation/icub_kinematics/icub-model-naming-conventions/icub-model-naming-conventions/#links):

* joint: `l_arm_ft_sensor` parentLink: `l_shoulder_3` childLink: `l_upper_arm`
* joint: `r_arm_ft_sensor` parentLink: `r_shoulder_3` childLink: `r_upper_arm`

before this PR, for iCub 2.* models the used to refer to `l_shoulder_3` and `r_shoulder_3` for the definitions related to `l_arm_ft_sensor` and `r_arm_ft_sensor` . I am not sure if this is the source of the error in https://github.com/robotology/icub-models-generator/issues/233 (in that case, probably if there is a bug in https://github.com/robotology/simmechanics-to-urdf), but for sure using the childLink make the model easier to debug as you can directly check that the translation between `l_upper_arm` and `l_arm_ft_sensor` is indeed `0 0 0`.