### PR TITLE
Add pixi support to permit local users to generated models

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# GitHub syntax highlighting
+pixi.lock linguist-language=YAML
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 build/
+.build/
+# pixi environments
+.pixi
+
+deploy_commit_message

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Authors: Silvio Traversaro
 # CopyPolicy: Released under the terms of the GNU LGPL v2+.
 
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.16)
 
 project(icub-model-generator)
 

--- a/README.md
+++ b/README.md
@@ -6,18 +6,28 @@ are available at https://github.com/robotology/icub-models .
 
 **Note: this repository is meant to streamline the process of producing iCub URDF/SDF models by iCub mantainers. It is not meant to be used directly by users of iCub. For offical info on the kinematic parameters of the iCub, please see [the documentation in iCub's documentation](https://icub-tech-iit.github.io/documentation/icub_kinematics/icub-forward-kinematics/icub-forward-kinematics/).**
 
-## Dependencies
-- [iDynTree](https://github.com/robotology/idyntree)
-- [YARP](https://github.com/robotology/yarp)
-- [simmechanics-to-urdf](https://github.com/robotology/simmechanics-to-urdf)
-
-Detailed documentation on how to install the softare is current work in progress. In the meanwhile, you can check the exact way in which the software is installing by inspecting the [`CI` GitHub Actions workflow](.github/workflows/ci.yml) that is used to automatically generate the models of iCub using this repo and commit it to the [icub-models](https://github.com/robotology/icub-models) repo.
-
 
 ## Usage
-To generate the models, please ensure that you have all the necessary dependencies.
-To update the content of a local `icub-models` repository, set in the `ICUB_MODELS_SOURCE_DIR`
-CMake variable the absolute path to your `icub-models` repository, and execute the `copy-models-to-icub-models` target.
+
+To generate the models, first of all that you have [pixi installed](https://pixi.sh/#installation).
+
+Then, clone the repo and generate and the models via the `test_generated_models` pixi task:
+
+~~~
+cd ~
+git clone https://github.com/robotology/icub-models-generator
+cd icub-models-generator
+pixi run test_generated_models
+~~~
+
+If you want to generate the models in a local clone of icub-models, set the `ICUB_MODELS_SOURCE_DIR` environment variable to the location of the `icub-models` local folder, and run the `copy_models_to_icub_models` pixi task:
+~~~
+cd ~
+git clone https://github.com/robotology/icub-models
+export ICUB_MODELS_SOURCE_DIR=`pwd`/icub-models
+cd icub-models-generator
+pixi run copy_models_to_icub_models
+~~~
 
 ## Pipelines
 Currently, it is possible to generate iCub models by means of two different pipelines.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ To generate the models, first of all that you have [pixi installed](https://pixi
 
 Then, clone the repo and generate and the models via the `test_generated_models` pixi task:
 
-~~~
+~~~bash
 cd ~
 git clone https://github.com/robotology/icub-models-generator
 cd icub-models-generator
@@ -21,10 +21,17 @@ pixi run test_generated_models
 ~~~
 
 If you want to generate the models in a local clone of icub-models, set the `ICUB_MODELS_SOURCE_DIR` environment variable to the location of the `icub-models` local folder, and run the `copy_models_to_icub_models` pixi task:
-~~~
+~~~bash
 cd ~
 git clone https://github.com/robotology/icub-models
 export ICUB_MODELS_SOURCE_DIR=`pwd`/icub-models
+cd icub-models-generator
+pixi run copy_models_to_icub_models
+~~~
+
+For example, if you already have a icub-models copy as part of a robotology-superbuild installation located in `/usr/local/src/robotology-superbuild`, to generate the models there you can do the following:
+~~~bash
+export ICUB_MODELS_SOURCE_DIR=/usr/local/src/robotology-superbuild/src/icub-models
 cd icub-models-generator
 pixi run copy_models_to_icub_models
 ~~~

--- a/pixi.lock
+++ b/pixi.lock
@@ -1,0 +1,16415 @@
+version: 4
+environments:
+  default:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge/
+    packages:
+      linux-64:
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ace-7.1.3-h59595ed_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.10-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ampl-mp-3.1.0-h2cc385e_1006.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aom-3.8.1-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/assimp-5.3.1-hfb0e8fe_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/attr-2.5.1-h166bdaf_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils-2.40-hdd6e379_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.40-hf600244_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.40-hbdbef99_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hd590300_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.26.0-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/c-compiler-1.7.0-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.2.2-hbcca054_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.0-h3faef2a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cxx-compiler-1.7.0-h00ab1b0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/dav1d-1.2.1-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.13.6-h5008d03_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/docutils-0.20.1-py311h38be061_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/eigen-3.4.0-h00ab1b0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/expat-2.5.0-hcb278e6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ffmpeg-6.1.1-gpl_h8007c5b_104.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.14.2-h14ed4e7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/freeglut-3.2.2-hac7e632_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.12.1-h267a509_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fribidi-1.0.10-h36c2ea0_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc-12.3.0-h8d2909c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-12.3.0-he2b93b0_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-12.3.0-h76fc315_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gdbm-1.18-h0a1914f_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gettext-0.21.1-h27087fc_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/glfw-3.3.9-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/glib-2.78.3-hfc55251_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.78.3-hfc55251_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.3.0-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gnutls-3.7.9-hb077bed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.13-h58526e2_1001.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gst-plugins-base-1.22.9-h8e1006c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gstreamer-1.22.9-h98fc4e7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx-12.3.0-h8d2909c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-12.3.0-he2b93b0_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-12.3.0-h8a814eb_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-8.3.0-h3d44ed6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.3-nompi_h4f84152_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-73.2-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/idyntree-10.3.0-py311ha885c8a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ipopt-3.14.14-h04b96a2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/irrlicht-1.8.5-h2a6caf8_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/jasper-4.2.0-he6dfbbe_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.1-h166bdaf_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.2-h659d440_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lame-3.100-h166bdaf_1003.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.40-h41732ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h27087fc_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20230802.1-cxx17_h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libaec-1.1.2-h59595ed_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libass-0.17.1-h8fe9dca_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-21_linux64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-1.82.0-h6fcfa73_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcap-2.69-h0f662aa_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-21_linux64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-15.0.7-default_hb11cfb5_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang13-15.0.7-default_ha2b6cf4_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-h4637d8d_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.5.0-hca28451_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.19-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.114-h166bdaf_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.12-hf998b51_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.5.0-hcb278e6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libflac-1.4.3-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-13.2.0-h807b86a_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcrypt-1.10.3-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-13.2.0-h69a702a_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-13.2.0-ha4646dd_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.78.3-h783c2da_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglu-9.0.0-hac7e632_1003.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-13.2.0-h807b86a_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgpg-error-1.47-h71f35ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.9.3-default_h554bfaf_1009.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libi2c-4.3-hcb278e6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.17-hd590300_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libidn2-2.3.7-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.0.0-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-21_linux64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapacke-3.9.0-21_linux64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm15-15.0.7-hb3ce162_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.58.0-h47da74e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libogg-1.3.4-h7f98852_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.26-pthreads_h413a1c8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopencv-4.9.0-py311haea74c2_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-2023.3.0-h2e90f83_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-batch-plugin-2023.3.0-hd5fc58b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-plugin-2023.3.0-hd5fc58b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-hetero-plugin-2023.3.0-h3ecfda7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-cpu-plugin-2023.3.0-h2e90f83_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-gpu-plugin-2023.3.0-h2e90f83_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-ir-frontend-2023.3.0-h3ecfda7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-onnx-frontend-2023.3.0-hfbc7f12_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-paddle-frontend-2023.3.0-hfbc7f12_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-pytorch-frontend-2023.3.0-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-frontend-2023.3.0-h0bff32c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-lite-frontend-2023.3.0-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopus-1.3.1-h7f98852_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libosqp-0.6.3-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.17-h166bdaf_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.42-h2797004_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-16.2-h33b98f1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-4.25.1-hf27288f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libqdldl-0.1.5-h27087fc_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-12.3.0-h0f45ef3_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libscotch-7.0.4-h91e35bf_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsndfile-1.2.2-hc60ed4a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libspral-2023.09.07-h6aa6db2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.45.1-h2797004_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.0-h0841786_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-13.2.0-h7e041cc_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-255-h3516f8a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libtasn1-4.19.0-h166bdaf_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.6.0-ha9c0a0a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libunistring-0.9.10-h7f98852_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libva-2.20.0-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libvorbis-1.3.7-h9c3ff4c_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libvpx-1.13.1-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.3.2-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.15-h0b41bf4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxkbcommon-1.6.0-hd429924_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.12.5-h232c23b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxslt-1.1.39-h76b75d6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libyarp-3.9.0-ha614a09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.2.13-hd590300_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lxml-4.9.4-py311h9691dec_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.9.4-hcb278e6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/metis-5.1.0-h59595ed_1007.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/mpg123-1.32.4-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/mumps-include-5.6.2-ha770c72_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/mumps-seq-5.6.2-hfef103a_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/mysql-common-8.0.33-hf1915f5_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/mysql-libs-8.0.33-hca2cd23_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.4-h59595ed_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/nettle-3.9.1-h7ab15ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ninja-1.11.1-h924138e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/nspr-4.35-h27087fc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/nss-3.97-h1d7d5a4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.26.4-py311h64a7726_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ocl-icd-2.3.2-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ocl-icd-system-1.0.0-1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openh264-2.4.1-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.2.1-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/osqp-eigen-0.8.1-hdd734ac_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/p11-kit-0.24.1-hc5aa10d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.42-hcad00b1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.43.2-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/portaudio-19.6.0-h7c63dc7_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-h36c2ea0_1001.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pugixml-1.14-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pulseaudio-client-16.1-hb77b528_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.11.7-hab00c5b_1_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.11-4_cp311.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-5.4.1-py311hd4cff14_4.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/qt-main-5.15.8-h5810be5_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/robot-testing-framework-2.0.1-hcb278e6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ruby-3.2.2-h983345b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/scotch-7.0.4-h23d43cc_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/sdl-1.2.68-h293081c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/sdl2-2.28.5-h77f46ba_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.1.10-h9fff704_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/soxr-0.1.3-h0b41bf4_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/svt-av1-1.8.0-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2021.11.0-h00ab1b0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tinyxml-2.6.2-h4bd325d_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/unixodbc-2.3.12-h661eb56_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/x264-1!164.3095-h166bdaf_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/x265-3.5-h924138e_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-0.4.0-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-image-0.4.0-h8ee46fc_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-keysyms-0.4.0-h8ee46fc_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-renderutil-0.3.9-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-wm-0.4.1-h8ee46fc_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.41-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-fixesproto-5.0-h7f98852_1002.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-inputproto-2.3.2-h7f98852_1002.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-kbproto-1.0.7-h7f98852_1002.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.1-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.4-h7391055_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.7-h8ee46fc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.11-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxcursor-1.2.0-h0b41bf4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.3-h7f98852_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.4-h0b41bf4_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxfixes-5.0.3-h7f98852_1004.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxi-1.7.10-h7f98852_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxinerama-1.1.5-h27087fc_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrandr-1.5.2-h7f98852_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.11-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-randrproto-1.5.0-h7f98852_1001.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-renderproto-0.11.1-h7f98852_1002.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xextproto-7.3.0-h0b41bf4_1003.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xf86vidmodeproto-2.3.1-h7f98852_1002.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xproto-7.0.31-h7f98852_1007.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h7f98852_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/yarp-3.9.0-ha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/yarp-python-3.9.0-py311h0e2f32c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ycm-cmake-modules-0.16.2-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.2.13-hd590300_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.5-hfc55251_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/catkin_pkg-1.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-2.6.32-he073ed8_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-12.3.0-h8bca6fd_105.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-12.3.0-h8bca6fd_105.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.8.2-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-69.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.12-he073ed8_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.42.0-pyhd8ed1ab_0.conda
+      linux-aarch64:
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-2_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ace-7.1.3-h787c7f5_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/alsa-lib-1.2.10-h31becfc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ampl-mp-3.1.0-h05efe27_1006.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aom-3.8.1-h0425590_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/assimp-5.3.1-h28f1edd_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/attr-2.5.1-h4e544f5_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils-2.40-h64c2a2e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_impl_linux-aarch64-2.40-h870a726_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_linux-aarch64-2.40-h94bbfa1_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bzip2-1.0.8-h31becfc_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/c-ares-1.26.0-h31becfc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/c-compiler-1.7.0-h31becfc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ca-certificates-2024.2.2-hcefe29a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cairo-1.18.0-ha13f110_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cxx-compiler-1.7.0-h2a328a1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/dav1d-1.2.1-h31becfc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/dbus-1.13.6-h12b9eeb_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/docutils-0.20.1-py311hfecb2dc_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/eigen-3.4.0-h2a328a1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/expat-2.5.0-hd600fc2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ffmpeg-6.1.1-gpl_hd8c5532_104.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fontconfig-2.14.2-ha9a116f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freeglut-3.2.2-hf4b6fbe_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freetype-2.12.1-hf0a5ef3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fribidi-1.0.10-hb9de7d4_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc-12.3.0-hc1b51f9_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_impl_linux-aarch64-12.3.0-hcde2664_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_linux-aarch64-12.3.0-h464a8f7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gettext-0.21.1-ha18d298_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glfw-3.3.9-h31becfc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glib-2.78.3-hd84c7bf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glib-tools-2.78.3-hd84c7bf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gmp-6.3.0-h2f0025b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gnutls-3.7.9-hb309da9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/graphite2-1.3.13-h7fd3ca4_1001.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gst-plugins-base-1.22.9-h6d82d15_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gstreamer-1.22.9-hed71854_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx-12.3.0-hc1b51f9_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_impl_linux-aarch64-12.3.0-hcde2664_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_linux-aarch64-12.3.0-h21accf6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/harfbuzz-8.3.0-hebeb849_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/hdf5-1.14.3-nompi_ha486f32_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-73.2-h787c7f5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/idyntree-10.3.0-py311h5498c2b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ipopt-3.14.14-h64a9e3f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/irrlicht-1.8.5-h962fdfd_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/jasper-4.2.0-h381c573_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/keyutils-1.6.1-h4e544f5_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/krb5-1.21.2-hc419048_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lame-3.100-h4e544f5_1003.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.40-h2d8c526_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lerc-4.0.0-h4de3ea5_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libabseil-20230802.1-cxx17_h2f0025b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libaec-1.1.2-h2f0025b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libass-0.17.1-h36b5d3b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libblas-3.9.0-21_linuxaarch64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libboost-1.82.0-h133f18d_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcap-2.69-h883460d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcblas-3.9.0-21_linuxaarch64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang-15.0.7-default_h65c9d4d_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang13-15.0.7-default_hf5d3afd_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcups-2.3.3-h405e4a8_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurl-8.5.0-h4e8248e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libdeflate-1.19-h31becfc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libev-4.33-h31becfc_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libevent-2.1.12-h4ba1bb4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libexpat-2.5.0-hd600fc2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libffi-3.4.2-h3557bc0_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libflac-1.4.3-h2f0025b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-13.2.0-hf8544c7_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcrypt-1.10.3-h31becfc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-ng-13.2.0-he9431aa_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-13.2.0-h582850c_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglib-2.78.3-h311d5f7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglu-9.0.0-hf4b6fbe_1003.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-13.2.0-hf8544c7_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgpg-error-1.47-h5ce24db_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libhwloc-2.9.3-default_hda148da_1009.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libi2c-4.3-hd600fc2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libiconv-1.17-h31becfc_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libidn2-2.3.7-h31becfc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libjpeg-turbo-3.0.0-h31becfc_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblapack-3.9.0-21_linuxaarch64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblapacke-3.9.0-21_linuxaarch64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libllvm15-15.0.7-hb4f23b0_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnghttp2-1.58.0-hb0e430d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnsl-2.0.1-h31becfc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libogg-1.3.4-h3557bc0_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenblas-0.3.26-pthreads_h5a5ec62_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopencv-4.9.0-py311h5435783_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-2023.3.0-h3e0449b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-arm-cpu-plugin-2023.3.0-h3e0449b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-auto-batch-plugin-2023.3.0-hd429f41_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-auto-plugin-2023.3.0-hd429f41_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-hetero-plugin-2023.3.0-hc6dd956_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-ir-frontend-2023.3.0-hc6dd956_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-onnx-frontend-2023.3.0-hb0b24c1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-paddle-frontend-2023.3.0-hb0b24c1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-pytorch-frontend-2023.3.0-h2f0025b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-tensorflow-frontend-2023.3.0-h5dc61ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-tensorflow-lite-frontend-2023.3.0-h2f0025b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopus-1.3.1-hf897c2e_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libosqp-0.6.3-h2f0025b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpng-1.6.42-h194ca79_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpq-16.2-h58720eb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libprotobuf-4.25.1-h87e877f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libqdldl-0.1.5-h4de3ea5_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsanitizer-12.3.0-h8ebda82_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libscotch-7.0.4-h16908e7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsndfile-1.2.2-h79657aa_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libspral-2023.09.07-h98a5362_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsqlite-3.45.1-h194ca79_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libssh2-1.11.0-h492db2e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-ng-13.2.0-h9a76618_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsystemd0-255-h91e93f8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libtasn1-4.19.0-h4e544f5_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libtiff-4.6.0-h1708d11_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libunistring-0.9.10-hf897c2e_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libuuid-2.38.1-hb4cce97_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libvorbis-1.3.7-h01db608_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libvpx-1.13.1-h2f0025b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libwebp-base-1.3.2-h31becfc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxcb-1.15-h2a766a3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxcrypt-4.4.36-h31becfc_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxkbcommon-1.6.0-h217f472_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxml2-2.12.5-h3091e33_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxslt-1.1.39-h1cc9640_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libyarp-3.9.0-h6d2be9b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libzlib-1.2.13-h31becfc_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lxml-4.9.4-py311h30c7647_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lz4-c-1.9.4-hd600fc2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/metis-5.1.0-h2f0025b_1007.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mpg123-1.32.4-h2f0025b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mumps-include-5.6.2-h8af1aa0_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mumps-seq-5.6.2-hae18a20_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mysql-common-8.0.33-hb6794ad_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mysql-libs-8.0.33-hf629957_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ncurses-6.4-h0425590_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/nettle-3.9.1-h9d1147b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ninja-1.11.1-hdd96247_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/nspr-4.35-h4de3ea5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/nss-3.97-hc5a5cc2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/numpy-1.26.4-py311h69ead2a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openh264-2.4.1-h2f0025b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.2.1-h31becfc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/osqp-eigen-0.8.1-h63a7d18_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/p11-kit-0.24.1-h9f2702f_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pcre2-10.42-hd0f9c67_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pixman-0.43.2-h2f0025b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/portaudio-19.6.0-h5c6c0ed_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pthread-stubs-0.4-hb9de7d4_1001.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pugixml-1.14-h2f0025b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pulseaudio-client-16.1-h729494f_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python-3.11.7-h43d1f9e_1_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python_abi-3.11-4_cp311.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyyaml-5.4.1-py311hdfa8b44_4.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/qt-main-5.15.8-h5992497_18.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/readline-8.2-h8fc344f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/robot-testing-framework-2.0.1-hd600fc2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ruby-3.2.2-hcdc5f17_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/scotch-7.0.4-habe6132_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sdl-1.2.68-h32cd00b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sdl2-2.28.5-h4e7748e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/snappy-1.1.10-he8610fa_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/soxr-0.1.3-hb4cce97_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/svt-av1-1.8.0-h2f0025b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tbb-2021.11.0-h2a328a1_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tinyxml-2.6.2-hd62202e_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tk-8.6.13-h194ca79_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/unixodbc-2.3.12-h7b6a552_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/x264-1!164.3095-h4e544f5_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/x265-3.5-hdd96247_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-0.4.0-h31becfc_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-image-0.4.0-hcb25cf1_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-keysyms-0.4.0-hcb25cf1_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-renderutil-0.3.9-h31becfc_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-wm-0.4.1-hcb25cf1_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xkeyboard-config-2.41-h31becfc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-fixesproto-5.0-h3557bc0_1002.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-inputproto-2.3.2-h3557bc0_1002.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-kbproto-1.0.7-h3557bc0_1002.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libice-1.1.1-h7935292_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libsm-1.2.4-h5a01bc2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libx11-1.8.7-h055a233_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxau-1.0.11-h31becfc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxcursor-1.2.0-hb4cce97_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxdmcp-1.1.3-h3557bc0_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxext-1.3.4-h2a766a3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxfixes-5.0.3-h3557bc0_1004.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxi-1.7.10-h3557bc0_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxinerama-1.1.5-h4de3ea5_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxrandr-1.5.2-hf897c2e_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxrender-0.9.11-h7935292_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-randrproto-1.5.0-hf897c2e_1001.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-renderproto-0.11.1-h3557bc0_1002.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-xextproto-7.3.0-h2a766a3_1003.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-xf86vidmodeproto-2.3.1-hf897c2e_1002.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-xproto-7.0.31-h3557bc0_1007.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xz-5.2.6-h9cdd2b7_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/yaml-0.2.5-hf897c2e_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/yarp-3.9.0-h8af1aa0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/yarp-python-3.9.0-py311h6b46aae_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ycm-cmake-modules-0.16.2-h2f0025b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zlib-1.2.13-h31becfc_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zstd-1.5.5-h4c53e97_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/_sysroot_linux-aarch64_curr_repodata_hack-4-h57d6b7b_13.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/catkin_pkg-1.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-aarch64-4.18.0-h5b4a56d_13.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-aarch64-12.3.0-h8b5ab12_105.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-aarch64-12.3.0-h8b5ab12_105.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.8.2-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-69.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-aarch64-2.17-h5b4a56d_13.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.42.0-pyhd8ed1ab_0.conda
+      osx-64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/catkin_pkg-1.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/compiler-rt_osx-64-16.0.6-ha38d28d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.8.2-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-69.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.42.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ace-7.1.3-h73e2aa4_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ampl-mp-3.1.0-h2beb688_1006.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aom-3.8.1-h73e2aa4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/assimp-5.3.1-h460e769_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h10d778d_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.26.0-h10d778d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/c-compiler-1.7.0-h282daa2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2024.2.2-h8857fd0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cairo-1.18.0-h99e66fa_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cctools-973.0.1-h40f6528_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cctools_osx-64-973.0.1-ha1c5b94_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/clang-16-16.0.6-default_h7151d67_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/clang-16.0.6-hdae98eb_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/clang_impl_osx-64-16.0.6-h8787910_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/clang_osx-64-16.0.6-hb91bd55_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/clangxx-16.0.6-default_h7151d67_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/clangxx_impl_osx-64-16.0.6-h6d92fbe_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/clangxx_osx-64-16.0.6-hb91bd55_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/compiler-rt-16.0.6-ha38d28d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cxx-compiler-1.7.0-h7728843_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/dav1d-1.2.1-h0dc2134_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/docutils-0.20.1-py311h6eed73b_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/eigen-3.4.0-h1c7c39f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/expat-2.5.0-hf0c8a7f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ffmpeg-6.1.1-gpl_h73cf981_104.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/fontconfig-2.14.2-h5bb23bf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/freetype-2.12.1-h60636b9_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/fribidi-1.0.10-hbcb3906_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/gdbm-1.18-h8a0c380_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/gettext-0.21.1-h8a4c099_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/glfw-3.3.9-h10d778d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/glib-2.78.3-hf4d7fad_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/glib-tools-2.78.3-hf4d7fad_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/gmp-6.3.0-h93d8f39_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/gnutls-3.7.9-h1951705_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/graphite2-1.3.13-h2e338ed_1001.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/gst-plugins-base-1.22.9-h3fb38fc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/gstreamer-1.22.9-hf63bbb8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/harfbuzz-8.3.0-hf45c392_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/hdf5-1.14.3-nompi_h691f4bf_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/icu-73.2-hf5e326d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/idyntree-10.3.0-py311h616ed6d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ipopt-3.14.14-h09c0c07_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/irrlicht-1.8.5-h5bfa9a0_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/jasper-4.2.0-h6ff19ee_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/krb5-1.21.2-hb884880_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/lame-3.100-hb7f2c08_1003.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ld64-609-ha02d983_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ld64_osx-64-609-ha20a434_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/lerc-4.0.0-hb486fe8_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libabseil-20230802.1-cxx17_h048a20a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libaec-1.1.2-he965462_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libass-0.17.1-h80904bb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-21_osx64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libboost-1.82.0-h99d8d82_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.9.0-21_osx64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libclang-15.0.7-default_h6b1ee41_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libclang-cpp16-16.0.6-default_h7151d67_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libclang13-15.0.7-default_h89cd682_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.5.0-h726d00d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-16.0.6-hd57cbcb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libdeflate-1.19-ha4e1b8e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libedit-3.1.20191231-h0678c8f_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-h10d778d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.5.0-hf0c8a7f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.4.2-h0d85af4_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-5.0.0-13_2_0_h97931a8_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-13.2.0-h2873a65_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libglib-2.78.3-h198397b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libhwloc-2.9.3-default_h24e0189_1009.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.17-hd75f5a5_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libidn2-2.3.7-h10d778d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libjpeg-turbo-3.0.0-h0dc2134_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.9.0-21_osx64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/liblapacke-3.9.0-21_osx64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libllvm15-15.0.7-hbedff68_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libllvm16-16.0.6-hbedff68_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.58.0-h64cf6d3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libogg-1.3.4-h35c211d_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.26-openmp_hfef2a42_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopencv-4.9.0-py310ha3ab171_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-2023.3.0-h113ac47_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-auto-batch-plugin-2023.3.0-h9adb129_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-auto-plugin-2023.3.0-h9adb129_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-hetero-plugin-2023.3.0-hfe2fe54_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-intel-cpu-plugin-2023.3.0-h113ac47_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-ir-frontend-2023.3.0-hfe2fe54_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-onnx-frontend-2023.3.0-hd0b7f58_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-paddle-frontend-2023.3.0-hd0b7f58_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-pytorch-frontend-2023.3.0-hd427752_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-tensorflow-frontend-2023.3.0-h35b5a9d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-tensorflow-lite-frontend-2023.3.0-hd427752_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopus-1.3.1-hc929b4f_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libosqp-0.6.3-he965462_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.42-h92b6c6a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libpq-16.2-ha925e61_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libprotobuf-4.25.1-hc4f2305_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libqdldl-0.1.5-hf0c8a7f_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libscotch-7.0.4-hc2ac6e5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.45.1-h92b6c6a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libssh2-1.11.0-hd019ec5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libtasn1-4.19.0-hb7f2c08_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libtiff-4.6.0-h684deea_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libunistring-0.9.10-h0d85af4_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libvorbis-1.3.7-h046ec9c_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libvpx-1.13.1-he965462_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libwebp-base-1.3.2-h0dc2134_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libxcb-1.15-hb7f2c08_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.12.5-hc0ae0f7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libxslt-1.1.39-h03b04e6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libyarp-3.9.0-h9c0c770_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.2.13-h8a1eda9_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-17.0.6-hb6ac08f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-tools-16.0.6-hbedff68_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/lxml-4.9.4-py311h033124e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/metis-5.1.0-he965462_1007.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/mumps-include-5.6.2-h694c41f_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/mumps-seq-5.6.2-he3629b0_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/mysql-common-8.0.33-h1d20c9b_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/mysql-libs-8.0.33-hed35180_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.4-h93d8f39_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/nettle-3.9.1-h8e11ae5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ninja-1.11.1-hb8565cd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/nspr-4.35-hea0b92c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/nss-3.97-ha05da47_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-1.26.4-py311hc43a94b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/openh264-2.4.1-h73e2aa4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.2.1-hd75f5a5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/osqp-eigen-0.8.1-hede6739_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/p11-kit-0.24.1-h65f8906_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pcre2-10.42-h0ad2156_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pixman-0.43.2-h73e2aa4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/portaudio-19.6.0-he965462_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pthread-stubs-0.4-hc929b4f_1001.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pugixml-1.14-he965462_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.11.7-h9f0c242_1_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.11-4_cp311.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyyaml-5.4.1-py311h5547dcb_4.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/qt-main-5.15.8-h4385fff_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.2-h9e318b2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/robot-testing-framework-2.0.1-hf0c8a7f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ruby-3.2.2-h4b2e751_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/scotch-7.0.4-h52a132a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/sdl-1.2.68-hce1cd6f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/sdl2-2.28.5-h73e2aa4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/sigtool-0.1.3-h88f4db0_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/snappy-1.1.10-h225ccf5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/soxr-0.1.3-hbf74d83_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/svt-av1-1.8.0-h93d8f39_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tapi-1100.0.11-h9ce4665_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tbb-2021.11.0-h7728843_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tinyxml-2.6.2-h65a07b1_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h1abcd95_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/unixodbc-2.3.12-he8a5cf4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/x264-1!164.3095-h775f41a_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/x265-3.5-hbb4e6a2_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-kbproto-1.0.7-h35c211d_1002.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libx11-1.8.7-hbd0b022_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxau-1.0.11-h0dc2134_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxdmcp-1.1.3-h35c211d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxext-1.3.4-hb7f2c08_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-xextproto-7.3.0-hb7f2c08_1003.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-xproto-7.0.31-h35c211d_1007.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xz-5.2.6-h775f41a_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-h0d85af4_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/yarp-3.9.0-h694c41f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/yarp-python-3.9.0-py311h22f05a9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ycm-cmake-modules-0.16.2-h73e2aa4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/zlib-1.2.13-h8a1eda9_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.5-h829000d_0.conda
+      osx-arm64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/catkin_pkg-1.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/compiler-rt_osx-arm64-16.0.6-h3808999_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.8.2-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-69.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.42.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ampl-mp-3.1.0-hbec66e7_1006.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aom-3.8.1-h078ce10_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/assimp-5.3.1-he63ff86_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h93a5062_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.26.0-h93a5062_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-compiler-1.7.0-h6aa9301_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2024.2.2-hf0a4a13_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cairo-1.18.0-hd1e100b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cctools-973.0.1-h4faf515_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cctools_osx-arm64-973.0.1-h62378fb_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang-16-16.0.6-default_he012953_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang-16.0.6-h30cc82d_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang_impl_osx-arm64-16.0.6-hc421ffc_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang_osx-arm64-16.0.6-h54d7cd3_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clangxx-16.0.6-default_h4cf2255_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clangxx_impl_osx-arm64-16.0.6-hcd7bac0_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clangxx_osx-arm64-16.0.6-h54d7cd3_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/compiler-rt-16.0.6-h3808999_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cxx-compiler-1.7.0-h2ffa867_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/dav1d-1.2.1-hb547adb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/docutils-0.20.1-py311h267d04e_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/eigen-3.4.0-h1995070_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/expat-2.5.0-hb7217d7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ffmpeg-6.1.1-gpl_h31ea89b_104.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fontconfig-2.14.2-h82840c6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/freetype-2.12.1-hadb7bae_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fribidi-1.0.10-h27ca646_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gettext-0.21.1-h0186832_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/glfw-3.3.9-h93a5062_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/glib-2.78.3-h9e231a4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/glib-tools-2.78.3-h9e231a4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gmp-6.3.0-h965bd2d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gnutls-3.7.9-hd26332c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/graphite2-1.3.13-h9f76cd9_1001.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gst-plugins-base-1.22.9-h09b4b5e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gstreamer-1.22.9-h551c6ff_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/harfbuzz-8.3.0-h8f0ba13_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-1.14.3-nompi_h5bb55e9_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-73.2-hc8870d7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/idyntree-10.3.0-py311ha38bcb2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ipopt-3.14.14-h6639f4a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/irrlicht-1.8.5-h1344824_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/jasper-4.2.0-h7c0e182_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.21.2-h92f50d5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lame-3.100-h1a8c8d9_1003.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ld64-609-h634c8be_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ld64_osx-arm64-609-ha4bd21c_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lerc-4.0.0-h9a09cb3_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20230802.1-cxx17_h13dd4ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libaec-1.1.2-h13dd4ca_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libass-0.17.1-hf7da4fe_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-21_osxarm64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libboost-1.82.0-h489e689_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-21_osxarm64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libclang-15.0.7-default_hd209bcb_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libclang-cpp16-16.0.6-default_he012953_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libclang13-15.0.7-default_ha49e599_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.5.0-h2d989ff_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-16.0.6-h4653b0c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.19-hb547adb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20191231-hc8eb9b7_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h93a5062_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.5.0-hb7217d7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-5.0.0-13_2_0_hd922786_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-13.2.0-hf226fd6_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libglib-2.78.3-hb438215_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libhwloc-2.9.3-default_h4394839_1009.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.17-h0d3ecfb_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libidn2-2.3.7-h93a5062_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libjpeg-turbo-3.0.0-hb547adb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-21_osxarm64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapacke-3.9.0-21_osxarm64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm15-15.0.7-h2621b3d_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm16-16.0.6-haab561b_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.58.0-ha4dd798_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libogg-1.3.4-h27ca646_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.26-openmp_h6c19121_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopencv-4.9.0-py311hdccf81a_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-2023.3.0-he6dadac_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-arm-cpu-plugin-2023.3.0-he6dadac_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-auto-batch-plugin-2023.3.0-hc9f00d9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-auto-plugin-2023.3.0-hc9f00d9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-hetero-plugin-2023.3.0-hf483cef_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-ir-frontend-2023.3.0-hf483cef_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-onnx-frontend-2023.3.0-h98f6304_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-paddle-frontend-2023.3.0-h98f6304_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-pytorch-frontend-2023.3.0-hebf3989_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-tensorflow-frontend-2023.3.0-hb5ee477_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-tensorflow-lite-frontend-2023.3.0-hebf3989_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopus-1.3.1-h27ca646_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libosqp-0.6.3-h13dd4ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.42-h091b4b1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpq-16.2-h0f8b458_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-4.25.1-h810fc01_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libqdldl-0.1.5-hb7217d7_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libscotch-7.0.4-hc938e73_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.45.1-h091b4b1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libssh2-1.11.0-h7a5bd25_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libtasn1-4.19.0-h1a8c8d9_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.6.0-ha8a6c65_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libunistring-0.9.10-h3422bc3_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libvorbis-1.3.7-h9f76cd9_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libvpx-1.13.1-hb765f3a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libwebp-base-1.3.2-hb547adb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxcb-1.15-hf346824_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.12.5-h0d0cfa8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxslt-1.1.39-h223e5b9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libyarp-3.9.0-hff4382b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.2.13-h53f4e23_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-17.0.6-hcd81f8e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-tools-16.0.6-haab561b_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lxml-4.9.4-py311h85df328_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/metis-5.1.0-h13dd4ca_1007.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mumps-include-5.6.2-hce30654_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mumps-seq-5.6.2-hbbab245_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mysql-common-8.0.33-hf9e6398_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mysql-libs-8.0.33-he3dca8b_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.4-h463b476_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/nettle-3.9.1-h40ed0f5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ninja-1.11.1-hffc8910_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/nspr-4.35-hb7217d7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/nss-3.97-h5ce2875_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-1.26.4-py311h7125741_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openh264-2.4.1-hebf3989_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.2.1-h0d3ecfb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/osqp-eigen-0.8.1-hfae311c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/p11-kit-0.24.1-h29577a5_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pcre2-10.42-h26f9a81_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pixman-0.43.2-hebf3989_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/portaudio-19.6.0-h13dd4ca_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-h27ca646_1001.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pugixml-1.14-h13dd4ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.11.7-hdf0ec26_1_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.11-4_cp311.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-5.4.1-py311he2be06e_4.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/qt-main-5.15.8-h6bf1bb6_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h92ec313_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/robot-testing-framework-2.0.1-hb7217d7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruby-3.2.2-ha6ee62f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scotch-7.0.4-heaa5b5c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sdl-1.2.68-hfc12253_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sdl2-2.28.5-hebf3989_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sigtool-0.1.3-h44b9a77_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/snappy-1.1.10-h17c5cce_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/soxr-0.1.3-h5008568_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/svt-av1-1.8.0-h463b476_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tapi-1100.0.11-he4954df_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tbb-2021.11.0-h2ffa867_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tinyxml-2.6.2-h260d524_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h5083fa2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/unixodbc-2.3.12-h0e2417a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/x264-1!164.3095-h57fd34a_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/x265-3.5-hbc6ce65_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-kbproto-1.0.7-h27ca646_1002.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libx11-1.8.7-hfd9643e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.11-hb547adb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.3-h27ca646_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxext-1.3.4-h1a8c8d9_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-xextproto-7.3.0-h1a8c8d9_1003.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-xproto-7.0.31-h27ca646_1007.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.2.6-h57fd34a_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h3422bc3_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yarp-3.9.0-hce30654_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yarp-python-3.9.0-py311h1e2cc8c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ycm-cmake-modules-0.16.2-hebf3989_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.2.13-h53f4e23_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.5-h4f39d0f_0.conda
+      win-64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/catkin_pkg-1.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/llvm-meta-5.0.0-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.8.2-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-69.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.42.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ace-7.1.3-h63175ca_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aom-3.8.1-h63175ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/assimp-5.3.1-h81f0834_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-hcfcfb64_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/c-compiler-1.7.0-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2024.2.2-h56e8100_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cairo-1.18.0-h1fef639_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cxx-compiler-1.7.0-h91493d7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/dav1d-1.2.1-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/docutils-0.20.1-py311h1ea47a8_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/eigen-3.4.0-h91493d7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/expat-2.5.0-h63175ca_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ffmpeg-6.1.1-gpl_hb766fab_104.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/fontconfig-2.14.2-hbde0cde_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/freeglut-3.2.2-h63175ca_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/freetype-2.12.1-hdaf720e_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/gettext-0.21.1-h5728263_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/glfw-3.3.9-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/glib-2.78.3-h12be248_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/glib-tools-2.78.3-h12be248_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/graphite2-1.3.13-1000.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/gst-plugins-base-1.22.9-h001b923_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/gstreamer-1.22.9-hb4038d2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/harfbuzz-8.3.0-h7ab893a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/hdf5-1.14.3-nompi_h73e8ff5_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/icu-73.2-h63175ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/idyntree-10.3.0-py311heed4631_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2024.0.0-h57928b3_49841.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ipopt-3.14.14-h1709daf_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/irrlicht-1.8.5-h65f4d7e_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/jasper-4.2.0-h28f2b1a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/khronos-opencl-icd-loader-2023.04.17-h64bf75a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/krb5-1.21.2-heb0366b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lerc-4.0.0-h63175ca_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libabseil-20230802.1-cxx17_h63175ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libaec-1.1.2-h63175ca_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-21_win64_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libboost-1.82.0-h65993cd_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-21_win64_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libclang-15.0.7-default_hde6756a_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libclang13-15.0.7-default_h85b4d89_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.5.0-hd5e4a3a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.19-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.5.0-h63175ca_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.4.2-h8ffe710_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libflang-5.0.0-h6538335_20180525.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libglib-2.78.3-h16e383f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.9.3-default_haede6df_1009.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.17-hcfcfb64_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libjpeg-turbo-3.0.0-hcfcfb64_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-21_win64_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/liblapacke-3.9.0-21_win64_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libogg-1.3.4-h8ffe710_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopencv-4.9.0-py312h766d233_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-2023.3.0-hc2557fa_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-auto-batch-plugin-2023.3.0-h002f227_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-auto-plugin-2023.3.0-h002f227_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-hetero-plugin-2023.3.0-h7e3b17c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-intel-cpu-plugin-2023.3.0-hc2557fa_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-intel-gpu-plugin-2023.3.0-hc2557fa_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-ir-frontend-2023.3.0-h7e3b17c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-onnx-frontend-2023.3.0-h8f0bfdc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-paddle-frontend-2023.3.0-h8f0bfdc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-pytorch-frontend-2023.3.0-h63175ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-tensorflow-frontend-2023.3.0-h815df86_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-tensorflow-lite-frontend-2023.3.0-h63175ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopus-1.3.1-h8ffe710_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libosqp-0.6.3-h63175ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.42-h19919ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libprotobuf-4.25.1-hb8276f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libqdldl-0.1.5-h63175ca_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.45.1-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libssh2-1.11.0-h7dfc565_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.6.0-h6e2ebb7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libvorbis-1.3.7-h0e60522_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libwebp-base-1.3.2-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.12.5-hc3477c8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libxslt-1.1.39-h3df6e99_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libyarp-3.9.0-ha0ae21b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.2.13-hcfcfb64_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lxml-4.9.4-py311h064e5ff_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/metis-5.1.0-h63175ca_1007.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/mkl-2024.0.0-h66d3029_49657.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/mumps-seq-5.6.2-h1f49738_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ninja-1.11.1-h91493d7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/numpy-1.26.4-py311h0b4df5a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openh264-2.4.1-h63175ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openmp-5.0.0-vc14_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.2.1-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/osqp-eigen-0.8.1-h6d7489e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pcre2-10.42-h17e33f8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pixman-0.43.2-h63175ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/portaudio-19.6.0-h63175ca_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pthreads-win32-2.9.1-hfa6e2cd_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pugixml-1.14-h63175ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.11.7-h2628c8c_1_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.11-4_cp311.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyyaml-5.4.1-py311ha68e1ae_4.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/qt-main-5.15.8-h9e85ed6_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/robot-testing-framework-2.0.1-h63175ca_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ruby-3.2.2-h20ad4f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/sdl-1.2.68-h21dd15a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/sdl2-2.28.5-h63175ca_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/snappy-1.1.10-hfb803bf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/soxr-0.1.3-hcfcfb64_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/svt-av1-1.8.0-h63175ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.11.0-h91493d7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tinyxml-2.6.2-h2d74725_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h5226925_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-hcf57466_18.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.38.33130-h82b7239_18.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.38.33130-hcb4865c_18.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vs2019_win-64-19.29.30139-he1865b1_18.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vswhere-3.1.4-h57928b3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/x264-1!164.3095-h8ffe710_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/x265-3.5-h2d74725_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/xz-5.2.6-h8d14728_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/yaml-0.2.5-h8ffe710_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/yarp-3.9.0-h57928b3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/yarp-python-3.9.0-py311h49b8dee_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ycm-cmake-modules-0.16.2-h63175ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zlib-1.2.13-hcfcfb64_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.5-h12be248_0.conda
+packages:
+- kind: conda
+  name: _libgcc_mutex
+  version: '0.1'
+  build: conda_forge
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
+  sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
+  md5: d7c89558ba9fa0495403155b64376d81
+  license: None
+  size: 2562
+  timestamp: 1578324546067
+- kind: conda
+  name: _openmp_mutex
+  version: '4.5'
+  build: 2_gnu
+  build_number: 16
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+  sha256: fbe2c5e56a653bebb982eda4876a9178aedfc2b545f25d0ce9c4c0b508253d22
+  md5: 73aaf86a425cc6e73fcf236a5a46396d
+  depends:
+  - _libgcc_mutex 0.1 conda_forge
+  - libgomp >=7.5.0
+  constrains:
+  - openmp_impl 9999
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23621
+  timestamp: 1650670423406
+- kind: conda
+  name: _openmp_mutex
+  version: '4.5'
+  build: 2_gnu
+  build_number: 16
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-2_gnu.tar.bz2
+  sha256: 3702bef2f0a4d38bd8288bbe54aace623602a1343c2cfbefd3fa188e015bebf0
+  md5: 6168d71addc746e8f2b8d57dfd2edcea
+  depends:
+  - libgomp >=7.5.0
+  constrains:
+  - openmp_impl 9999
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23712
+  timestamp: 1650670790230
+- kind: conda
+  name: _sysroot_linux-aarch64_curr_repodata_hack
+  version: '4'
+  build: h57d6b7b_13
+  build_number: 13
+  subdir: noarch
+  noarch: generic
+  url: https://conda.anaconda.org/conda-forge/noarch/_sysroot_linux-aarch64_curr_repodata_hack-4-h57d6b7b_13.conda
+  sha256: 45eaba02c457c78d1bb2ff2cf90bb3f6f9c25de40f43d83936a58e349f247a2b
+  md5: 56cba32729a63e97bfb1ef958940ff07
+  license: LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0
+  license_family: GPL
+  size: 20799
+  timestamp: 1682995515087
+- kind: conda
+  name: ace
+  version: 7.1.3
+  build: h59595ed_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/ace-7.1.3-h59595ed_2.conda
+  sha256: ffe53a66b9a164e57b7482758f9c5f30fe11d0da72cca29e61369b34f6b216e4
+  md5: 417cf3a2ff5b3335777c31f73a42f19d
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: DOC
+  size: 5472312
+  timestamp: 1707130255299
+- kind: conda
+  name: ace
+  version: 7.1.3
+  build: h63175ca_2
+  build_number: 2
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/ace-7.1.3-h63175ca_2.conda
+  sha256: 263ef6e06e6cd75e5c426e19da0933192ed6ca85454ae93055c9c6431cbfd48d
+  md5: e1142f08cb44c9ed2d2b876859a61367
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: DOC
+  size: 2041944
+  timestamp: 1707130991728
+- kind: conda
+  name: ace
+  version: 7.1.3
+  build: h73e2aa4_2
+  build_number: 2
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/ace-7.1.3-h73e2aa4_2.conda
+  sha256: 0c862552e321d2be1e1ca91541ea05c0c5fa76731d9af95e9891d16717227215
+  md5: 3599788d7debc200ff2ce71a5e6c9a13
+  depends:
+  - libcxx >=16
+  license: DOC
+  size: 1799511
+  timestamp: 1707130916668
+- kind: conda
+  name: ace
+  version: 7.1.3
+  build: h787c7f5_2
+  build_number: 2
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/ace-7.1.3-h787c7f5_2.conda
+  sha256: f1e0643e5c9c9124d434138bf8e39c0ee7f9e568d46923ce22ebce8709cbee23
+  md5: 8f6b4a15696eb9d4a7e1dd1b874972c5
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: DOC
+  size: 5364970
+  timestamp: 1707133447836
+- kind: conda
+  name: alsa-lib
+  version: 1.2.10
+  build: h31becfc_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/alsa-lib-1.2.10-h31becfc_0.conda
+  sha256: 4ecf0c2f8cbe1112e6b1b983ed3606759deecc31e9f1c2bb15d3ceacea633047
+  md5: bbe8d80c6d5bfbcc4869470954f35de4
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.1-or-later
+  license_family: GPL
+  size: 584257
+  timestamp: 1693609522269
+- kind: conda
+  name: alsa-lib
+  version: 1.2.10
+  build: hd590300_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.10-hd590300_0.conda
+  sha256: 51147922bad9d3176e780eb26f748f380cd3184896a9f9125d8ac64fe330158b
+  md5: 75dae9a4201732aa78a530b826ee5fe0
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.1-or-later
+  license_family: GPL
+  size: 554938
+  timestamp: 1693607226431
+- kind: conda
+  name: ampl-mp
+  version: 3.1.0
+  build: h05efe27_1006
+  build_number: 1006
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/ampl-mp-3.1.0-h05efe27_1006.tar.bz2
+  sha256: f178cb90d1fb76453a712573c4229de353962e21b53be47f5d10f66af9226bad
+  md5: 4bd9e551560df784b4c998f56cc83b4a
+  depends:
+  - libgcc-ng >=9.4.0
+  - libgfortran-ng
+  - libgfortran5 >=9.4.0
+  - libstdcxx-ng >=9.4.0
+  - unixodbc >=2.3.9,<2.4.0a0
+  license: HPND
+  size: 1275764
+  timestamp: 1645060845399
+- kind: conda
+  name: ampl-mp
+  version: 3.1.0
+  build: h2beb688_1006
+  build_number: 1006
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/ampl-mp-3.1.0-h2beb688_1006.tar.bz2
+  sha256: 300f929bee9775b4d3625036376cd7d5f38e03fd949094e819f46e319bd53978
+  md5: 2ed1f1350aade6feacfcb7ea22aa8505
+  depends:
+  - libcxx >=11.1.0
+  - libgfortran 5.*
+  - libgfortran5 >=9.3.0
+  - unixodbc >=2.3.9,<2.4.0a0
+  license: HPND
+  size: 1076342
+  timestamp: 1645058227340
+- kind: conda
+  name: ampl-mp
+  version: 3.1.0
+  build: h2cc385e_1006
+  build_number: 1006
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/ampl-mp-3.1.0-h2cc385e_1006.tar.bz2
+  sha256: ff6e942d6490496d98d670f783275078d2a30c694202304ecd49fb759b93c07f
+  md5: 6c2f16f5650a7c66ffdfee57b890ea06
+  depends:
+  - libgcc-ng >=9.4.0
+  - libgfortran-ng
+  - libgfortran5 >=9.4.0
+  - libstdcxx-ng >=9.4.0
+  - unixodbc >=2.3.9,<2.4.0a0
+  license: HPND
+  size: 1137486
+  timestamp: 1645057516176
+- kind: conda
+  name: ampl-mp
+  version: 3.1.0
+  build: hbec66e7_1006
+  build_number: 1006
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ampl-mp-3.1.0-hbec66e7_1006.tar.bz2
+  sha256: 781ef33b48e2b9687dce2019db411994fea44e56c2d0265e197c3acb19bbefa2
+  md5: 39bd6ea77989a38b163b971a54bb1aba
+  depends:
+  - libcxx >=11.1.0
+  - libgfortran 5.*
+  - libgfortran5 >=11.0.1.dev0
+  - unixodbc >=2.3.9,<2.4.0a0
+  license: HPND
+  size: 991108
+  timestamp: 1645057976681
+- kind: conda
+  name: aom
+  version: 3.8.1
+  build: h0425590_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/aom-3.8.1-h0425590_0.conda
+  sha256: 26b77fbfc09ae8924d94404177c2fc1c262b78cea775b58f429340341163c7e9
+  md5: 2ab54b9919d04aaa57dd6bf2b803dea8
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 3219181
+  timestamp: 1706649146839
+- kind: conda
+  name: aom
+  version: 3.8.1
+  build: h078ce10_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aom-3.8.1-h078ce10_0.conda
+  sha256: 8a531d2ea3080b298231ebed2e0251e4bb861c4a7a1e91a2f7a5532335199139
+  md5: b84b3ce3dd4f5185dad3c00e03df598d
+  depends:
+  - libcxx >=15
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2203496
+  timestamp: 1706649351976
+- kind: conda
+  name: aom
+  version: 3.8.1
+  build: h59595ed_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/aom-3.8.1-h59595ed_0.conda
+  sha256: 42fd8fc28735deac6c578c9a07fc4c6b1912ba4300b63631e64fc0a6e0f22370
+  md5: 50871627bc8ba3a46ec5650f4a5b9d43
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2700689
+  timestamp: 1706649284348
+- kind: conda
+  name: aom
+  version: 3.8.1
+  build: h63175ca_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/aom-3.8.1-h63175ca_0.conda
+  sha256: 35ffd4da72759b3ba61cd75050f902777926bccb7d24987585d9c7e3e77795a6
+  md5: ab5e0ac3be5f9aa615d0a52c5efeb196
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1955126
+  timestamp: 1706649889826
+- kind: conda
+  name: aom
+  version: 3.8.1
+  build: h73e2aa4_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/aom-3.8.1-h73e2aa4_0.conda
+  sha256: ee8677cc9bea352c7fe12d5f42f0d277cee1d7e7f5518ae728dc1befc75fe49a
+  md5: 3194f8209de31e1e09f2ae915c5288d4
+  depends:
+  - libcxx >=15
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2756364
+  timestamp: 1706649344166
+- kind: conda
+  name: assimp
+  version: 5.3.1
+  build: h28f1edd_2
+  build_number: 2
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/assimp-5.3.1-h28f1edd_2.conda
+  sha256: b7efae7ec17e9ab7dd43c6e86ef2b3a527f465eb73a096bb4cf186524d4319a7
+  md5: 97a7479c43d59994b0f443e8f7f41ea0
+  depends:
+  - libboost >=1.82.0,<1.83.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
+  - zlib
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3456753
+  timestamp: 1696140162996
+- kind: conda
+  name: assimp
+  version: 5.3.1
+  build: h460e769_2
+  build_number: 2
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/assimp-5.3.1-h460e769_2.conda
+  sha256: 68c0ea861c8bc565dcf6dd07b3291027da8cc8341e38c53e125df1bab2faf948
+  md5: 10aec07083b02bff5c57d6ad9d8d6bff
+  depends:
+  - libboost >=1.82.0,<1.83.0a0
+  - libcxx >=15.0.7
+  - libzlib >=1.2.13,<1.3.0a0
+  - zlib
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2773322
+  timestamp: 1696140507513
+- kind: conda
+  name: assimp
+  version: 5.3.1
+  build: h81f0834_2
+  build_number: 2
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/assimp-5.3.1-h81f0834_2.conda
+  sha256: aa92006a846ada16630b065449876c33bc5bfd2d399fa38d69c841d0fea6ca0d
+  md5: 4406a7eb5b3120acac852b90a62d9346
+  depends:
+  - libboost >=1.82.0,<1.83.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zlib
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3034123
+  timestamp: 1696140428807
+- kind: conda
+  name: assimp
+  version: 5.3.1
+  build: he63ff86_2
+  build_number: 2
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/assimp-5.3.1-he63ff86_2.conda
+  sha256: 54437f7afeb6b6b2dadf20947b1a2847066cc5c14c2d4b12a8936f90e50d910b
+  md5: d3b4b719e08c8d062443743bf8743839
+  depends:
+  - libboost >=1.82.0,<1.83.0a0
+  - libcxx >=15.0.7
+  - libzlib >=1.2.13,<1.3.0a0
+  - zlib
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2593786
+  timestamp: 1696140474457
+- kind: conda
+  name: assimp
+  version: 5.3.1
+  build: hfb0e8fe_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/assimp-5.3.1-hfb0e8fe_2.conda
+  sha256: 9774067ce0d7809f6f057cd5f350e1e1dc78c4f76ee9d10bf3fa40a408026e95
+  md5: fd0d79a77ae5b77fdb60ced45d474f88
+  depends:
+  - libboost >=1.82.0,<1.83.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
+  - zlib
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3548864
+  timestamp: 1696139838953
+- kind: conda
+  name: attr
+  version: 2.5.1
+  build: h166bdaf_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/attr-2.5.1-h166bdaf_1.tar.bz2
+  sha256: 82c13b1772c21fc4a17441734de471d3aabf82b61db9b11f4a1bd04a9c4ac324
+  md5: d9c69a24ad678ffce24c6543a0176b00
+  depends:
+  - libgcc-ng >=12
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 71042
+  timestamp: 1660065501192
+- kind: conda
+  name: attr
+  version: 2.5.1
+  build: h4e544f5_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/attr-2.5.1-h4e544f5_1.tar.bz2
+  sha256: 2c793b48e835a8fac93f1664c706442972a0206963bf8ca202e83f7f4d29a7d7
+  md5: 1ef6c06fec1b6f5ee99ffe2152e53568
+  depends:
+  - libgcc-ng >=12
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 74992
+  timestamp: 1660065534958
+- kind: conda
+  name: binutils
+  version: '2.40'
+  build: h64c2a2e_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils-2.40-h64c2a2e_0.conda
+  sha256: 624f6e9dd9cf651d9fd6ed3a7c1af38ea60aaa3213b35f14c088d8de37ffda5e
+  md5: 50083e4c6e024fcb0b0dd195204276a3
+  depends:
+  - binutils_impl_linux-aarch64 >=2.40,<2.41.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 30742
+  timestamp: 1674833883570
+- kind: conda
+  name: binutils
+  version: '2.40'
+  build: hdd6e379_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/binutils-2.40-hdd6e379_0.conda
+  sha256: 35f3b042f295fd7387de11cf426ca8ee5257e5c98b88560c6c5ad4ef3c85d38c
+  md5: ccc940fddbc3fcd3d79cd4c654c4b5c4
+  depends:
+  - binutils_impl_linux-64 >=2.40,<2.41.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 30469
+  timestamp: 1674833987166
+- kind: conda
+  name: binutils_impl_linux-64
+  version: '2.40'
+  build: hf600244_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.40-hf600244_0.conda
+  sha256: a7e0ea2b71a5b03d82e5a58fb6b612ab1c44d72ce161f9aa441f7ba467cd4c8d
+  md5: 33084421a8c0af6aef1b439707f7662a
+  depends:
+  - ld_impl_linux-64 2.40 h41732ed_0
+  - sysroot_linux-64
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 5414922
+  timestamp: 1674833958334
+- kind: conda
+  name: binutils_impl_linux-aarch64
+  version: '2.40'
+  build: h870a726_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_impl_linux-aarch64-2.40-h870a726_0.conda
+  sha256: 43a69e65a7d66fe9f6f17f71814eef807c94f2bc60c7892e6658498cb3759e13
+  md5: 1945203dbddc28b0080c5129a3a704b1
+  depends:
+  - ld_impl_linux-aarch64 2.40 h2d8c526_0
+  - sysroot_linux-aarch64
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 5535072
+  timestamp: 1674833858298
+- kind: conda
+  name: binutils_linux-64
+  version: '2.40'
+  build: hbdbef99_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.40-hbdbef99_2.conda
+  sha256: 333f3339d94c93bcc02a723e3e460cb6ff6075e05f5247e15bef5dcdcec541a3
+  md5: adfebae9fdc63a598495dfe3b006973a
+  depends:
+  - binutils_impl_linux-64 2.40.*
+  - sysroot_linux-64
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28178
+  timestamp: 1694604071236
+- kind: conda
+  name: binutils_linux-aarch64
+  version: '2.40'
+  build: h94bbfa1_2
+  build_number: 2
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_linux-aarch64-2.40-h94bbfa1_2.conda
+  sha256: 239fa4ec306dc21459bc05a3cc411a318ba8eb45e31dc3e846f7e06ab7062368
+  md5: 1963001481680dde1bcc33e722172d14
+  depends:
+  - binutils_impl_linux-aarch64 2.40.*
+  - sysroot_linux-aarch64
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28319
+  timestamp: 1694604100748
+- kind: conda
+  name: bzip2
+  version: 1.0.8
+  build: h10d778d_5
+  build_number: 5
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h10d778d_5.conda
+  sha256: 61fb2b488928a54d9472113e1280b468a309561caa54f33825a3593da390b242
+  md5: 6097a6ca9ada32699b5fc4312dd6ef18
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 127885
+  timestamp: 1699280178474
+- kind: conda
+  name: bzip2
+  version: 1.0.8
+  build: h31becfc_5
+  build_number: 5
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/bzip2-1.0.8-h31becfc_5.conda
+  sha256: b9f170990625cb1eeefaca02e091dc009a64264b077166d8ed7aeb7a09e923b0
+  md5: a64e35f01e0b7a2a152eca87d33b9c87
+  depends:
+  - libgcc-ng >=12
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 189668
+  timestamp: 1699280060686
+- kind: conda
+  name: bzip2
+  version: 1.0.8
+  build: h93a5062_5
+  build_number: 5
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h93a5062_5.conda
+  sha256: bfa84296a638bea78a8bb29abc493ee95f2a0218775642474a840411b950fe5f
+  md5: 1bbc659ca658bfd49a481b5ef7a0f40f
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 122325
+  timestamp: 1699280294368
+- kind: conda
+  name: bzip2
+  version: 1.0.8
+  build: hcfcfb64_5
+  build_number: 5
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-hcfcfb64_5.conda
+  sha256: ae5f47a5c86fd6db822931255dcf017eb12f60c77f07dc782ccb477f7808aab2
+  md5: 26eb8ca6ea332b675e11704cce84a3be
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 124580
+  timestamp: 1699280668742
+- kind: conda
+  name: bzip2
+  version: 1.0.8
+  build: hd590300_5
+  build_number: 5
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hd590300_5.conda
+  sha256: 242c0c324507ee172c0e0dd2045814e746bb303d1eb78870d182ceb0abc726a8
+  md5: 69b8b6202a07720f448be700e300ccf4
+  depends:
+  - libgcc-ng >=12
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 254228
+  timestamp: 1699279927352
+- kind: conda
+  name: c-ares
+  version: 1.26.0
+  build: h10d778d_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.26.0-h10d778d_0.conda
+  sha256: 4b01708ed02f3e2cf9e8919a6fc1d3116cdf84c1a771294031e880f54235f47c
+  md5: 04a8ab3d4f9a9446b286c4a90f665148
+  license: MIT
+  license_family: MIT
+  size: 147816
+  timestamp: 1706300301840
+- kind: conda
+  name: c-ares
+  version: 1.26.0
+  build: h31becfc_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/c-ares-1.26.0-h31becfc_0.conda
+  sha256: d9eebd51d89c68789957e92d73c0ca4651aef859c6caa5899dd0c8d46b936d8c
+  md5: f5094fec0d7d788152c7503140929bf2
+  depends:
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 168655
+  timestamp: 1706299916731
+- kind: conda
+  name: c-ares
+  version: 1.26.0
+  build: h93a5062_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.26.0-h93a5062_0.conda
+  sha256: 1dfdbac985a74a905f2bcf62f13ce758a8356e50d4b28ddbc2027df8580717d8
+  md5: 58b9187431de0a2ffebc907f4590e2e5
+  license: MIT
+  license_family: MIT
+  size: 145325
+  timestamp: 1706300196534
+- kind: conda
+  name: c-ares
+  version: 1.26.0
+  build: hd590300_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.26.0-hd590300_0.conda
+  sha256: 3771589a91303710a59d1d40bbcdca43743969fe993ea576538ba375ac8ab0fa
+  md5: a86d90025198fd411845fc245ebc06c8
+  depends:
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 162725
+  timestamp: 1706299899438
+- kind: conda
+  name: c-compiler
+  version: 1.7.0
+  build: h282daa2_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/c-compiler-1.7.0-h282daa2_0.conda
+  sha256: c32fdb29dac5e1a01aa486aba1f7b21cff5c1c7748c0cf9b6c9475888b61eb17
+  md5: 4652f33fe8d895f61177e2783b289377
+  depends:
+  - cctools >=949.0.1
+  - clang_osx-64 16.*
+  - ld64 >=530
+  - llvm-openmp
+  license: BSD
+  size: 6409
+  timestamp: 1701505468495
+- kind: conda
+  name: c-compiler
+  version: 1.7.0
+  build: h31becfc_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/c-compiler-1.7.0-h31becfc_0.conda
+  sha256: d669377ff234838216e3bbd32b46872fe6f19c40c9477c8119305d2204168829
+  md5: 4df75f282f5841cc6dc6126a6d281268
+  depends:
+  - binutils
+  - gcc
+  - gcc_linux-aarch64 12.*
+  license: BSD
+  size: 6282
+  timestamp: 1701505282730
+- kind: conda
+  name: c-compiler
+  version: 1.7.0
+  build: h6aa9301_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/c-compiler-1.7.0-h6aa9301_0.conda
+  sha256: 1d5992140eef7c4df1a479767f8430367c2b856627dc6f84e2f6fc62d919bc37
+  md5: 1d3e1f0096f791944c07a9ca5e0a92c5
+  depends:
+  - cctools >=949.0.1
+  - clang_osx-arm64 16.*
+  - ld64 >=530
+  - llvm-openmp
+  license: BSD
+  size: 6422
+  timestamp: 1701505466835
+- kind: conda
+  name: c-compiler
+  version: 1.7.0
+  build: hcfcfb64_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/c-compiler-1.7.0-hcfcfb64_0.conda
+  sha256: 8abfef37bfebf05b5412dabb7908c7b07263b373c37442ebec13cfb7eddd0e08
+  md5: 32d42233276c87fc1b774a3f17014611
+  depends:
+  - vs2019_win-64
+  license: BSD
+  size: 6493
+  timestamp: 1701505478619
+- kind: conda
+  name: c-compiler
+  version: 1.7.0
+  build: hd590300_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/c-compiler-1.7.0-hd590300_0.conda
+  sha256: 19343f6cdefd0a2e36c4f0da81ed9ea964e5b4e82a2304809afd8f151bf2ac8c
+  md5: fad1d0a651bf929c6c16fbf1f6ccfa7c
+  depends:
+  - binutils
+  - gcc
+  - gcc_linux-64 12.*
+  license: BSD
+  size: 6287
+  timestamp: 1701505302633
+- kind: conda
+  name: ca-certificates
+  version: 2024.2.2
+  build: h56e8100_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2024.2.2-h56e8100_0.conda
+  sha256: 4d587088ecccd393fec3420b64f1af4ee1a0e6897a45cfd5ef38055322cea5d0
+  md5: 63da060240ab8087b60d1357051ea7d6
+  license: ISC
+  size: 155886
+  timestamp: 1706843918052
+- kind: conda
+  name: ca-certificates
+  version: 2024.2.2
+  build: h8857fd0_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2024.2.2-h8857fd0_0.conda
+  sha256: 54a794aedbb4796afeabdf54287b06b1d27f7b13b3814520925f4c2c80f58ca9
+  md5: f2eacee8c33c43692f1ccfd33d0f50b1
+  license: ISC
+  size: 155665
+  timestamp: 1706843838227
+- kind: conda
+  name: ca-certificates
+  version: 2024.2.2
+  build: hbcca054_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.2.2-hbcca054_0.conda
+  sha256: 91d81bfecdbb142c15066df70cc952590ae8991670198f92c66b62019b251aeb
+  md5: 2f4327a1cbe7f022401b236e915a5fef
+  license: ISC
+  size: 155432
+  timestamp: 1706843687645
+- kind: conda
+  name: ca-certificates
+  version: 2024.2.2
+  build: hcefe29a_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/ca-certificates-2024.2.2-hcefe29a_0.conda
+  sha256: 0f6b34d835e26e5fa97cca4985dc46f0aba551a3a23f07c6f13cca2542b8c642
+  md5: 57c226edb90c4e973b9b7503537dd339
+  license: ISC
+  size: 155738
+  timestamp: 1706845723412
+- kind: conda
+  name: ca-certificates
+  version: 2024.2.2
+  build: hf0a4a13_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2024.2.2-hf0a4a13_0.conda
+  sha256: 49bc3439816ac72d0c0e0f144b8cc870fdcc4adec2e861407ec818d8116b2204
+  md5: fb416a1795f18dcc5a038bc2dc54edf9
+  license: ISC
+  size: 155725
+  timestamp: 1706844034242
+- kind: conda
+  name: cairo
+  version: 1.18.0
+  build: h1fef639_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/cairo-1.18.0-h1fef639_0.conda
+  sha256: 451e714f065b5dd0c11169058be56b10973dfd7d9a0fccf9c6a05d1e09995730
+  md5: b3fe2c6381ec74afe8128e16a11eee02
+  depends:
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - icu >=73.2,<74.0a0
+  - libglib >=2.78.0,<3.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - pixman >=0.42.2,<1.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zlib
+  license: LGPL-2.1-only or MPL-1.1
+  size: 1520159
+  timestamp: 1697029136038
+- kind: conda
+  name: cairo
+  version: 1.18.0
+  build: h3faef2a_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.0-h3faef2a_0.conda
+  sha256: 142e2639a5bc0e99c44d76f4cc8dce9c6a2d87330c4beeabb128832cd871a86e
+  md5: f907bb958910dc404647326ca80c263e
+  depends:
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - icu >=73.2,<74.0a0
+  - libgcc-ng >=12
+  - libglib >=2.78.0,<3.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libstdcxx-ng >=12
+  - libxcb >=1.15,<1.16.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - pixman >=0.42.2,<1.0a0
+  - xorg-libice >=1.1.1,<2.0a0
+  - xorg-libsm >=1.2.4,<2.0a0
+  - xorg-libx11 >=1.8.6,<2.0a0
+  - xorg-libxext >=1.3.4,<2.0a0
+  - xorg-libxrender >=0.9.11,<0.10.0a0
+  - zlib
+  license: LGPL-2.1-only or MPL-1.1
+  size: 982351
+  timestamp: 1697028423052
+- kind: conda
+  name: cairo
+  version: 1.18.0
+  build: h99e66fa_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/cairo-1.18.0-h99e66fa_0.conda
+  sha256: f8d1142cf244eadcbc44e8ca2266aa61a05b6cda5571f9b745ba32c7ebbfdfba
+  md5: 13f830b1bf46018f7062d1b798d53eca
+  depends:
+  - __osx >=10.9
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - icu >=73.2,<74.0a0
+  - libcxx >=16.0.6
+  - libglib >=2.78.0,<3.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - pixman >=0.42.2,<1.0a0
+  - zlib
+  license: LGPL-2.1-only or MPL-1.1
+  size: 885311
+  timestamp: 1697028802967
+- kind: conda
+  name: cairo
+  version: 1.18.0
+  build: ha13f110_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/cairo-1.18.0-ha13f110_0.conda
+  sha256: 79b6323661b535d90aaec0eac0e91ccda88cc5917d9e597a03d7de183bc22f26
+  md5: 425111f8cc6945c5d1307357dd819b9b
+  depends:
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - icu >=73.2,<74.0a0
+  - libgcc-ng >=12
+  - libglib >=2.78.0,<3.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libstdcxx-ng >=12
+  - libxcb >=1.15,<1.16.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - pixman >=0.42.2,<1.0a0
+  - xorg-libice >=1.1.1,<2.0a0
+  - xorg-libsm >=1.2.4,<2.0a0
+  - xorg-libx11 >=1.8.6,<2.0a0
+  - xorg-libxext >=1.3.4,<2.0a0
+  - xorg-libxrender >=0.9.11,<0.10.0a0
+  - zlib
+  license: LGPL-2.1-only or MPL-1.1
+  size: 983779
+  timestamp: 1697028424329
+- kind: conda
+  name: cairo
+  version: 1.18.0
+  build: hd1e100b_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/cairo-1.18.0-hd1e100b_0.conda
+  sha256: 599f8820553b3a3405706d9cad390ac199e24515a0a82c87153c9b5b5fdba3b8
+  md5: 3fa6eebabb77f65e82f86b72b95482db
+  depends:
+  - __osx >=10.9
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - icu >=73.2,<74.0a0
+  - libcxx >=16.0.6
+  - libglib >=2.78.0,<3.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - pixman >=0.42.2,<1.0a0
+  - zlib
+  license: LGPL-2.1-only or MPL-1.1
+  size: 897919
+  timestamp: 1697028755150
+- kind: conda
+  name: catkin_pkg
+  version: 1.0.0
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/catkin_pkg-1.0.0-pyhd8ed1ab_0.conda
+  sha256: b97401522d6b6b4ef1ec3ae1904ef44435f6e09df044a213c0b26c24c7bfb914
+  md5: e8e0308c8d90a038cf58fd346a80a6a3
+  depends:
+  - docutils
+  - pyparsing >=1.5.7
+  - python >=3.6
+  - python-dateutil
+  - setuptools
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 53408
+  timestamp: 1694652027818
+- kind: conda
+  name: cctools
+  version: 973.0.1
+  build: h40f6528_16
+  build_number: 16
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/cctools-973.0.1-h40f6528_16.conda
+  sha256: ef3afa0ca2e159360575d5de6cba102494d2dd03c0fda77e858ae9fba73b9e61
+  md5: b7234c329d4503600b032f168f4b65e7
+  depends:
+  - cctools_osx-64 973.0.1 ha1c5b94_16
+  - ld64 609 ha02d983_16
+  - libllvm16 >=16.0.6,<16.1.0a0
+  license: APSL-2.0
+  license_family: Other
+  size: 22144
+  timestamp: 1706798167450
+- kind: conda
+  name: cctools
+  version: 973.0.1
+  build: h4faf515_16
+  build_number: 16
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/cctools-973.0.1-h4faf515_16.conda
+  sha256: eb62575b0a4f306ed4fb8b874f109af7c622013eace2d9e533d6b3c88fea6c42
+  md5: 5fd71c6d5cef61d41af51b460265ef6f
+  depends:
+  - cctools_osx-arm64 973.0.1 h62378fb_16
+  - ld64 609 h634c8be_16
+  - libllvm16 >=16.0.6,<16.1.0a0
+  license: APSL-2.0
+  license_family: Other
+  size: 22117
+  timestamp: 1706798232449
+- kind: conda
+  name: cctools_osx-64
+  version: 973.0.1
+  build: ha1c5b94_16
+  build_number: 16
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/cctools_osx-64-973.0.1-ha1c5b94_16.conda
+  sha256: aa69f18388246169ac603148501bdd507bf935e97f384cf8f78ef94e3b296158
+  md5: 00eb71204323fa6449b38dd34ab9c65d
+  depends:
+  - ld64_osx-64 >=609,<610.0a0
+  - libcxx
+  - libllvm16 >=16.0.6,<16.1.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - sigtool
+  constrains:
+  - cctools 973.0.1.*
+  - clang 16.0.*
+  - ld64 609.*
+  license: APSL-2.0
+  license_family: Other
+  size: 1116102
+  timestamp: 1706798100072
+- kind: conda
+  name: cctools_osx-arm64
+  version: 973.0.1
+  build: h62378fb_16
+  build_number: 16
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/cctools_osx-arm64-973.0.1-h62378fb_16.conda
+  sha256: cdd2ce1a4d17084096626e9d074f19ab5abef1e330901358533455e12895572d
+  md5: be98824be7fa378bd06cb2670ad0b4cc
+  depends:
+  - ld64_osx-arm64 >=609,<610.0a0
+  - libcxx
+  - libllvm16 >=16.0.6,<16.1.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - sigtool
+  constrains:
+  - cctools 973.0.1.*
+  - clang 16.0.*
+  - ld64 609.*
+  license: APSL-2.0
+  license_family: Other
+  size: 1124537
+  timestamp: 1706798177156
+- kind: conda
+  name: clang
+  version: 16.0.6
+  build: h30cc82d_5
+  build_number: 5
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/clang-16.0.6-h30cc82d_5.conda
+  sha256: 09d5c870768512e3439bf2a33346a0092fc728bbf2ef3efba1c187220636507d
+  md5: f3bbbf40f13424248d9ff9650d9379af
+  depends:
+  - clang-16 16.0.6 default_he012953_5
+  constrains:
+  - clang-tools 16.0.6.*
+  - llvm 16.0.6.*
+  - llvm-tools 16.0.6.*
+  - llvmdev 16.0.6.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 21610
+  timestamp: 1706894245139
+- kind: conda
+  name: clang
+  version: 16.0.6
+  build: hdae98eb_5
+  build_number: 5
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/clang-16.0.6-hdae98eb_5.conda
+  sha256: df7180f4ee7bed92849cb36e46a9641e71eb6c99b990dedc48f7469c080d5f5f
+  md5: 5f020dce5a00342141d87f952c9c0282
+  depends:
+  - clang-16 16.0.6 default_h7151d67_5
+  constrains:
+  - clang-tools 16.0.6.*
+  - llvm 16.0.6.*
+  - llvm-tools 16.0.6.*
+  - llvmdev 16.0.6.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 21576
+  timestamp: 1706894282581
+- kind: conda
+  name: clang-16
+  version: 16.0.6
+  build: default_h7151d67_5
+  build_number: 5
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/clang-16-16.0.6-default_h7151d67_5.conda
+  sha256: 1ddcdef73115b5584f171a0182c1fdbbf168c667d8dcde19178d18f5c837fb43
+  md5: e132cf98d775fd7ec3b43859373bc070
+  depends:
+  - libclang-cpp16 16.0.6 default_h7151d67_5
+  - libcxx >=16.0.6
+  - libllvm16 >=16.0.6,<16.1.0a0
+  constrains:
+  - clangxx 16.0.6
+  - clangdev 16.0.6
+  - llvm-tools 16.0.6
+  - clang-tools 16.0.6
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 692571
+  timestamp: 1706894157239
+- kind: conda
+  name: clang-16
+  version: 16.0.6
+  build: default_he012953_5
+  build_number: 5
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/clang-16-16.0.6-default_he012953_5.conda
+  sha256: 38ce232aab29ac5ab6ec6dcbeae855d331c192f756da19c1c95db45e9ad28cbb
+  md5: 5986bf8dc369fc4f55f0393bf94b4494
+  depends:
+  - libclang-cpp16 16.0.6 default_he012953_5
+  - libcxx >=16.0.6
+  - libllvm16 >=16.0.6,<16.1.0a0
+  constrains:
+  - clangdev 16.0.6
+  - llvm-tools 16.0.6
+  - clang-tools 16.0.6
+  - clangxx 16.0.6
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 692537
+  timestamp: 1706894104516
+- kind: conda
+  name: clang_impl_osx-64
+  version: 16.0.6
+  build: h8787910_9
+  build_number: 9
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/clang_impl_osx-64-16.0.6-h8787910_9.conda
+  sha256: 3aeee43c777d67a334a7917a9a6cc43c67fabbf8acbceca31e2bef0702f0c81e
+  md5: 36dc72f20205cf43f63765334a5f0be7
+  depends:
+  - cctools_osx-64
+  - clang 16.0.6.*
+  - compiler-rt 16.0.6.*
+  - ld64_osx-64
+  - llvm-tools 16.0.6.*
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17576
+  timestamp: 1706817889548
+- kind: conda
+  name: clang_impl_osx-arm64
+  version: 16.0.6
+  build: hc421ffc_9
+  build_number: 9
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/clang_impl_osx-arm64-16.0.6-hc421ffc_9.conda
+  sha256: db8d0f1418bd5a6284da7137f278b5ec373b8382791aa550b4af711f7e079f8b
+  md5: 6ba30ea4b866e03cb834447d934d8d5f
+  depends:
+  - cctools_osx-arm64
+  - clang 16.0.6.*
+  - compiler-rt 16.0.6.*
+  - ld64_osx-arm64
+  - llvm-tools 16.0.6.*
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17585
+  timestamp: 1706831903732
+- kind: conda
+  name: clang_osx-64
+  version: 16.0.6
+  build: hb91bd55_9
+  build_number: 9
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/clang_osx-64-16.0.6-hb91bd55_9.conda
+  sha256: 970a919b17f6c5c04624b6a0269211bd3d7b41b3177e50f5dd7b5d036f4c25c9
+  md5: 3ebda8406efd8c09ebeeba80396ac6bd
+  depends:
+  - clang_impl_osx-64 16.0.6 h8787910_9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20647
+  timestamp: 1706817901570
+- kind: conda
+  name: clang_osx-arm64
+  version: 16.0.6
+  build: h54d7cd3_9
+  build_number: 9
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/clang_osx-arm64-16.0.6-h54d7cd3_9.conda
+  sha256: d712ced3aaf31275d3ca1f0b3dbe21ca82ba169e35a5e3e8115a67b381be2197
+  md5: 5df587e67413858308caac4c86b9c92a
+  depends:
+  - clang_impl_osx-arm64 16.0.6 hc421ffc_9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20568
+  timestamp: 1706831915550
+- kind: conda
+  name: clangxx
+  version: 16.0.6
+  build: default_h4cf2255_5
+  build_number: 5
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/clangxx-16.0.6-default_h4cf2255_5.conda
+  sha256: d5cdb838c3b67c4fdf1683e7659d011db228d5f762f85e2833e1c67c7c5cccdc
+  md5: 83d1eb2693ad27dec744ac21f1ad9812
+  depends:
+  - clang 16.0.6 h30cc82d_5
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 21761
+  timestamp: 1706894272948
+- kind: conda
+  name: clangxx
+  version: 16.0.6
+  build: default_h7151d67_5
+  build_number: 5
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/clangxx-16.0.6-default_h7151d67_5.conda
+  sha256: 9aafb8802adfe804ae38b66b01b00e133f1c14713ed1abed2710ed95ddbaa3e7
+  md5: 8c3fb5d2005174683f3958383643e335
+  depends:
+  - clang 16.0.6 hdae98eb_5
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 21699
+  timestamp: 1706894307583
+- kind: conda
+  name: clangxx_impl_osx-64
+  version: 16.0.6
+  build: h6d92fbe_9
+  build_number: 9
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/clangxx_impl_osx-64-16.0.6-h6d92fbe_9.conda
+  sha256: d0d712b2ea90fd4e0c7215cb319830496ced15c56ee208f6ebba5e0d0b21f765
+  md5: bfea277f004e2815ebd59294e9c08746
+  depends:
+  - clang_osx-64 16.0.6 hb91bd55_9
+  - clangxx 16.0.6.*
+  - libcxx >=16
+  - libllvm16 >=16.0.6,<16.1.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17667
+  timestamp: 1706817919437
+- kind: conda
+  name: clangxx_impl_osx-arm64
+  version: 16.0.6
+  build: hcd7bac0_9
+  build_number: 9
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/clangxx_impl_osx-arm64-16.0.6-hcd7bac0_9.conda
+  sha256: db061d8e7d6c1410cb188bbc5485d630cb076ae6981dca42def058822497536f
+  md5: 949089893ce76c6d743b77d6eec251bf
+  depends:
+  - clang_osx-arm64 16.0.6 h54d7cd3_9
+  - clangxx 16.0.6.*
+  - libcxx >=16
+  - libllvm16 >=16.0.6,<16.1.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17692
+  timestamp: 1706832802039
+- kind: conda
+  name: clangxx_osx-64
+  version: 16.0.6
+  build: hb91bd55_9
+  build_number: 9
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/clangxx_osx-64-16.0.6-hb91bd55_9.conda
+  sha256: 9225222bf1cd611e63f2b68c0838325f2fd5be930f81a7f3563ff5e2818955a5
+  md5: e7297accf408701c298308eeae807c5e
+  depends:
+  - clang_osx-64 16.0.6 hb91bd55_9
+  - clangxx_impl_osx-64 16.0.6 h6d92fbe_9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19414
+  timestamp: 1706817934575
+- kind: conda
+  name: clangxx_osx-arm64
+  version: 16.0.6
+  build: h54d7cd3_9
+  build_number: 9
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/clangxx_osx-arm64-16.0.6-h54d7cd3_9.conda
+  sha256: ee39efac1691f9f2d646bc64f04548179577e3c65c1ca5947cd4f944e4ccbdee
+  md5: e47d40e35f855ad41af35ba60937e41c
+  depends:
+  - clang_osx-arm64 16.0.6 h54d7cd3_9
+  - clangxx_impl_osx-arm64 16.0.6 hcd7bac0_9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19330
+  timestamp: 1706832814124
+- kind: conda
+  name: compiler-rt
+  version: 16.0.6
+  build: h3808999_2
+  build_number: 2
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/compiler-rt-16.0.6-h3808999_2.conda
+  sha256: 67f6883f37ea720f97d016c3384962d86ec8853e5f4b0065aa77e335ca80193e
+  md5: 517f18b3260bb7a508d1f54a96e6285b
+  depends:
+  - clang 16.0.6.*
+  - clangxx 16.0.6.*
+  - compiler-rt_osx-arm64 16.0.6.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  size: 93724
+  timestamp: 1701467327657
+- kind: conda
+  name: compiler-rt
+  version: 16.0.6
+  build: ha38d28d_2
+  build_number: 2
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/compiler-rt-16.0.6-ha38d28d_2.conda
+  sha256: de0e2c94d9a04f60ec9aedde863d6c1fad3f261bdb63ec8adc70e2d9ecdb07bb
+  md5: 3b9e8c5c63b8e86234f499490acd85c2
+  depends:
+  - clang 16.0.6.*
+  - clangxx 16.0.6.*
+  - compiler-rt_osx-64 16.0.6.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  size: 94198
+  timestamp: 1701467261175
+- kind: conda
+  name: compiler-rt_osx-64
+  version: 16.0.6
+  build: ha38d28d_2
+  build_number: 2
+  subdir: noarch
+  noarch: generic
+  url: https://conda.anaconda.org/conda-forge/noarch/compiler-rt_osx-64-16.0.6-ha38d28d_2.conda
+  sha256: 75270bd8e306967f6e1a8c17d14f2dfe76602a5c162088f3ea98034fe3d71e0c
+  md5: 7a46507edc35c6c8818db0adaf8d787f
+  depends:
+  - clang 16.0.6.*
+  - clangxx 16.0.6.*
+  constrains:
+  - compiler-rt 16.0.6
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  size: 9895261
+  timestamp: 1701467223753
+- kind: conda
+  name: compiler-rt_osx-arm64
+  version: 16.0.6
+  build: h3808999_2
+  build_number: 2
+  subdir: noarch
+  noarch: generic
+  url: https://conda.anaconda.org/conda-forge/noarch/compiler-rt_osx-arm64-16.0.6-h3808999_2.conda
+  sha256: 61f1a10e6e8ec147f17c5e36cf1c2fe77ac6d1907b05443fa319fd59be20fa33
+  md5: 8c7d77d888e1a218cccd9e82b1458ec6
+  depends:
+  - clang 16.0.6.*
+  - clangxx 16.0.6.*
+  constrains:
+  - compiler-rt 16.0.6
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  size: 9829914
+  timestamp: 1701467293179
+- kind: conda
+  name: cxx-compiler
+  version: 1.7.0
+  build: h00ab1b0_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/cxx-compiler-1.7.0-h00ab1b0_0.conda
+  sha256: 9278c12ed455a39a50d908381786540c9fd1627e4489dca9638b3e222c86d3f7
+  md5: b4537c98cb59f8725b0e1e65816b4a28
+  depends:
+  - c-compiler 1.7.0 hd590300_0
+  - gxx
+  - gxx_linux-64 12.*
+  license: BSD
+  size: 6262
+  timestamp: 1701505307165
+- kind: conda
+  name: cxx-compiler
+  version: 1.7.0
+  build: h2a328a1_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/cxx-compiler-1.7.0-h2a328a1_0.conda
+  sha256: 56176ede436f5fad7b43c5876c977a30c885de1e755d71f5bee53177559a26f9
+  md5: 51797a0f32e945d0ecb2406b6a576157
+  depends:
+  - c-compiler 1.7.0 h31becfc_0
+  - gxx
+  - gxx_linux-aarch64 12.*
+  license: BSD
+  size: 6277
+  timestamp: 1701505285388
+- kind: conda
+  name: cxx-compiler
+  version: 1.7.0
+  build: h2ffa867_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/cxx-compiler-1.7.0-h2ffa867_0.conda
+  sha256: 654d70c5a57002fbd6f567236cf6a354597631e9256d21fad6937f08de5ec00a
+  md5: cfc5dbb08e4808fe647493fd911724a7
+  depends:
+  - c-compiler 1.7.0 h6aa9301_0
+  - clangxx_osx-arm64 16.*
+  license: BSD
+  size: 6454
+  timestamp: 1701505505979
+- kind: conda
+  name: cxx-compiler
+  version: 1.7.0
+  build: h7728843_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/cxx-compiler-1.7.0-h7728843_0.conda
+  sha256: fe198da9a3ea1f3d1c9f18cceff633594549ef80c20bdb9522beb4b4446be09c
+  md5: 8abaa2694c1fba2b6bd3753d00a60415
+  depends:
+  - c-compiler 1.7.0 h282daa2_0
+  - clangxx_osx-64 16.*
+  license: BSD
+  size: 6428
+  timestamp: 1701505479181
+- kind: conda
+  name: cxx-compiler
+  version: 1.7.0
+  build: h91493d7_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/cxx-compiler-1.7.0-h91493d7_0.conda
+  sha256: f16dc990c284d704c43d28822c6153ccb63ef9716d5d7a47d3125b767f72a6d8
+  md5: 3949c652bedb193a39fa637d03f93150
+  depends:
+  - vs2019_win-64
+  license: BSD
+  size: 6517
+  timestamp: 1701505483027
+- kind: conda
+  name: dav1d
+  version: 1.2.1
+  build: h0dc2134_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/dav1d-1.2.1-h0dc2134_0.conda
+  sha256: ec71a835866b42e946cd2039a5f7a6458851a21890d315476f5e66790ac11c96
+  md5: 9d88733c715300a39f8ca2e936b7808d
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 668439
+  timestamp: 1685696184631
+- kind: conda
+  name: dav1d
+  version: 1.2.1
+  build: h31becfc_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/dav1d-1.2.1-h31becfc_0.conda
+  sha256: 33fe66d025cf5bac7745196d1a3dd7a437abcf2dbce66043e9745218169f7e17
+  md5: 6e5a87182d66b2d1328a96b61ca43a62
+  depends:
+  - libgcc-ng >=12
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 347363
+  timestamp: 1685696690003
+- kind: conda
+  name: dav1d
+  version: 1.2.1
+  build: hb547adb_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/dav1d-1.2.1-hb547adb_0.conda
+  sha256: 93e077b880a85baec8227e8c72199220c7f87849ad32d02c14fb3807368260b8
+  md5: 5a74cdee497e6b65173e10d94582fae6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 316394
+  timestamp: 1685695959391
+- kind: conda
+  name: dav1d
+  version: 1.2.1
+  build: hcfcfb64_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/dav1d-1.2.1-hcfcfb64_0.conda
+  sha256: 2aa2083c9c186da7d6f975ccfbef654ed54fff27f4bc321dbcd12cee932ec2c4
+  md5: ed2c27bda330e3f0ab41577cf8b9b585
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 618643
+  timestamp: 1685696352968
+- kind: conda
+  name: dav1d
+  version: 1.2.1
+  build: hd590300_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/dav1d-1.2.1-hd590300_0.conda
+  sha256: 22053a5842ca8ee1cf8e1a817138cdb5e647eb2c46979f84153f6ad7bde73020
+  md5: 418c6ca5929a611cbd69204907a83995
+  depends:
+  - libgcc-ng >=12
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 760229
+  timestamp: 1685695754230
+- kind: conda
+  name: dbus
+  version: 1.13.6
+  build: h12b9eeb_3
+  build_number: 3
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/dbus-1.13.6-h12b9eeb_3.tar.bz2
+  sha256: 5fe76bdf27a142cfb9da0fb3197c562e528d2622b573765bee5c9904cf5e6b6b
+  md5: f3d63805602166bac09386741e00935e
+  depends:
+  - expat >=2.4.2,<3.0a0
+  - libgcc-ng >=9.4.0
+  - libglib >=2.70.2,<3.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 672759
+  timestamp: 1640113663539
+- kind: conda
+  name: dbus
+  version: 1.13.6
+  build: h5008d03_3
+  build_number: 3
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.13.6-h5008d03_3.tar.bz2
+  sha256: 8f5f995699a2d9dbdd62c61385bfeeb57c82a681a7c8c5313c395aa0ccab68a5
+  md5: ecfff944ba3960ecb334b9a2663d708d
+  depends:
+  - expat >=2.4.2,<3.0a0
+  - libgcc-ng >=9.4.0
+  - libglib >=2.70.2,<3.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 618596
+  timestamp: 1640112124844
+- kind: conda
+  name: docutils
+  version: 0.20.1
+  build: py311h1ea47a8_3
+  build_number: 3
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/docutils-0.20.1-py311h1ea47a8_3.conda
+  sha256: fcce275ca03558a4feab18964ee1368f529fe095304a3a99b22e34459a4c0090
+  md5: 53e577542ed0df5a3af146e4a746dbd9
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: CC-PDDC AND BSD-3-Clause AND BSD-2-Clause AND ZPL-2.1
+  size: 973107
+  timestamp: 1701883312560
+- kind: conda
+  name: docutils
+  version: 0.20.1
+  build: py311h267d04e_3
+  build_number: 3
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/docutils-0.20.1-py311h267d04e_3.conda
+  sha256: 21af625c067faa77cd3aa2bfd8ca2449cdacdb1b531da8b4cbb476f4a928fdd9
+  md5: 29944e93a6f38b2e0fd4f6b743558959
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: CC-PDDC AND BSD-3-Clause AND BSD-2-Clause AND ZPL-2.1
+  size: 919194
+  timestamp: 1701883260630
+- kind: conda
+  name: docutils
+  version: 0.20.1
+  build: py311h38be061_3
+  build_number: 3
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/docutils-0.20.1-py311h38be061_3.conda
+  sha256: 0011a2193a5995a6706936156ea5d1021153ec11eb8869b6abfe15a8f6f22ea8
+  md5: 1c33f55e5cdcc2a2b973c432b5225bfe
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: CC-PDDC AND BSD-3-Clause AND BSD-2-Clause AND ZPL-2.1
+  size: 918352
+  timestamp: 1701882791483
+- kind: conda
+  name: docutils
+  version: 0.20.1
+  build: py311h6eed73b_3
+  build_number: 3
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/docutils-0.20.1-py311h6eed73b_3.conda
+  sha256: 0fae62e203900a8a013ba2ede852645b87b1568980ddd8e11390c11dc24c3e3c
+  md5: 2919376c4957faadc7b96f8894759bfb
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: CC-PDDC AND BSD-3-Clause AND BSD-2-Clause AND ZPL-2.1
+  size: 919457
+  timestamp: 1701883162608
+- kind: conda
+  name: docutils
+  version: 0.20.1
+  build: py311hfecb2dc_3
+  build_number: 3
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/docutils-0.20.1-py311hfecb2dc_3.conda
+  sha256: 6014cea3b085161592f94dae39625e38cc3268d1b934e1730eccc584a7a9677b
+  md5: 2ca9748cbdaa1111d20e4ce8313d2a8a
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: CC-PDDC AND BSD-3-Clause AND BSD-2-Clause AND ZPL-2.1
+  size: 920708
+  timestamp: 1701884568861
+- kind: conda
+  name: eigen
+  version: 3.4.0
+  build: h00ab1b0_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/eigen-3.4.0-h00ab1b0_0.conda
+  sha256: 53b15a98aadbe0704479bacaf7a5618fcb32d1577be320630674574241639b34
+  md5: b1b879d6d093f55dd40d58b5eb2f0699
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 1088433
+  timestamp: 1690272126173
+- kind: conda
+  name: eigen
+  version: 3.4.0
+  build: h1995070_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/eigen-3.4.0-h1995070_0.conda
+  sha256: c20b3677b16d8907343fce68e7c437184fef7f5ed0a765c104b775f8a485c5c9
+  md5: 3691ea3ff568ba38826389bafc717909
+  depends:
+  - libcxx >=15.0.7
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 1087751
+  timestamp: 1690275869049
+- kind: conda
+  name: eigen
+  version: 3.4.0
+  build: h1c7c39f_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/eigen-3.4.0-h1c7c39f_0.conda
+  sha256: 187c0677e0cdcdc39aed716687a6290dd5b7f52b49eedaef2ed76be6cd0a5a3d
+  md5: 5b2cfc277e3d42d84a2a648825761156
+  depends:
+  - libcxx >=15.0.7
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 1090184
+  timestamp: 1690272503232
+- kind: conda
+  name: eigen
+  version: 3.4.0
+  build: h2a328a1_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/eigen-3.4.0-h2a328a1_0.conda
+  sha256: f9c763805938ebaa43183b07caadce8eb3e1af8c21df8792f2793c3dd5210b4e
+  md5: 0057b28f7ed26d80bd2277a128f324b2
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 1090421
+  timestamp: 1690273745233
+- kind: conda
+  name: eigen
+  version: 3.4.0
+  build: h91493d7_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/eigen-3.4.0-h91493d7_0.conda
+  sha256: 633a6a8db1f9a010cb0619f3446fb61f62dea348b09615ffae9744ab1001c24c
+  md5: 305b3ca7023ac046b9a42a48661f6512
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 1089706
+  timestamp: 1690273089254
+- kind: conda
+  name: expat
+  version: 2.5.0
+  build: h63175ca_1
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/expat-2.5.0-h63175ca_1.conda
+  sha256: 3bcd88290cd462d5573c2923c796599d0dece2ff9d9c9d6c914d31e9c5881aaf
+  md5: 87c77fe1b445aedb5c6d207dd236fa3e
+  depends:
+  - libexpat 2.5.0 h63175ca_1
+  license: MIT
+  license_family: MIT
+  size: 226571
+  timestamp: 1680190888036
+- kind: conda
+  name: expat
+  version: 2.5.0
+  build: hb7217d7_1
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/expat-2.5.0-hb7217d7_1.conda
+  sha256: 9f06afbe4604decf6a2e8e7e87f5ca218a3e9049d57d5b3fcd538ca6240d21a0
+  md5: 624fa0dd6fdeaa650b71a62296fdfedf
+  depends:
+  - libexpat 2.5.0 hb7217d7_1
+  license: MIT
+  license_family: MIT
+  size: 117851
+  timestamp: 1680190940654
+- kind: conda
+  name: expat
+  version: 2.5.0
+  build: hcb278e6_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/expat-2.5.0-hcb278e6_1.conda
+  sha256: 36dfeb4375059b3bba75ce9b38c29c69fd257342a79e6cf20e9f25c1523f785f
+  md5: 8b9b5aca60558d02ddaa09d599e55920
+  depends:
+  - libexpat 2.5.0 hcb278e6_1
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 136778
+  timestamp: 1680190541750
+- kind: conda
+  name: expat
+  version: 2.5.0
+  build: hd600fc2_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/expat-2.5.0-hd600fc2_1.conda
+  sha256: a00bae815836f8fc73e47701c25998be81284dcefab28e002efde68e0bb7eee0
+  md5: 6dfca4be3e0080934b1105d009747e98
+  depends:
+  - libexpat 2.5.0 hd600fc2_1
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 126442
+  timestamp: 1680190687808
+- kind: conda
+  name: expat
+  version: 2.5.0
+  build: hf0c8a7f_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/expat-2.5.0-hf0c8a7f_1.conda
+  sha256: 15c04a5a690b337b50fb7550cce057d843cf94dd0109d576ec9bc3448a8571d0
+  md5: e12630038077877cbb6c7851e139c17c
+  depends:
+  - libexpat 2.5.0 hf0c8a7f_1
+  license: MIT
+  license_family: MIT
+  size: 120323
+  timestamp: 1680191057827
+- kind: conda
+  name: ffmpeg
+  version: 6.1.1
+  build: gpl_h31ea89b_104
+  build_number: 104
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ffmpeg-6.1.1-gpl_h31ea89b_104.conda
+  sha256: aa69abad947cf935ce8973687592d58c66f81c1f9634e2043cbab472d2cd78f3
+  md5: 80205476e9cbfc243e0f45369f9d347e
+  depends:
+  - aom >=3.8.1,<3.9.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - dav1d >=1.2.1,<1.2.2.0a0
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - gmp >=6.3.0,<7.0a0
+  - gnutls >=3.7.9,<3.8.0a0
+  - harfbuzz >=8.3.0,<9.0a0
+  - lame >=3.100,<3.101.0a0
+  - libass >=0.17.1,<0.17.2.0a0
+  - libcxx >=16
+  - libiconv >=1.17,<2.0a0
+  - libopenvino >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-arm-cpu-plugin >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-auto-batch-plugin >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-auto-plugin >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-hetero-plugin >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-ir-frontend >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-onnx-frontend >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-paddle-frontend >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-pytorch-frontend >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-tensorflow-frontend >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-tensorflow-lite-frontend >=2023.3.0,<2023.3.1.0a0
+  - libopus >=1.3.1,<2.0a0
+  - libvpx >=1.13.1,<1.14.0a0
+  - libxml2 >=2.12.4,<3.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - openh264 >=2.4.1,<2.4.2.0a0
+  - svt-av1 >=1.8.0,<1.8.1.0a0
+  - x264 >=1!164.3095,<1!165
+  - x265 >=3.5,<3.6.0a0
+  - xz >=5.2.6,<6.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 21451640
+  timestamp: 1706919814873
+- kind: conda
+  name: ffmpeg
+  version: 6.1.1
+  build: gpl_h73cf981_104
+  build_number: 104
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/ffmpeg-6.1.1-gpl_h73cf981_104.conda
+  sha256: b018f5d1243b2c7051913f34b009ffdd801eae6f8f06ae246087012f64117498
+  md5: 4bd5cae498e5dd672143414e2b21a5c7
+  depends:
+  - aom >=3.8.1,<3.9.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - dav1d >=1.2.1,<1.2.2.0a0
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - gmp >=6.3.0,<7.0a0
+  - gnutls >=3.7.9,<3.8.0a0
+  - harfbuzz >=8.3.0,<9.0a0
+  - lame >=3.100,<3.101.0a0
+  - libass >=0.17.1,<0.17.2.0a0
+  - libcxx >=16
+  - libiconv >=1.17,<2.0a0
+  - libopenvino >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-auto-batch-plugin >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-auto-plugin >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-hetero-plugin >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-intel-cpu-plugin >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-ir-frontend >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-onnx-frontend >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-paddle-frontend >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-pytorch-frontend >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-tensorflow-frontend >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-tensorflow-lite-frontend >=2023.3.0,<2023.3.1.0a0
+  - libopus >=1.3.1,<2.0a0
+  - libvpx >=1.13.1,<1.14.0a0
+  - libxml2 >=2.12.4,<3.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - openh264 >=2.4.1,<2.4.2.0a0
+  - svt-av1 >=1.8.0,<1.8.1.0a0
+  - x264 >=1!164.3095,<1!165
+  - x265 >=3.5,<3.6.0a0
+  - xz >=5.2.6,<6.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 9670063
+  timestamp: 1706919839093
+- kind: conda
+  name: ffmpeg
+  version: 6.1.1
+  build: gpl_h8007c5b_104
+  build_number: 104
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/ffmpeg-6.1.1-gpl_h8007c5b_104.conda
+  sha256: 94e86b86c0815d961f6a837eaa7783bf011946aaa7e8c7c1ac9417caf298f8d2
+  md5: 5d86b2425076a811f7321a97928eaccd
+  depends:
+  - aom >=3.8.1,<3.9.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - dav1d >=1.2.1,<1.2.2.0a0
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - gmp >=6.3.0,<7.0a0
+  - gnutls >=3.7.9,<3.8.0a0
+  - harfbuzz >=8.3.0,<9.0a0
+  - lame >=3.100,<3.101.0a0
+  - libass >=0.17.1,<0.17.2.0a0
+  - libgcc-ng >=12
+  - libiconv >=1.17,<2.0a0
+  - libopenvino >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-auto-batch-plugin >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-auto-plugin >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-hetero-plugin >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-intel-cpu-plugin >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-intel-gpu-plugin >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-ir-frontend >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-onnx-frontend >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-paddle-frontend >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-pytorch-frontend >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-tensorflow-frontend >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-tensorflow-lite-frontend >=2023.3.0,<2023.3.1.0a0
+  - libopus >=1.3.1,<2.0a0
+  - libstdcxx-ng >=12
+  - libva >=2.20.0,<3.0a0
+  - libvpx >=1.13.1,<1.14.0a0
+  - libxcb >=1.15,<1.16.0a0
+  - libxml2 >=2.12.4,<3.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - openh264 >=2.4.1,<2.4.2.0a0
+  - svt-av1 >=1.8.0,<1.8.1.0a0
+  - x264 >=1!164.3095,<1!165
+  - x265 >=3.5,<3.6.0a0
+  - xorg-libx11 >=1.8.7,<2.0a0
+  - xz >=5.2.6,<6.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 9779948
+  timestamp: 1706919059782
+- kind: conda
+  name: ffmpeg
+  version: 6.1.1
+  build: gpl_hb766fab_104
+  build_number: 104
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/ffmpeg-6.1.1-gpl_hb766fab_104.conda
+  sha256: 19a4d76f5e7c6120cfa81dd082021e37a233371342f30d922701c3c7518e362c
+  md5: f108e2770fbe8546b921e2a6c90576e5
+  depends:
+  - aom >=3.8.1,<3.9.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - dav1d >=1.2.1,<1.2.2.0a0
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - harfbuzz >=8.3.0,<9.0a0
+  - libiconv >=1.17,<2.0a0
+  - libopus >=1.3.1,<2.0a0
+  - libxml2 >=2.12.4,<3.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - openh264 >=2.4.1,<2.4.2.0a0
+  - svt-av1 >=1.8.0,<1.8.1.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - x264 >=1!164.3095,<1!165
+  - x265 >=3.5,<3.6.0a0
+  - xz >=5.2.6,<6.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 9695911
+  timestamp: 1706920715649
+- kind: conda
+  name: ffmpeg
+  version: 6.1.1
+  build: gpl_hd8c5532_104
+  build_number: 104
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/ffmpeg-6.1.1-gpl_hd8c5532_104.conda
+  sha256: 6cf2b6f7acc6602827cc5bebd0d15a00d707938536b18a871cad4c18d33d3aca
+  md5: e1ef2221ec735d299722003e18c7db56
+  depends:
+  - aom >=3.8.1,<3.9.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - dav1d >=1.2.1,<1.2.2.0a0
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - gmp >=6.3.0,<7.0a0
+  - gnutls >=3.7.9,<3.8.0a0
+  - harfbuzz >=8.3.0,<9.0a0
+  - lame >=3.100,<3.101.0a0
+  - libass >=0.17.1,<0.17.2.0a0
+  - libgcc-ng >=12
+  - libiconv >=1.17,<2.0a0
+  - libopenvino >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-arm-cpu-plugin >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-auto-batch-plugin >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-auto-plugin >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-hetero-plugin >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-ir-frontend >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-onnx-frontend >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-paddle-frontend >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-pytorch-frontend >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-tensorflow-frontend >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-tensorflow-lite-frontend >=2023.3.0,<2023.3.1.0a0
+  - libopus >=1.3.1,<2.0a0
+  - libstdcxx-ng >=12
+  - libvpx >=1.13.1,<1.14.0a0
+  - libxcb >=1.15,<1.16.0a0
+  - libxml2 >=2.12.4,<3.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - openh264 >=2.4.1,<2.4.2.0a0
+  - svt-av1 >=1.8.0,<1.8.1.0a0
+  - x264 >=1!164.3095,<1!165
+  - x265 >=3.5,<3.6.0a0
+  - xorg-libx11 >=1.8.7,<2.0a0
+  - xz >=5.2.6,<6.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 9352167
+  timestamp: 1706919357006
+- kind: conda
+  name: font-ttf-dejavu-sans-mono
+  version: '2.37'
+  build: hab24e00_0
+  subdir: noarch
+  noarch: generic
+  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+  sha256: 58d7f40d2940dd0a8aa28651239adbf5613254df0f75789919c4e6762054403b
+  md5: 0c96522c6bdaed4b1566d11387caaf45
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 397370
+  timestamp: 1566932522327
+- kind: conda
+  name: font-ttf-inconsolata
+  version: '3.000'
+  build: h77eed37_0
+  subdir: noarch
+  noarch: generic
+  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+  sha256: c52a29fdac682c20d252facc50f01e7c2e7ceac52aa9817aaf0bb83f7559ec5c
+  md5: 34893075a5c9e55cdafac56607368fc6
+  license: OFL-1.1
+  license_family: Other
+  size: 96530
+  timestamp: 1620479909603
+- kind: conda
+  name: font-ttf-source-code-pro
+  version: '2.038'
+  build: h77eed37_0
+  subdir: noarch
+  noarch: generic
+  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+  sha256: 00925c8c055a2275614b4d983e1df637245e19058d79fc7dd1a93b8d9fb4b139
+  md5: 4d59c254e01d9cde7957100457e2d5fb
+  license: OFL-1.1
+  license_family: Other
+  size: 700814
+  timestamp: 1620479612257
+- kind: conda
+  name: font-ttf-ubuntu
+  version: '0.83'
+  build: h77eed37_1
+  build_number: 1
+  subdir: noarch
+  noarch: generic
+  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_1.conda
+  sha256: 056c85b482d58faab5fd4670b6c1f5df0986314cca3bc831d458b22e4ef2c792
+  md5: 6185f640c43843e5ad6fd1c5372c3f80
+  license: LicenseRef-Ubuntu-Font-Licence-Version-1.0
+  license_family: Other
+  size: 1619820
+  timestamp: 1700944216729
+- kind: conda
+  name: fontconfig
+  version: 2.14.2
+  build: h14ed4e7_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.14.2-h14ed4e7_0.conda
+  sha256: 155d534c9037347ea7439a2c6da7c24ffec8e5dd278889b4c57274a1d91e0a83
+  md5: 0f69b688f52ff6da70bccb7ff7001d1d
+  depends:
+  - expat >=2.5.0,<3.0a0
+  - freetype >=2.12.1,<3.0a0
+  - libgcc-ng >=12
+  - libuuid >=2.32.1,<3.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 272010
+  timestamp: 1674828850194
+- kind: conda
+  name: fontconfig
+  version: 2.14.2
+  build: h5bb23bf_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/fontconfig-2.14.2-h5bb23bf_0.conda
+  sha256: f63e6d1d6aef8ba6de4fc54d3d7898a153479888d40ffdf2e4cfad6f92679d34
+  md5: 86cc5867dfbee4178118392bae4a3c89
+  depends:
+  - expat >=2.5.0,<3.0a0
+  - freetype >=2.12.1,<3.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 237068
+  timestamp: 1674829100063
+- kind: conda
+  name: fontconfig
+  version: 2.14.2
+  build: h82840c6_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/fontconfig-2.14.2-h82840c6_0.conda
+  sha256: 7094917fc6758186e17c61d8ee8fd2bbbe9f303b4addac61d918fa415c497e2b
+  md5: f77d47ddb6d3cc5b39b9bdf65635afbb
+  depends:
+  - expat >=2.5.0,<3.0a0
+  - freetype >=2.12.1,<3.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 237668
+  timestamp: 1674829263740
+- kind: conda
+  name: fontconfig
+  version: 2.14.2
+  build: ha9a116f_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/fontconfig-2.14.2-ha9a116f_0.conda
+  sha256: 71143b04d9beeb76264a54cb42a2953ff858a95f7383531fcb3a33ac6433e7f6
+  md5: 6d2d19ea85f9d41534cd28fdefd59a25
+  depends:
+  - expat >=2.5.0,<3.0a0
+  - freetype >=2.12.1,<3.0a0
+  - libgcc-ng >=12
+  - libuuid >=2.32.1,<3.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 280375
+  timestamp: 1674830224830
+- kind: conda
+  name: fontconfig
+  version: 2.14.2
+  build: hbde0cde_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/fontconfig-2.14.2-hbde0cde_0.conda
+  sha256: 643f2b95be68abeb130c53d543dcd0c1244bebabd58c774a21b31e4b51ac3c96
+  md5: 08767992f1a4f1336a257af1241034bd
+  depends:
+  - expat >=2.5.0,<3.0a0
+  - freetype >=2.12.1,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 190111
+  timestamp: 1674829354122
+- kind: conda
+  name: fonts-conda-ecosystem
+  version: '1'
+  build: '0'
+  subdir: noarch
+  noarch: generic
+  url: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+  sha256: a997f2f1921bb9c9d76e6fa2f6b408b7fa549edd349a77639c9fe7a23ea93e61
+  md5: fee5683a3f04bd15cbd8318b096a27ab
+  depends:
+  - fonts-conda-forge
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3667
+  timestamp: 1566974674465
+- kind: conda
+  name: fonts-conda-forge
+  version: '1'
+  build: '0'
+  subdir: noarch
+  noarch: generic
+  url: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
+  sha256: 53f23a3319466053818540bcdf2091f253cbdbab1e0e9ae7b9e509dcaa2a5e38
+  md5: f766549260d6815b0c52253f1fb1bb29
+  depends:
+  - font-ttf-dejavu-sans-mono
+  - font-ttf-inconsolata
+  - font-ttf-source-code-pro
+  - font-ttf-ubuntu
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4102
+  timestamp: 1566932280397
+- kind: conda
+  name: freeglut
+  version: 3.2.2
+  build: h63175ca_2
+  build_number: 2
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/freeglut-3.2.2-h63175ca_2.conda
+  sha256: 42fd40d97dab1adb63ff0bb001e4ed9b3eef377a2de5e572bf989c6db79262c8
+  md5: e2d290a0159d485932abed83878e6952
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 111787
+  timestamp: 1684688787619
+- kind: conda
+  name: freeglut
+  version: 3.2.2
+  build: hac7e632_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/freeglut-3.2.2-hac7e632_2.conda
+  sha256: 6dc7be5d0853ea5bcbb2b1921baf7d069605594c207e8ce36a662f447cd81a3f
+  md5: 6e553df297f6e64668efb54302e0f139
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libxcb >=1.15,<1.16.0a0
+  - xorg-libx11 >=1.8.4,<2.0a0
+  - xorg-libxau >=1.0.11,<2.0a0
+  - xorg-libxext >=1.3.4,<2.0a0
+  - xorg-libxfixes
+  - xorg-libxi
+  license: MIT
+  license_family: MIT
+  size: 142933
+  timestamp: 1684688443008
+- kind: conda
+  name: freeglut
+  version: 3.2.2
+  build: hf4b6fbe_2
+  build_number: 2
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/freeglut-3.2.2-hf4b6fbe_2.conda
+  sha256: 7765eb701b7e0644a856c962f55f241098c09e4a9bf721aad7dad6f2e2fabb50
+  md5: c604494e2f7fd2df83bd6491fdc2c6ca
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libxcb >=1.15,<1.16.0a0
+  - xorg-libx11 >=1.8.4,<2.0a0
+  - xorg-libxau >=1.0.11,<2.0a0
+  - xorg-libxext >=1.3.4,<2.0a0
+  - xorg-libxfixes
+  - xorg-libxi
+  license: MIT
+  license_family: MIT
+  size: 144350
+  timestamp: 1684688403035
+- kind: conda
+  name: freetype
+  version: 2.12.1
+  build: h267a509_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.12.1-h267a509_2.conda
+  sha256: b2e3c449ec9d907dd4656cb0dc93e140f447175b125a3824b31368b06c666bb6
+  md5: 9ae35c3d96db2c94ce0cef86efdfa2cb
+  depends:
+  - libgcc-ng >=12
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  license: GPL-2.0-only OR FTL
+  size: 634972
+  timestamp: 1694615932610
+- kind: conda
+  name: freetype
+  version: 2.12.1
+  build: h60636b9_2
+  build_number: 2
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/freetype-2.12.1-h60636b9_2.conda
+  sha256: b292cf5a25f094eeb4b66e37d99a97894aafd04a5683980852a8cbddccdc8e4e
+  md5: 25152fce119320c980e5470e64834b50
+  depends:
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  license: GPL-2.0-only OR FTL
+  size: 599300
+  timestamp: 1694616137838
+- kind: conda
+  name: freetype
+  version: 2.12.1
+  build: hadb7bae_2
+  build_number: 2
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/freetype-2.12.1-hadb7bae_2.conda
+  sha256: 791673127e037a2dc0eebe122dc4f904cb3f6e635bb888f42cbe1a76b48748d9
+  md5: e6085e516a3e304ce41a8ee08b9b89ad
+  depends:
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  license: GPL-2.0-only OR FTL
+  size: 596430
+  timestamp: 1694616332835
+- kind: conda
+  name: freetype
+  version: 2.12.1
+  build: hdaf720e_2
+  build_number: 2
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/freetype-2.12.1-hdaf720e_2.conda
+  sha256: 2c53ee8879e05e149a9e525481d36adfd660a6abda26fd731376fa64ff03e728
+  md5: 3761b23693f768dc75a8fd0a73ca053f
+  depends:
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: GPL-2.0-only OR FTL
+  size: 510306
+  timestamp: 1694616398888
+- kind: conda
+  name: freetype
+  version: 2.12.1
+  build: hf0a5ef3_2
+  build_number: 2
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/freetype-2.12.1-hf0a5ef3_2.conda
+  sha256: 7af93030f4407f076dce181062360efac2cd54dce863b5d7765287a6f5382537
+  md5: a5ab74c5bd158c3d5532b66d8d83d907
+  depends:
+  - libgcc-ng >=12
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  license: GPL-2.0-only OR FTL
+  size: 642092
+  timestamp: 1694617858496
+- kind: conda
+  name: fribidi
+  version: 1.0.10
+  build: h27ca646_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/fribidi-1.0.10-h27ca646_0.tar.bz2
+  sha256: 4b37ea851a2cf85edf0a63d2a63266847ec3dcbba4a31156d430cdd6aa811303
+  md5: c64443234ff91d70cb9c7dc926c58834
+  license: LGPL-2.1
+  size: 60255
+  timestamp: 1604417405528
+- kind: conda
+  name: fribidi
+  version: 1.0.10
+  build: h36c2ea0_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/fribidi-1.0.10-h36c2ea0_0.tar.bz2
+  sha256: 5d7b6c0ee7743ba41399e9e05a58ccc1cfc903942e49ff6f677f6e423ea7a627
+  md5: ac7bc6a654f8f41b352b38f4051135f8
+  depends:
+  - libgcc-ng >=7.5.0
+  license: LGPL-2.1
+  size: 114383
+  timestamp: 1604416621168
+- kind: conda
+  name: fribidi
+  version: 1.0.10
+  build: hb9de7d4_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/fribidi-1.0.10-hb9de7d4_0.tar.bz2
+  sha256: bcb5a40f1aaf4ea8cda2fc6b2b12aa336403772121350281ce31fd2d9d3e214e
+  md5: f6c91a43eace6fb926a8730b3b9a8a50
+  depends:
+  - libgcc-ng >=7.5.0
+  license: LGPL-2.1
+  size: 115689
+  timestamp: 1604417149643
+- kind: conda
+  name: fribidi
+  version: 1.0.10
+  build: hbcb3906_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/fribidi-1.0.10-hbcb3906_0.tar.bz2
+  sha256: 4f6db86ecc4984cd4ac88ca52030726c3cfd11a64dfb15c8602025ee3001a2b5
+  md5: f1c6b41e0f56998ecd9a3e210faa1dc0
+  license: LGPL-2.1
+  size: 65388
+  timestamp: 1604417213
+- kind: conda
+  name: gcc
+  version: 12.3.0
+  build: h8d2909c_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/gcc-12.3.0-h8d2909c_2.conda
+  sha256: 1bbf077688822993c39518056fb43d83ff0920eb42fef11e8714d2a298cc0f27
+  md5: e2f2f81f367e14ca1f77a870bda2fe59
+  depends:
+  - gcc_impl_linux-64 12.3.0.*
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27086
+  timestamp: 1694604171830
+- kind: conda
+  name: gcc
+  version: 12.3.0
+  build: hc1b51f9_2
+  build_number: 2
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc-12.3.0-hc1b51f9_2.conda
+  sha256: 36ff01aef1b38e02539fae8c4637e661f380d5ca768cf27854cbbd5b54e85441
+  md5: 97aac23de07980a315aa0133d6efa742
+  depends:
+  - gcc_impl_linux-aarch64 12.3.0.*
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27218
+  timestamp: 1694604210046
+- kind: conda
+  name: gcc_impl_linux-64
+  version: 12.3.0
+  build: he2b93b0_5
+  build_number: 5
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-12.3.0-he2b93b0_5.conda
+  sha256: a87826c55e6aa2ed5d17f267e6a583f7951658afaa4bf45cd5ba97f5583608b9
+  md5: e89827619e73df59496c708b94f6f3d5
+  depends:
+  - binutils_impl_linux-64 >=2.39
+  - libgcc-devel_linux-64 12.3.0 h8bca6fd_105
+  - libgcc-ng >=12.3.0
+  - libgomp >=12.3.0
+  - libsanitizer 12.3.0 h0f45ef3_5
+  - libstdcxx-ng >=12.3.0
+  - sysroot_linux-64
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 51856676
+  timestamp: 1706820019081
+- kind: conda
+  name: gcc_impl_linux-aarch64
+  version: 12.3.0
+  build: hcde2664_5
+  build_number: 5
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_impl_linux-aarch64-12.3.0-hcde2664_5.conda
+  sha256: c9d333af50695a002173fbfd906278b7709993139e65523c484853a70e769d06
+  md5: 07e2aacd52ad96db11f72558be9ad6ab
+  depends:
+  - binutils_impl_linux-aarch64 >=2.39
+  - libgcc-devel_linux-aarch64 12.3.0 h8b5ab12_105
+  - libgcc-ng >=12.3.0
+  - libgomp >=12.3.0
+  - libsanitizer 12.3.0 h8ebda82_5
+  - libstdcxx-ng >=12.3.0
+  - sysroot_linux-aarch64
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 47107717
+  timestamp: 1706820306980
+- kind: conda
+  name: gcc_linux-64
+  version: 12.3.0
+  build: h76fc315_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-12.3.0-h76fc315_2.conda
+  sha256: 86f6db7399ec0362e4c4025939debbfebc8ad9ccef75e3c0e4069f85b149f24d
+  md5: 11517e7b5c910c5b5d6985c0c7eb7f50
+  depends:
+  - binutils_linux-64 2.40 hbdbef99_2
+  - gcc_impl_linux-64 12.3.0.*
+  - sysroot_linux-64
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30351
+  timestamp: 1694604476800
+- kind: conda
+  name: gcc_linux-aarch64
+  version: 12.3.0
+  build: h464a8f7_2
+  build_number: 2
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_linux-aarch64-12.3.0-h464a8f7_2.conda
+  sha256: 169b506c0d74e6f4d531fd75ea7a73dbd484e55bad5674c7bc55dbfec9b7a882
+  md5: 955e5b68fde8c90f0db374f4fa8af401
+  depends:
+  - binutils_linux-aarch64 2.40 h94bbfa1_2
+  - gcc_impl_linux-aarch64 12.3.0.*
+  - sysroot_linux-aarch64
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30487
+  timestamp: 1694604559822
+- kind: conda
+  name: gdbm
+  version: '1.18'
+  build: h0a1914f_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/gdbm-1.18-h0a1914f_2.tar.bz2
+  sha256: 8b9606dc896bd9262d09ab2ef1cb55c4ee43f352473209b58b37a9289dd7b00c
+  md5: b77bc399b07a19c00fe12fdc95ee0297
+  depends:
+  - libgcc-ng >=7.5.0
+  - readline >=8.0,<9.0a0
+  license: GPL-3.0
+  license_family: GPL
+  size: 194790
+  timestamp: 1597622040785
+- kind: conda
+  name: gdbm
+  version: '1.18'
+  build: h8a0c380_2
+  build_number: 2
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/gdbm-1.18-h8a0c380_2.tar.bz2
+  sha256: babcb995c2771c5f7ea6b4dea92556fa211b06674669d8d14e5e5513ad8fcba9
+  md5: bcef512adfef490486e0ac10e24a6bff
+  depends:
+  - readline >=8.0,<9.0a0
+  license: GPL-3.0
+  license_family: GPL
+  size: 134183
+  timestamp: 1597622089595
+- kind: conda
+  name: gettext
+  version: 0.21.1
+  build: h0186832_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/gettext-0.21.1-h0186832_0.tar.bz2
+  sha256: 093b2f96dc4b48e4952ab8946facec98b34b708a056251fc19c23c3aad30039e
+  md5: 63d2ff6fddfa74e5458488fd311bf635
+  depends:
+  - libiconv >=1.17,<2.0a0
+  license: LGPL-2.1-or-later AND GPL-3.0-or-later
+  size: 4021036
+  timestamp: 1665674192347
+- kind: conda
+  name: gettext
+  version: 0.21.1
+  build: h27087fc_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/gettext-0.21.1-h27087fc_0.tar.bz2
+  sha256: 4fcfedc44e4c9a053f0416f9fc6ab6ed50644fca3a761126dbd00d09db1f546a
+  md5: 14947d8770185e5153fdd04d4673ed37
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.1-or-later AND GPL-3.0-or-later
+  size: 4320628
+  timestamp: 1665673494324
+- kind: conda
+  name: gettext
+  version: 0.21.1
+  build: h5728263_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/gettext-0.21.1-h5728263_0.tar.bz2
+  sha256: 71c75b0a4dc2cf95d2860ea0076edf9f5558baeb4dacaeecb32643b199074616
+  md5: 299d4fd6798a45337042ff5a48219e5f
+  depends:
+  - libiconv >=1.17,<2.0a0
+  license: LGPL-2.1-or-later AND GPL-3.0-or-later
+  size: 5579416
+  timestamp: 1665676022441
+- kind: conda
+  name: gettext
+  version: 0.21.1
+  build: h8a4c099_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/gettext-0.21.1-h8a4c099_0.tar.bz2
+  sha256: 915d3cd2d777b9b3fc2e87a25901b8e4a6aa1b2b33cf2ba54e9e9ed4f6b67d94
+  md5: 1e3aff29ce703d421c43f371ad676cc5
+  depends:
+  - libiconv >=1.17,<2.0a0
+  license: LGPL-2.1-or-later AND GPL-3.0-or-later
+  size: 4153781
+  timestamp: 1665674106245
+- kind: conda
+  name: gettext
+  version: 0.21.1
+  build: ha18d298_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gettext-0.21.1-ha18d298_0.tar.bz2
+  sha256: b1d8ee80b7577661a8cebdfd21dd1676ba73b676d106c458d4ecdbe4a6d9c2eb
+  md5: b109f1a4d22966793d61fd7f75b744c3
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.1-or-later AND GPL-3.0-or-later
+  size: 4671428
+  timestamp: 1665673486488
+- kind: conda
+  name: glfw
+  version: 3.3.9
+  build: h10d778d_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/glfw-3.3.9-h10d778d_0.conda
+  sha256: 9b3f8d8ff33b9689d3a26b1e1255ef2f1357319f7319ed3435124de2e1802fbb
+  md5: ed02678bc45a4ba8787ec6ba53402a2f
+  license: Zlib
+  size: 103972
+  timestamp: 1702521488886
+- kind: conda
+  name: glfw
+  version: 3.3.9
+  build: h31becfc_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/glfw-3.3.9-h31becfc_0.conda
+  sha256: 7170ac780926ed9a782b75ee3bcce48763931bb14684b7d08ef52a721ed7e8e6
+  md5: 3e229580bd30a396e5797de474b0130e
+  depends:
+  - libgcc-ng >=12
+  - xorg-libx11 >=1.8.7,<2.0a0
+  - xorg-libxcursor
+  - xorg-libxinerama >=1.1.5,<1.2.0a0
+  - xorg-libxrandr
+  license: Zlib
+  size: 130930
+  timestamp: 1702523214498
+- kind: conda
+  name: glfw
+  version: 3.3.9
+  build: h93a5062_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/glfw-3.3.9-h93a5062_0.conda
+  sha256: e35d9593ff3392d04565a6a44bfb7adc1357074af197bd0c470bfd084520255f
+  md5: 58a97fac8b80f01c8eb6108567e25d7d
+  license: Zlib
+  size: 102485
+  timestamp: 1702521314984
+- kind: conda
+  name: glfw
+  version: 3.3.9
+  build: hcfcfb64_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/glfw-3.3.9-hcfcfb64_0.conda
+  sha256: 3889c0bb9aafcba685c862accce0e641df719151f27c806f3ea465d8d5770ca4
+  md5: 3bbd2159f1ad6a42290661031148d969
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Zlib
+  size: 107154
+  timestamp: 1702521596413
+- kind: conda
+  name: glfw
+  version: 3.3.9
+  build: hd590300_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/glfw-3.3.9-hd590300_0.conda
+  sha256: 7aa72cab0063ccb205860f09be409d9e1469a179ebd7fdfbaa45ad576492dc7e
+  md5: 0bcf0fbbc357108ce6915c55c1f4b5a6
+  depends:
+  - libgcc-ng >=12
+  - xorg-libx11 >=1.8.7,<2.0a0
+  - xorg-libxcursor
+  - xorg-libxinerama >=1.1.5,<1.2.0a0
+  - xorg-libxrandr
+  license: Zlib
+  size: 128209
+  timestamp: 1702521018709
+- kind: conda
+  name: glib
+  version: 2.78.3
+  build: h12be248_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/glib-2.78.3-h12be248_0.conda
+  sha256: 1d3176b93c17a4cae930441691e18bf2824a235903895dd54c65c641f3da3e64
+  md5: a14440f1d004a2ddccd9c1354dbeffdf
+  depends:
+  - gettext >=0.21.1,<1.0a0
+  - glib-tools 2.78.3 h12be248_0
+  - libglib 2.78.3 h16e383f_0
+  - libzlib >=1.2.13,<1.3.0a0
+  - python *
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: LGPL-2.1-or-later
+  size: 506931
+  timestamp: 1702003592251
+- kind: conda
+  name: glib
+  version: 2.78.3
+  build: h9e231a4_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/glib-2.78.3-h9e231a4_0.conda
+  sha256: d30d8d81a5a153a397c5d464e7ebb3c4ed6ff8d49e0e944c0807693b9241ff67
+  md5: afccd23fd84928932e9a215cac1c0b69
+  depends:
+  - __osx >=10.9
+  - gettext >=0.21.1,<1.0a0
+  - glib-tools 2.78.3 h9e231a4_0
+  - libcxx >=16.0.6
+  - libglib 2.78.3 hb438215_0
+  - libzlib >=1.2.13,<1.3.0a0
+  - python *
+  license: LGPL-2.1-or-later
+  size: 488582
+  timestamp: 1702003388910
+- kind: conda
+  name: glib
+  version: 2.78.3
+  build: hd84c7bf_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/glib-2.78.3-hd84c7bf_0.conda
+  sha256: cc609469a4e3e36acea15641c4b99857940788474d07420877806484c9e1e4da
+  md5: fcbd147637a60cb5437020b784e595a0
+  depends:
+  - gettext >=0.21.1,<1.0a0
+  - glib-tools 2.78.3 hd84c7bf_0
+  - libgcc-ng >=12
+  - libglib 2.78.3 h311d5f7_0
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
+  - python *
+  license: LGPL-2.1-or-later
+  size: 497505
+  timestamp: 1702002962229
+- kind: conda
+  name: glib
+  version: 2.78.3
+  build: hf4d7fad_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/glib-2.78.3-hf4d7fad_0.conda
+  sha256: 99276582071aacbd482ba8e86f35ea64b3b9b81055db42081afbc1d620e13b83
+  md5: 66a951ef12f9e9d00331b83511a34d1d
+  depends:
+  - __osx >=10.9
+  - gettext >=0.21.1,<1.0a0
+  - glib-tools 2.78.3 hf4d7fad_0
+  - libcxx >=16.0.6
+  - libglib 2.78.3 h198397b_0
+  - libzlib >=1.2.13,<1.3.0a0
+  - python *
+  license: LGPL-2.1-or-later
+  size: 488601
+  timestamp: 1702003422773
+- kind: conda
+  name: glib
+  version: 2.78.3
+  build: hfc55251_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/glib-2.78.3-hfc55251_0.conda
+  sha256: 5c0630146185d806a4dd8cedd0e1983bc3a4ad8f9c0f1db8ee5fd28011396316
+  md5: e08e51acc7d1ae8dbe13255e7b4c64ac
+  depends:
+  - gettext >=0.21.1,<1.0a0
+  - glib-tools 2.78.3 hfc55251_0
+  - libgcc-ng >=12
+  - libglib 2.78.3 h783c2da_0
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
+  - python *
+  license: LGPL-2.1-or-later
+  size: 489536
+  timestamp: 1702003193690
+- kind: conda
+  name: glib-tools
+  version: 2.78.3
+  build: h12be248_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/glib-tools-2.78.3-h12be248_0.conda
+  sha256: 70078a3ec46898e857ba90840446b82a3da5cf658c56980c73ba789fd176c09c
+  md5: 03c45e65dbac2ba6c247dfd4896b664c
+  depends:
+  - libglib 2.78.3 h16e383f_0
+  - libzlib >=1.2.13,<1.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: LGPL-2.1-or-later
+  size: 144752
+  timestamp: 1702003510059
+- kind: conda
+  name: glib-tools
+  version: 2.78.3
+  build: h9e231a4_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/glib-tools-2.78.3-h9e231a4_0.conda
+  sha256: cfeb45f030ab0909242e2a13ef9bf238d0f3f92ef4e8388a98ba79a6287d077f
+  md5: 3af7028006d041755cfc3669002070ba
+  depends:
+  - __osx >=10.9
+  - libcxx >=16.0.6
+  - libglib 2.78.3 hb438215_0
+  - libzlib >=1.2.13,<1.3.0a0
+  license: LGPL-2.1-or-later
+  size: 97158
+  timestamp: 1702003287146
+- kind: conda
+  name: glib-tools
+  version: 2.78.3
+  build: hd84c7bf_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/glib-tools-2.78.3-hd84c7bf_0.conda
+  sha256: ff33d19ed7dbd1a16eefda3614a0e32e16d5cdf231642422cfa75173a8af5b5d
+  md5: 0761f585c27dbba88273065ff93ef9b8
+  depends:
+  - libgcc-ng >=12
+  - libglib 2.78.3 h311d5f7_0
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
+  license: LGPL-2.1-or-later
+  size: 123498
+  timestamp: 1702002895464
+- kind: conda
+  name: glib-tools
+  version: 2.78.3
+  build: hf4d7fad_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/glib-tools-2.78.3-hf4d7fad_0.conda
+  sha256: f0f62e9505b92c5349cbf3a7e5069f95eef99a348bb460638429dc9f9c249db0
+  md5: c424dbfa0ca7fd1405c1c6d543e6762e
+  depends:
+  - __osx >=10.9
+  - libcxx >=16.0.6
+  - libglib 2.78.3 h198397b_0
+  - libzlib >=1.2.13,<1.3.0a0
+  license: LGPL-2.1-or-later
+  size: 97399
+  timestamp: 1702003308254
+- kind: conda
+  name: glib-tools
+  version: 2.78.3
+  build: hfc55251_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.78.3-hfc55251_0.conda
+  sha256: f7f9ed77beb5d0012a501abc7711f338ab9036f8d1e0259e71e3236bfcae2ad2
+  md5: 41d2f46e0ac8372eeb959860713d9b21
+  depends:
+  - libgcc-ng >=12
+  - libglib 2.78.3 h783c2da_0
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
+  license: LGPL-2.1-or-later
+  size: 110689
+  timestamp: 1702003133163
+- kind: conda
+  name: gmp
+  version: 6.3.0
+  build: h2f0025b_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gmp-6.3.0-h2f0025b_0.conda
+  sha256: ef427440346cb6e794e6c6eb190b362aa25afb5ee91bac0567b206b1eb9bfed8
+  md5: 95351a6fb62c7d1292210f4fb761f69b
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: GPL-2.0-or-later AND LGPL-3.0-or-later
+  size: 502848
+  timestamp: 1699629968394
+- kind: conda
+  name: gmp
+  version: 6.3.0
+  build: h59595ed_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.3.0-h59595ed_0.conda
+  sha256: 2a50495b6bbbacb03107ea0b752d8358d4a40b572d124a8cade068c147f344f5
+  md5: 0e33ef437202db431aa5a928248cf2e8
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: GPL-2.0-or-later AND LGPL-3.0-or-later
+  size: 563123
+  timestamp: 1699629991732
+- kind: conda
+  name: gmp
+  version: 6.3.0
+  build: h93d8f39_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/gmp-6.3.0-h93d8f39_0.conda
+  sha256: 49443e6c41070e3967936c7f09b7686d3dd715f3351918c4edfd8072e1776013
+  md5: a4ffd4bfd88659cbecbd36b61594bf0d
+  depends:
+  - __osx >=10.9
+  - libcxx >=16.0.6
+  license: GPL-2.0-or-later AND LGPL-3.0-or-later
+  size: 520933
+  timestamp: 1699630591994
+- kind: conda
+  name: gmp
+  version: 6.3.0
+  build: h965bd2d_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/gmp-6.3.0-h965bd2d_0.conda
+  sha256: d13f09ba46dc4732a3513da76da2352b9a6b71376dc3ba8210bbf1ca0c2e51e3
+  md5: bb8f17b25ebdb9d8819c2c5bf3ccb180
+  depends:
+  - __osx >=10.9
+  - libcxx >=16.0.6
+  license: GPL-2.0-or-later AND LGPL-3.0-or-later
+  size: 446486
+  timestamp: 1699630529917
+- kind: conda
+  name: gnutls
+  version: 3.7.9
+  build: h1951705_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/gnutls-3.7.9-h1951705_0.conda
+  sha256: 6754e835f78733ddded127e0a044c476be466f67f6b5881b685730590bf8436f
+  md5: b43bd7c59ff7f7163106a58a493b51f9
+  depends:
+  - __osx >=10.9
+  - gettext >=0.21.1,<1.0a0
+  - libcxx >=16.0.6
+  - libidn2 >=2,<3.0a0
+  - libtasn1 >=4.19.0,<5.0a0
+  - nettle >=3.9.1,<3.10.0a0
+  - p11-kit >=0.24.1,<0.25.0a0
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 1980037
+  timestamp: 1701111603786
+- kind: conda
+  name: gnutls
+  version: 3.7.9
+  build: hb077bed_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/gnutls-3.7.9-hb077bed_0.conda
+  sha256: 52d824a5d2b8a5566cd469cae6ad6920469b5a15b3e0ddc609dd29151be71be2
+  md5: 33eded89024f21659b1975886a4acf70
+  depends:
+  - libgcc-ng >=12
+  - libidn2 >=2,<3.0a0
+  - libstdcxx-ng >=12
+  - libtasn1 >=4.19.0,<5.0a0
+  - nettle >=3.9.1,<3.10.0a0
+  - p11-kit >=0.24.1,<0.25.0a0
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 1974935
+  timestamp: 1701111180127
+- kind: conda
+  name: gnutls
+  version: 3.7.9
+  build: hb309da9_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gnutls-3.7.9-hb309da9_0.conda
+  sha256: 8c69e7e8073e3a9c5c4c4e0cd77e406abcf2a41b0cd3b98edbb5c6d612fd4562
+  md5: 324ec92c368d1ae5f40fe93470ec0317
+  depends:
+  - libgcc-ng >=12
+  - libidn2 >=2,<3.0a0
+  - libstdcxx-ng >=12
+  - libtasn1 >=4.19.0,<5.0a0
+  - nettle >=3.9.1,<3.10.0a0
+  - p11-kit >=0.24.1,<0.25.0a0
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 2021021
+  timestamp: 1701110217449
+- kind: conda
+  name: gnutls
+  version: 3.7.9
+  build: hd26332c_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/gnutls-3.7.9-hd26332c_0.conda
+  sha256: 800eceea27032e6d3edbb0186a76d62ed4e4c05963a7d43b35c2ced9ce27ba68
+  md5: 64af58bb3f2a635471dfbe798a1b81f5
+  depends:
+  - __osx >=10.9
+  - gettext >=0.21.1,<1.0a0
+  - libcxx >=16.0.6
+  - libidn2 >=2,<3.0a0
+  - libtasn1 >=4.19.0,<5.0a0
+  - nettle >=3.9.1,<3.10.0a0
+  - p11-kit >=0.24.1,<0.25.0a0
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 1829713
+  timestamp: 1701110534084
+- kind: conda
+  name: graphite2
+  version: 1.3.13
+  build: '1000'
+  build_number: 1000
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/graphite2-1.3.13-1000.tar.bz2
+  sha256: ed47008df8e57a83f45112985b76ac4339177486bd4d1d1b305d685a832532aa
+  md5: 8fc0e04e5c852cadf2cad68b86a906ab
+  depends:
+  - vc 14.*
+  license: LGPLv2
+  size: 99391
+  timestamp: 1545518639227
+- kind: conda
+  name: graphite2
+  version: 1.3.13
+  build: h2e338ed_1001
+  build_number: 1001
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/graphite2-1.3.13-h2e338ed_1001.tar.bz2
+  sha256: 1dba68533e6888c5e2a7e37119a77d6f388fb82721c530ba3bd28d541828e59b
+  md5: 5f6e7f98caddd0fc2d345b207531814c
+  depends:
+  - libcxx >=10.0.1
+  license: LGPLv2
+  size: 86556
+  timestamp: 1604365555365
+- kind: conda
+  name: graphite2
+  version: 1.3.13
+  build: h58526e2_1001
+  build_number: 1001
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.13-h58526e2_1001.tar.bz2
+  sha256: 65da967f3101b737b08222de6a6a14e20e480e7d523a5d1e19ace7b960b5d6b1
+  md5: 8c54672728e8ec6aa6db90cf2806d220
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  license: LGPLv2
+  size: 104701
+  timestamp: 1604365484436
+- kind: conda
+  name: graphite2
+  version: 1.3.13
+  build: h7fd3ca4_1001
+  build_number: 1001
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/graphite2-1.3.13-h7fd3ca4_1001.tar.bz2
+  sha256: 7806a4efcd9a925be89dee90ebe5c1ec5c96948183b43010b393f30d1ff0bc58
+  md5: f966693c12b9d9a1cd572b1c02e9e37a
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  license: LGPLv2
+  size: 107252
+  timestamp: 1604366132423
+- kind: conda
+  name: graphite2
+  version: 1.3.13
+  build: h9f76cd9_1001
+  build_number: 1001
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/graphite2-1.3.13-h9f76cd9_1001.tar.bz2
+  sha256: 57db1e563cdfe469cd453a2988039118e96ce4b77c9219e2f1022be0e1c2b03f
+  md5: 288b591645cb9cb9c0af7309ac1114f5
+  depends:
+  - libcxx >=11.0.0
+  license: LGPLv2
+  size: 83198
+  timestamp: 1604365687923
+- kind: conda
+  name: gst-plugins-base
+  version: 1.22.9
+  build: h001b923_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/gst-plugins-base-1.22.9-h001b923_0.conda
+  sha256: 509a67ce9ad9c6a992694a2ecfaff99a6aa9681a8ceab5dfa448b76cc686e887
+  md5: 304b9124de13767ea8c933f72f50b348
+  depends:
+  - gettext >=0.21.1,<1.0a0
+  - gstreamer 1.22.9 hb4038d2_0
+  - libglib >=2.78.3,<3.0a0
+  - libogg >=1.3.4,<1.4.0a0
+  - libvorbis >=1.3.7,<1.4.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  size: 2034401
+  timestamp: 1706155374324
+- kind: conda
+  name: gst-plugins-base
+  version: 1.22.9
+  build: h09b4b5e_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/gst-plugins-base-1.22.9-h09b4b5e_0.conda
+  sha256: 8856911ccef5b9829601b08f19c7353cd5b86c8e58e87d7eb30d0511a2e23689
+  md5: de6c7944b3378db095218f0c76f0a054
+  depends:
+  - gettext >=0.21.1,<1.0a0
+  - gstreamer 1.22.9 h551c6ff_0
+  - libcxx >=15
+  - libglib >=2.78.3,<3.0a0
+  - libogg >=1.3.4,<1.4.0a0
+  - libopus >=1.3.1,<2.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libvorbis >=1.3.7,<1.4.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  size: 1917386
+  timestamp: 1706155193009
+- kind: conda
+  name: gst-plugins-base
+  version: 1.22.9
+  build: h3fb38fc_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/gst-plugins-base-1.22.9-h3fb38fc_0.conda
+  sha256: c633c837b6e24da03129144ac1ab5940f43035a639b39bb2a1b086ea2f025e8f
+  md5: a0a4e1596c79cb67ba243e5e4dfd559f
+  depends:
+  - gettext >=0.21.1,<1.0a0
+  - gstreamer 1.22.9 hf63bbb8_0
+  - libcxx >=15
+  - libglib >=2.78.3,<3.0a0
+  - libogg >=1.3.4,<1.4.0a0
+  - libopus >=1.3.1,<2.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libvorbis >=1.3.7,<1.4.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  size: 2344738
+  timestamp: 1706155251056
+- kind: conda
+  name: gst-plugins-base
+  version: 1.22.9
+  build: h6d82d15_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gst-plugins-base-1.22.9-h6d82d15_0.conda
+  sha256: 3590c472419063398d53efe1c14342a8cb566e4caad71e30cd01b61498a1afcd
+  md5: f931eeddcd3ae8698ab520656b4509aa
+  depends:
+  - alsa-lib >=1.2.10,<1.2.11.0a0
+  - gettext >=0.21.1,<1.0a0
+  - gstreamer 1.22.9 hed71854_0
+  - libexpat >=2.5.0,<3.0a0
+  - libgcc-ng >=12
+  - libglib >=2.78.3,<3.0a0
+  - libogg >=1.3.4,<1.4.0a0
+  - libopus >=1.3.1,<2.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libstdcxx-ng >=12
+  - libvorbis >=1.3.7,<1.4.0a0
+  - libxcb >=1.15,<1.16.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - xorg-libx11 >=1.8.7,<2.0a0
+  - xorg-libxau >=1.0.11,<2.0a0
+  - xorg-libxext >=1.3.4,<2.0a0
+  - xorg-libxrender >=0.9.11,<0.10.0a0
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  size: 2667153
+  timestamp: 1706159806777
+- kind: conda
+  name: gst-plugins-base
+  version: 1.22.9
+  build: h8e1006c_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/gst-plugins-base-1.22.9-h8e1006c_0.conda
+  sha256: a4312c96a670fdbf9ff0c3efd935e42fa4b655ff33dcc52c309b76a2afaf03f0
+  md5: 614b81f8ed66c56b640faee7076ad14a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - alsa-lib >=1.2.10,<1.2.11.0a0
+  - gettext >=0.21.1,<1.0a0
+  - gstreamer 1.22.9 h98fc4e7_0
+  - libexpat >=2.5.0,<3.0a0
+  - libgcc-ng >=12
+  - libglib >=2.78.3,<3.0a0
+  - libogg >=1.3.4,<1.4.0a0
+  - libopus >=1.3.1,<2.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libstdcxx-ng >=12
+  - libvorbis >=1.3.7,<1.4.0a0
+  - libxcb >=1.15,<1.16.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - xorg-libx11 >=1.8.7,<2.0a0
+  - xorg-libxau >=1.0.11,<2.0a0
+  - xorg-libxext >=1.3.4,<2.0a0
+  - xorg-libxrender >=0.9.11,<0.10.0a0
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  size: 2709696
+  timestamp: 1706154948546
+- kind: conda
+  name: gstreamer
+  version: 1.22.9
+  build: h551c6ff_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/gstreamer-1.22.9-h551c6ff_0.conda
+  sha256: 9c4944fe57ceddaf007abe4cec9a28486186bf25535ef176f089bc6cb24efe45
+  md5: f5025efbcae14c20393d6e55eef2e1b4
+  depends:
+  - gettext >=0.21.1,<1.0a0
+  - glib >=2.78.3,<3.0a0
+  - libcxx >=15
+  - libglib >=2.78.3,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  size: 1344295
+  timestamp: 1706154905073
+- kind: conda
+  name: gstreamer
+  version: 1.22.9
+  build: h98fc4e7_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/gstreamer-1.22.9-h98fc4e7_0.conda
+  sha256: aa2395bf1790f72d2706bac77430f765ec1318ca22e60e791c13ae452c045263
+  md5: bcc7157b06fce7f5e055402a8135dfd8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - gettext >=0.21.1,<1.0a0
+  - glib >=2.78.3,<3.0a0
+  - libgcc-ng >=12
+  - libglib >=2.78.3,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  - libstdcxx-ng >=12
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  size: 1981554
+  timestamp: 1706154826325
+- kind: conda
+  name: gstreamer
+  version: 1.22.9
+  build: hb4038d2_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/gstreamer-1.22.9-hb4038d2_0.conda
+  sha256: d2ba5248e1874608e6eb4e9d8f9a6af99c8395aec88696c4bfcc077e701d88f5
+  md5: 0480eecdb44a71929d5e78bf1a8644fb
+  depends:
+  - gettext >=0.21.1,<1.0a0
+  - glib >=2.78.3,<3.0a0
+  - libglib >=2.78.3,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  size: 1930741
+  timestamp: 1706155201555
+- kind: conda
+  name: gstreamer
+  version: 1.22.9
+  build: hed71854_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gstreamer-1.22.9-hed71854_0.conda
+  sha256: 248b95cb18326001b0eccf8aaaa2bd167bab2d95fa05781744ed9bd0e38183f7
+  md5: 076c2e12d015e6b2542bd3e6d6168fee
+  depends:
+  - gettext >=0.21.1,<1.0a0
+  - glib >=2.78.3,<3.0a0
+  - libgcc-ng >=12
+  - libglib >=2.78.3,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  - libstdcxx-ng >=12
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  size: 1988942
+  timestamp: 1706157645872
+- kind: conda
+  name: gstreamer
+  version: 1.22.9
+  build: hf63bbb8_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/gstreamer-1.22.9-hf63bbb8_0.conda
+  sha256: be9d64972f997e1f865673cbb059a8c653f1fb38ff5e6c6a049699823bad0d9f
+  md5: 1581bb03c4655191284a3eab9ee8690d
+  depends:
+  - gettext >=0.21.1,<1.0a0
+  - glib >=2.78.3,<3.0a0
+  - libcxx >=15
+  - libglib >=2.78.3,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  size: 1781693
+  timestamp: 1706154946526
+- kind: conda
+  name: gxx
+  version: 12.3.0
+  build: h8d2909c_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/gxx-12.3.0-h8d2909c_2.conda
+  sha256: 5fd65768fb602fd21466831c96e7a2355a4df692507abbd481aa65a777151d85
+  md5: 673bac341be6b90ef9e8abae7e52ca46
+  depends:
+  - gcc 12.3.0.*
+  - gxx_impl_linux-64 12.3.0.*
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26539
+  timestamp: 1694604501713
+- kind: conda
+  name: gxx
+  version: 12.3.0
+  build: hc1b51f9_2
+  build_number: 2
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx-12.3.0-hc1b51f9_2.conda
+  sha256: a22b61ccc63e2e1630654f840703cef734cfcd46aece2e36c858a50a5c3e9584
+  md5: 0c8ed54684ba4ac4753d08d18f8522a4
+  depends:
+  - gcc 12.3.0.*
+  - gxx_impl_linux-aarch64 12.3.0.*
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26664
+  timestamp: 1694604587289
+- kind: conda
+  name: gxx_impl_linux-64
+  version: 12.3.0
+  build: he2b93b0_5
+  build_number: 5
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-12.3.0-he2b93b0_5.conda
+  sha256: 69371a1e8ad718b033bc1c58743a395e06ad19d08a2ff97e264ed82fd3ccbd9c
+  md5: cddba8fd94e52012abea1caad722b9c2
+  depends:
+  - gcc_impl_linux-64 12.3.0 he2b93b0_5
+  - libstdcxx-devel_linux-64 12.3.0 h8bca6fd_105
+  - sysroot_linux-64
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 12742481
+  timestamp: 1706820327015
+- kind: conda
+  name: gxx_impl_linux-aarch64
+  version: 12.3.0
+  build: hcde2664_5
+  build_number: 5
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_impl_linux-aarch64-12.3.0-hcde2664_5.conda
+  sha256: 0efcc3ecf96692c08a9158b2b28a70b13e1c0ec5f301c026a302fe47b74f8b3c
+  md5: 88d365e3c078988887fc92e58228a5b4
+  depends:
+  - gcc_impl_linux-aarch64 12.3.0 hcde2664_5
+  - libstdcxx-devel_linux-aarch64 12.3.0 h8b5ab12_105
+  - sysroot_linux-aarch64
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 11490051
+  timestamp: 1706820597770
+- kind: conda
+  name: gxx_linux-64
+  version: 12.3.0
+  build: h8a814eb_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-12.3.0-h8a814eb_2.conda
+  sha256: 9878771cf1316230150a795d213a2f1dd7dead07dc0bccafae20533d631d5e69
+  md5: f517b1525e9783849bd56a5dc45a9960
+  depends:
+  - binutils_linux-64 2.40 hbdbef99_2
+  - gcc_linux-64 12.3.0 h76fc315_2
+  - gxx_impl_linux-64 12.3.0.*
+  - sysroot_linux-64
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28640
+  timestamp: 1694604524890
+- kind: conda
+  name: gxx_linux-aarch64
+  version: 12.3.0
+  build: h21accf6_2
+  build_number: 2
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_linux-aarch64-12.3.0-h21accf6_2.conda
+  sha256: 00bb0edc85120809ef2b43cb07b49214495adb8014767d489ea0be3747a06b0c
+  md5: 17030cb823d5e2cc5e0c4461ed01b9b0
+  depends:
+  - binutils_linux-aarch64 2.40 h94bbfa1_2
+  - gcc_linux-aarch64 12.3.0 h464a8f7_2
+  - gxx_impl_linux-aarch64 12.3.0.*
+  - sysroot_linux-aarch64
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28794
+  timestamp: 1694604612545
+- kind: conda
+  name: harfbuzz
+  version: 8.3.0
+  build: h3d44ed6_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-8.3.0-h3d44ed6_0.conda
+  sha256: 4b55aea03b18a4084b750eee531ad978d4a3690f63019132c26c6ad26bbe3aed
+  md5: 5a6f6c00ef982a9bc83558d9ac8f64a0
+  depends:
+  - cairo >=1.18.0,<2.0a0
+  - freetype >=2.12.1,<3.0a0
+  - graphite2
+  - icu >=73.2,<74.0a0
+  - libgcc-ng >=12
+  - libglib >=2.78.1,<3.0a0
+  - libstdcxx-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 1547473
+  timestamp: 1699925311766
+- kind: conda
+  name: harfbuzz
+  version: 8.3.0
+  build: h7ab893a_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/harfbuzz-8.3.0-h7ab893a_0.conda
+  sha256: 5365595303d95810d10662b46f9e857cedc82757cc7b5576bda30e15d66bb3ad
+  md5: b8ef0beb91df83c5e6038c9509b9f730
+  depends:
+  - cairo >=1.18.0,<2.0a0
+  - freetype >=2.12.1,<3.0a0
+  - graphite2
+  - icu >=73.2,<74.0a0
+  - libglib >=2.78.1,<3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 1070592
+  timestamp: 1699926990335
+- kind: conda
+  name: harfbuzz
+  version: 8.3.0
+  build: h8f0ba13_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/harfbuzz-8.3.0-h8f0ba13_0.conda
+  sha256: 55e95aee9e5be7ada5a1cccedf1bb74c1362a7504cb0251fb48bcfa8bbd7cae3
+  md5: 71e7f9ba27feae122733bb9f1bfe594c
+  depends:
+  - __osx >=10.9
+  - cairo >=1.18.0,<2.0a0
+  - freetype >=2.12.1,<3.0a0
+  - graphite2
+  - icu >=73.2,<74.0a0
+  - libcxx >=16.0.6
+  - libglib >=2.78.1,<3.0a0
+  license: MIT
+  license_family: MIT
+  size: 1295036
+  timestamp: 1699925935335
+- kind: conda
+  name: harfbuzz
+  version: 8.3.0
+  build: hebeb849_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/harfbuzz-8.3.0-hebeb849_0.conda
+  sha256: f6f39bb13d0070565e8975ad5f23005ce894655422a1c50089e6d754c69be084
+  md5: 1c06a74f88f085c2af16809fe4c31b73
+  depends:
+  - cairo >=1.18.0,<2.0a0
+  - freetype >=2.12.1,<3.0a0
+  - graphite2
+  - icu >=73.2,<74.0a0
+  - libgcc-ng >=12
+  - libglib >=2.78.1,<3.0a0
+  - libstdcxx-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 1583124
+  timestamp: 1699927567410
+- kind: conda
+  name: harfbuzz
+  version: 8.3.0
+  build: hf45c392_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/harfbuzz-8.3.0-hf45c392_0.conda
+  sha256: c6ea14e4f4869bc78b27276c09832af845dfa415585362ed6064e37a1b5fe9c5
+  md5: 41d890485f909e4ecdc608741718c75e
+  depends:
+  - __osx >=10.9
+  - cairo >=1.18.0,<2.0a0
+  - freetype >=2.12.1,<3.0a0
+  - graphite2
+  - icu >=73.2,<74.0a0
+  - libcxx >=16.0.6
+  - libglib >=2.78.1,<3.0a0
+  license: MIT
+  license_family: MIT
+  size: 1342172
+  timestamp: 1699925847743
+- kind: conda
+  name: hdf5
+  version: 1.14.3
+  build: nompi_h4f84152_100
+  build_number: 100
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.3-nompi_h4f84152_100.conda
+  sha256: b814f8f9598cc6e50127533ec256725183ba69db5fd8cf5443223627f19e3e59
+  md5: d471a5c3abc984b662d9bae3bb7fd8a5
+  depends:
+  - libaec >=1.1.2,<2.0a0
+  - libcurl >=8.4.0,<9.0a0
+  - libgcc-ng >=12
+  - libgfortran-ng
+  - libgfortran5 >=12.3.0
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.2.0,<4.0a0
+  license: LicenseRef-HDF5
+  license_family: BSD
+  size: 3892189
+  timestamp: 1701791599022
+- kind: conda
+  name: hdf5
+  version: 1.14.3
+  build: nompi_h5bb55e9_100
+  build_number: 100
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-1.14.3-nompi_h5bb55e9_100.conda
+  sha256: 22331a0ac71a4dd1868f05f8197c36815a41a9f2dcfd01b73ff0d87d9e0ea087
+  md5: 120fefd1da806c4d708ecdfe31263f0c
+  depends:
+  - __osx >=10.9
+  - libaec >=1.1.2,<2.0a0
+  - libcurl >=8.4.0,<9.0a0
+  - libcxx >=16.0.6
+  - libgfortran 5.*
+  - libgfortran5 >=12.3.0
+  - libgfortran5 >=13.2.0
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.2.0,<4.0a0
+  license: LicenseRef-HDF5
+  license_family: BSD
+  size: 3454453
+  timestamp: 1701791479858
+- kind: conda
+  name: hdf5
+  version: 1.14.3
+  build: nompi_h691f4bf_100
+  build_number: 100
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/hdf5-1.14.3-nompi_h691f4bf_100.conda
+  sha256: 158dd2ab901659b47e8f7ee0ec1d9e45a1fedc4871391a44a1c8b9e8ba4c9c6b
+  md5: 8e2ac4ae815a8c9743fe37d70f48f075
+  depends:
+  - __osx >=10.9
+  - libaec >=1.1.2,<2.0a0
+  - libcurl >=8.4.0,<9.0a0
+  - libcxx >=16.0.6
+  - libgfortran 5.*
+  - libgfortran5 >=12.3.0
+  - libgfortran5 >=13.2.0
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.2.0,<4.0a0
+  license: LicenseRef-HDF5
+  license_family: BSD
+  size: 3720132
+  timestamp: 1701792909005
+- kind: conda
+  name: hdf5
+  version: 1.14.3
+  build: nompi_h73e8ff5_100
+  build_number: 100
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/hdf5-1.14.3-nompi_h73e8ff5_100.conda
+  sha256: 89bbb2c878e1b6c6073ef5f1f25eac97ed48393541a4a44a7d182da5ede3dc98
+  md5: 1e91ce0f3a914b0dab762539c0df4ff1
+  depends:
+  - libaec >=1.1.2,<2.0a0
+  - libcurl >=8.4.0,<9.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.2.0,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: LicenseRef-HDF5
+  license_family: BSD
+  size: 2045774
+  timestamp: 1701791365837
+- kind: conda
+  name: hdf5
+  version: 1.14.3
+  build: nompi_ha486f32_100
+  build_number: 100
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/hdf5-1.14.3-nompi_ha486f32_100.conda
+  sha256: 6ab7ee800d06f7dcc1fa550c44416a981e213653138eb6da325693e1bd08d918
+  md5: 87cd6b1683c0eea2ba2856700aeee2cf
+  depends:
+  - libaec >=1.1.2,<2.0a0
+  - libcurl >=8.4.0,<9.0a0
+  - libgcc-ng >=12
+  - libgfortran-ng
+  - libgfortran5 >=12.3.0
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.2.0,<4.0a0
+  license: LicenseRef-HDF5
+  license_family: BSD
+  size: 4003056
+  timestamp: 1701796880476
+- kind: conda
+  name: icu
+  version: '73.2'
+  build: h59595ed_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/icu-73.2-h59595ed_0.conda
+  sha256: e12fd90ef6601da2875ebc432452590bc82a893041473bc1c13ef29001a73ea8
+  md5: cc47e1facc155f91abd89b11e48e72ff
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 12089150
+  timestamp: 1692900650789
+- kind: conda
+  name: icu
+  version: '73.2'
+  build: h63175ca_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/icu-73.2-h63175ca_0.conda
+  sha256: 423aaa2b69d713520712f55c7c71994b7e6f967824bb39b59ad968e7b209ce8c
+  md5: 0f47d9e3192d9e09ae300da0d28e0f56
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 13422193
+  timestamp: 1692901469029
+- kind: conda
+  name: icu
+  version: '73.2'
+  build: h787c7f5_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-73.2-h787c7f5_0.conda
+  sha256: aedb9c911ede5596c87e1abd763ed940fab680d71fdb953bce8e4094119d47b3
+  md5: 9d3c29d71f28452a2e843aff8cbe09d2
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 12237094
+  timestamp: 1692900632394
+- kind: conda
+  name: icu
+  version: '73.2'
+  build: hc8870d7_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/icu-73.2-hc8870d7_0.conda
+  sha256: ff9cd0c6cd1349954c801fb443c94192b637e1b414514539f3c49c56a39f51b1
+  md5: 8521bd47c0e11c5902535bb1a17c565f
+  license: MIT
+  license_family: MIT
+  size: 11997841
+  timestamp: 1692902104771
+- kind: conda
+  name: icu
+  version: '73.2'
+  build: hf5e326d_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/icu-73.2-hf5e326d_0.conda
+  sha256: f66362dc36178ac9b7c7a9b012948a9d2d050b3debec24bbd94aadbc44854185
+  md5: 5cc301d759ec03f28328428e28f65591
+  license: MIT
+  license_family: MIT
+  size: 11787527
+  timestamp: 1692901622519
+- kind: conda
+  name: idyntree
+  version: 10.3.0
+  build: py311h5498c2b_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/idyntree-10.3.0-py311h5498c2b_0.conda
+  sha256: b5d8b91033cda66b21db480326dca32225d9b0d77cb3bf59f833a251530fbe24
+  md5: 04ace56b5141be1602bff2bae7592f8c
+  depends:
+  - assimp >=5.3.1,<5.3.2.0a0
+  - glfw >=3.3.9,<4.0a0
+  - ipopt >=3.14.14,<3.14.15.0a0
+  - irrlicht >=1.8.5,<1.9.0a0
+  - libgcc-ng >=12
+  - libosqp >=0.6.3,<0.6.4.0a0
+  - libstdcxx-ng >=12
+  - libxml2 >=2.12.5,<3.0a0
+  - numpy >=1.23.5,<2.0a0
+  - osqp-eigen >=0.8.1,<0.8.2.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2179020
+  timestamp: 1707301981890
+- kind: conda
+  name: idyntree
+  version: 10.3.0
+  build: py311h616ed6d_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/idyntree-10.3.0-py311h616ed6d_0.conda
+  sha256: fdb11ff40bde0000f8461f384638599067a7481709d92da5913a1094c69ee5ac
+  md5: a414497214fce791cb7a3f0872bceaca
+  depends:
+  - assimp >=5.3.1,<5.3.2.0a0
+  - glfw >=3.3.9,<4.0a0
+  - ipopt >=3.14.14,<3.14.15.0a0
+  - irrlicht >=1.8.5,<1.9.0a0
+  - libcxx >=16
+  - libosqp >=0.6.3,<0.6.4.0a0
+  - libxml2 >=2.12.5,<3.0a0
+  - numpy >=1.23.5,<2.0a0
+  - osqp-eigen >=0.8.1,<0.8.2.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2196029
+  timestamp: 1707302172459
+- kind: conda
+  name: idyntree
+  version: 10.3.0
+  build: py311ha38bcb2_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/idyntree-10.3.0-py311ha38bcb2_0.conda
+  sha256: ed136d7d2713f9cf31d1c73a84fc73d1779b2b313a0f748796799418f838cecb
+  md5: cd839f15eae062bb9ec10f0c6981154a
+  depends:
+  - assimp >=5.3.1,<5.3.2.0a0
+  - glfw >=3.3.9,<4.0a0
+  - ipopt >=3.14.14,<3.14.15.0a0
+  - irrlicht >=1.8.5,<1.9.0a0
+  - libcxx >=16
+  - libosqp >=0.6.3,<0.6.4.0a0
+  - libxml2 >=2.12.5,<3.0a0
+  - numpy >=1.23.5,<2.0a0
+  - osqp-eigen >=0.8.1,<0.8.2.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1987685
+  timestamp: 1707302246316
+- kind: conda
+  name: idyntree
+  version: 10.3.0
+  build: py311ha885c8a_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/idyntree-10.3.0-py311ha885c8a_0.conda
+  sha256: 8304f7f107c6365a6c3e2fb8f4c1498323e9dfe686d134f4c1de9d0de6229df7
+  md5: 320f85bdceca139481d81c12a0a42be4
+  depends:
+  - assimp >=5.3.1,<5.3.2.0a0
+  - glfw >=3.3.9,<4.0a0
+  - ipopt >=3.14.14,<3.14.15.0a0
+  - irrlicht >=1.8.5,<1.9.0a0
+  - libgcc-ng >=12
+  - libosqp >=0.6.3,<0.6.4.0a0
+  - libstdcxx-ng >=12
+  - libxml2 >=2.12.5,<3.0a0
+  - numpy >=1.23.5,<2.0a0
+  - osqp-eigen >=0.8.1,<0.8.2.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2458581
+  timestamp: 1707301878373
+- kind: conda
+  name: idyntree
+  version: 10.3.0
+  build: py311heed4631_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/idyntree-10.3.0-py311heed4631_0.conda
+  sha256: d71bf7da560428eee4382123d2653a3a0d688831ebc22ad25add4f2a99e60e79
+  md5: 66b33b2f133c6d391a0eb2b12e857222
+  depends:
+  - assimp >=5.3.1,<5.3.2.0a0
+  - glfw >=3.3.9,<4.0a0
+  - ipopt >=3.14.14,<3.14.15.0a0
+  - irrlicht >=1.8.5,<1.9.0a0
+  - libosqp >=0.6.3,<0.6.4.0a0
+  - libxml2 >=2.12.5,<3.0a0
+  - numpy >=1.23.5,<2.0a0
+  - osqp-eigen >=0.8.1,<0.8.2.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7139439
+  timestamp: 1707302571942
+- kind: conda
+  name: intel-openmp
+  version: 2024.0.0
+  build: h57928b3_49841
+  build_number: 49841
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2024.0.0-h57928b3_49841.conda
+  sha256: 6ee8eb9080bb3268654e015dd17ad79d0c1ea98b2eee6b928ecd27f01d6b38e8
+  md5: e3255c8cdaf1d52f15816d1970f9c77a
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 2325424
+  timestamp: 1706182537883
+- kind: conda
+  name: ipopt
+  version: 3.14.14
+  build: h04b96a2_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/ipopt-3.14.14-h04b96a2_1.conda
+  sha256: 196622c65a65c28781642befd098a79f3afc485ef25458faa8fa2dc8d8cc7141
+  md5: 8e82b739d2ee8eb3b83e7882c18292f3
+  depends:
+  - ampl-mp >=3.1.0,<3.2.0a0
+  - libblas >=3.9.0,<4.0a0
+  - libgcc-ng >=12
+  - libgfortran-ng
+  - libgfortran5 >=12.3.0
+  - liblapack >=3.9.0,<4.0a0
+  - libspral >=2023.9.7,<2023.9.8.0a0
+  - libstdcxx-ng >=12
+  - metis >=5.1.0,<5.1.1.0a0
+  - mumps-seq >=5.6.2,<5.6.3.0a0
+  license: EPL-1.0
+  size: 1020625
+  timestamp: 1705695208814
+- kind: conda
+  name: ipopt
+  version: 3.14.14
+  build: h09c0c07_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/ipopt-3.14.14-h09c0c07_1.conda
+  sha256: 6d9a8a848a090b2a3f56c872e8ca083650b6200618181ec2fe7db8df4aba9b67
+  md5: 500df5bafb93562771057b7093f96dc8
+  depends:
+  - ampl-mp >=3.1.0,<3.2.0a0
+  - libblas >=3.9.0,<4.0a0
+  - libcxx >=15
+  - libgfortran 5.*
+  - libgfortran5 >=12.3.0
+  - libgfortran5 >=13.2.0
+  - liblapack >=3.9.0,<4.0a0
+  - metis >=5.1.0,<5.1.1.0a0
+  - mumps-seq >=5.6.2,<5.6.3.0a0
+  license: EPL-1.0
+  size: 819742
+  timestamp: 1705695597921
+- kind: conda
+  name: ipopt
+  version: 3.14.14
+  build: h1709daf_1
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/ipopt-3.14.14-h1709daf_1.conda
+  sha256: 99889a51a5cc7d672a8173e1fcfb3ae24a1be1b8aa1bf4977551be975ca75f3b
+  md5: 372691bce000bdd78d0aab46bc9bf248
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libflang >=5.0.0,<6.0.0.a0
+  - liblapack >=3.9.0,<4.0a0
+  - metis >=5.1.0,<5.1.1.0a0
+  - mumps-seq >=5.6.2,<5.6.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: EPL-1.0
+  size: 906170
+  timestamp: 1705695938763
+- kind: conda
+  name: ipopt
+  version: 3.14.14
+  build: h64a9e3f_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/ipopt-3.14.14-h64a9e3f_1.conda
+  sha256: 96e86248a57d993653d839ee7a218f0985a505402a461d4277907c03d6f6f059
+  md5: 30ea142f63fcb2c930d40bd963e9cbdd
+  depends:
+  - ampl-mp >=3.1.0,<3.2.0a0
+  - libblas >=3.9.0,<4.0a0
+  - libgcc-ng >=12
+  - libgfortran-ng
+  - libgfortran5 >=12.3.0
+  - liblapack >=3.9.0,<4.0a0
+  - libspral >=2023.9.7,<2023.9.8.0a0
+  - libstdcxx-ng >=12
+  - metis >=5.1.0,<5.1.1.0a0
+  - mumps-seq >=5.6.2,<5.6.3.0a0
+  license: EPL-1.0
+  size: 1026626
+  timestamp: 1705695334744
+- kind: conda
+  name: ipopt
+  version: 3.14.14
+  build: h6639f4a_1
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ipopt-3.14.14-h6639f4a_1.conda
+  sha256: 28f8ebe16a0787146f81d9164878d89a29f4473aa03c8f600664e26a38a9ed39
+  md5: 7d485b84d4955e999fed77071b7114db
+  depends:
+  - ampl-mp >=3.1.0,<3.2.0a0
+  - libblas >=3.9.0,<4.0a0
+  - libcxx >=15
+  - libgfortran 5.*
+  - libgfortran5 >=12.3.0
+  - libgfortran5 >=13.2.0
+  - liblapack >=3.9.0,<4.0a0
+  - metis >=5.1.0,<5.1.1.0a0
+  - mumps-seq >=5.6.2,<5.6.3.0a0
+  license: EPL-1.0
+  size: 757806
+  timestamp: 1705695882554
+- kind: conda
+  name: irrlicht
+  version: 1.8.5
+  build: h1344824_4
+  build_number: 4
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/irrlicht-1.8.5-h1344824_4.conda
+  sha256: 9ed28603eb7d0531923b742d75559507630ad96e534533a75a5f089edecdb086
+  md5: 65a53e41b87cffb99035952d370d6791
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libcxx >=15.0.7
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - sdl >=1.2.64,<1.3.0a0
+  - xorg-libx11 >=1.8.6,<2.0a0
+  - xorg-libxext >=1.3.4,<2.0a0
+  license: Zlib
+  size: 1192357
+  timestamp: 1695760649404
+- kind: conda
+  name: irrlicht
+  version: 1.8.5
+  build: h2a6caf8_4
+  build_number: 4
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/irrlicht-1.8.5-h2a6caf8_4.conda
+  sha256: edf4c0e81350580f638307f57d22bba93e9d270f6f6bef5a3dbb1c47978885a2
+  md5: 69d9f1f029ccc7b01f9136042dbe4633
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc-ng >=12
+  - libglu
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
+  - sdl >=1.2.64,<1.3.0a0
+  - xorg-libx11 >=1.8.6,<2.0a0
+  - xorg-libxext >=1.3.4,<2.0a0
+  license: Zlib
+  size: 1950791
+  timestamp: 1695760376933
+- kind: conda
+  name: irrlicht
+  version: 1.8.5
+  build: h5bfa9a0_4
+  build_number: 4
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/irrlicht-1.8.5-h5bfa9a0_4.conda
+  sha256: d7101e0426f4a42a97adebeab203113f67ff5ab219ed7b9f71168328d338efc7
+  md5: bb0152817299dab5fe6fdd731379bad4
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libcxx >=15.0.7
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - sdl >=1.2.64,<1.3.0a0
+  - xorg-libx11 >=1.8.6,<2.0a0
+  - xorg-libxext >=1.3.4,<2.0a0
+  license: Zlib
+  size: 1361017
+  timestamp: 1695760594533
+- kind: conda
+  name: irrlicht
+  version: 1.8.5
+  build: h65f4d7e_4
+  build_number: 4
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/irrlicht-1.8.5-h65f4d7e_4.conda
+  sha256: 9c92bda25dcb6da671b8bc76bfdf1a36900a314f923aa4c0aa46fda653cde1e1
+  md5: 25c1d32ba2975b713f3cbab6f99c6776
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - sdl >=1.2.64,<1.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Zlib
+  size: 1141034
+  timestamp: 1695760782225
+- kind: conda
+  name: irrlicht
+  version: 1.8.5
+  build: h962fdfd_4
+  build_number: 4
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/irrlicht-1.8.5-h962fdfd_4.conda
+  sha256: 7bc08a000016055d2187d839bdd1418ec97e90e08e299bdcd2d2a3f38f6b47ab
+  md5: 5ff727b81165e5146845a6e53162b044
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc-ng >=12
+  - libglu
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
+  - sdl >=1.2.68,<1.3.0a0
+  - xorg-libx11 >=1.8.6,<2.0a0
+  - xorg-libxext >=1.3.4,<2.0a0
+  license: Zlib
+  size: 1907558
+  timestamp: 1695760464370
+- kind: conda
+  name: jasper
+  version: 4.2.0
+  build: h28f2b1a_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/jasper-4.2.0-h28f2b1a_0.conda
+  sha256: eb5d4f5375f7830f868482fdc7f2809941af5344c1184fb179a4954ccb34d0cc
+  md5: e9241354826dbecd9d7f4ae95d7341e1
+  depends:
+  - freeglut >=3.2.2,<4.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: JasPer-2.0
+  size: 441542
+  timestamp: 1707216567670
+- kind: conda
+  name: jasper
+  version: 4.2.0
+  build: h381c573_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/jasper-4.2.0-h381c573_0.conda
+  sha256: 1fe07acdddec181b1f75e2a903a6104a6e9aede618dc2639f9f8613464fbcba9
+  md5: aa2adc330527a025bf96cfb86b7ae553
+  depends:
+  - freeglut >=3.2.2,<4.0a0
+  - libgcc-ng >=12
+  - libglu >=9.0.0,<10.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  license: JasPer-2.0
+  size: 718821
+  timestamp: 1707216422288
+- kind: conda
+  name: jasper
+  version: 4.2.0
+  build: h6ff19ee_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/jasper-4.2.0-h6ff19ee_0.conda
+  sha256: 73403dee7eecc78d430ec371f4bbd8d8645b53ef10809c38b1835d971dbe2765
+  md5: a34e037a284f9029b962f9375e7b7770
+  depends:
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  license: JasPer-2.0
+  size: 570602
+  timestamp: 1707219763546
+- kind: conda
+  name: jasper
+  version: 4.2.0
+  build: h7c0e182_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/jasper-4.2.0-h7c0e182_0.conda
+  sha256: 319b5f6a48f0574703a129e83f0e68a1e91826c203f6298e5004e64a6f7c98ef
+  md5: 100e3e14c13a78c72c50bba021f7e88c
+  depends:
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  license: JasPer-2.0
+  size: 583986
+  timestamp: 1707216785448
+- kind: conda
+  name: jasper
+  version: 4.2.0
+  build: he6dfbbe_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/jasper-4.2.0-he6dfbbe_0.conda
+  sha256: 2c7402313dfe18027b5a04968ed61da2f5fd4db412b30473bb634d3f0fd37b3e
+  md5: ba48f3659627380d18e236312c65bd76
+  depends:
+  - freeglut >=3.2.2,<4.0a0
+  - libgcc-ng >=12
+  - libglu >=9.0.0,<10.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  license: JasPer-2.0
+  size: 676385
+  timestamp: 1707216242945
+- kind: conda
+  name: kernel-headers_linux-64
+  version: 2.6.32
+  build: he073ed8_16
+  build_number: 16
+  subdir: noarch
+  noarch: generic
+  url: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-2.6.32-he073ed8_16.conda
+  sha256: aaa8aa6dc776d734a6702032588ff3c496721da905366d91162e3654c082aef0
+  md5: 7ca122655873935e02c91279c5b03c8c
+  constrains:
+  - sysroot_linux-64 ==2.12
+  license: LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0
+  license_family: GPL
+  size: 709007
+  timestamp: 1689214970644
+- kind: conda
+  name: kernel-headers_linux-aarch64
+  version: 4.18.0
+  build: h5b4a56d_13
+  build_number: 13
+  subdir: noarch
+  noarch: generic
+  url: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-aarch64-4.18.0-h5b4a56d_13.tar.bz2
+  sha256: 14e227d98193550f9da275e58e27de104ab569849f1ce16b810fae4d7b351d49
+  md5: a9385e5b11a076c40d75915986f498d7
+  constrains:
+  - sysroot_linux-aarch64 ==2.17
+  license: LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0
+  license_family: GPL
+  size: 1163630
+  timestamp: 1635519647658
+- kind: conda
+  name: keyutils
+  version: 1.6.1
+  build: h166bdaf_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.1-h166bdaf_0.tar.bz2
+  sha256: 150c05a6e538610ca7c43beb3a40d65c90537497a4f6a5f4d15ec0451b6f5ebb
+  md5: 30186d27e2c9fa62b45fb1476b7200e3
+  depends:
+  - libgcc-ng >=10.3.0
+  license: LGPL-2.1-or-later
+  size: 117831
+  timestamp: 1646151697040
+- kind: conda
+  name: keyutils
+  version: 1.6.1
+  build: h4e544f5_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/keyutils-1.6.1-h4e544f5_0.tar.bz2
+  sha256: 6d4233d97a9b38acbb26e1268bcf8c10a8e79c2aed7e5a385ec3769967e3e65b
+  md5: 1f24853e59c68892452ef94ddd8afd4b
+  depends:
+  - libgcc-ng >=10.3.0
+  license: LGPL-2.1-or-later
+  size: 112327
+  timestamp: 1646166857935
+- kind: conda
+  name: khronos-opencl-icd-loader
+  version: 2023.04.17
+  build: h64bf75a_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/khronos-opencl-icd-loader-2023.04.17-h64bf75a_0.conda
+  sha256: aca20cb000427881e0b1eb5301568278650ca9f7b069fec0c7904cdf94b995e6
+  md5: 8c51fee1005a058dc96b1da5eba9b308
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: APACHE
+  size: 86302
+  timestamp: 1681919883423
+- kind: conda
+  name: krb5
+  version: 1.21.2
+  build: h659d440_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.2-h659d440_0.conda
+  sha256: 259bfaae731989b252b7d2228c1330ef91b641c9d68ff87dae02cbae682cb3e4
+  md5: cd95826dbd331ed1be26bdf401432844
+  depends:
+  - keyutils >=1.6.1,<2.0a0
+  - libedit >=3.1.20191231,<3.2.0a0
+  - libedit >=3.1.20191231,<4.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - openssl >=3.1.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1371181
+  timestamp: 1692097755782
+- kind: conda
+  name: krb5
+  version: 1.21.2
+  build: h92f50d5_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.21.2-h92f50d5_0.conda
+  sha256: 70bdb9b4589ec7c7d440e485ae22b5a352335ffeb91a771d4c162996c3070875
+  md5: 92f1cff174a538e0722bf2efb16fc0b2
+  depends:
+  - libcxx >=15.0.7
+  - libedit >=3.1.20191231,<3.2.0a0
+  - libedit >=3.1.20191231,<4.0a0
+  - openssl >=3.1.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1195575
+  timestamp: 1692098070699
+- kind: conda
+  name: krb5
+  version: 1.21.2
+  build: hb884880_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/krb5-1.21.2-hb884880_0.conda
+  sha256: 081ae2008a21edf57c048f331a17c65d1ccb52d6ca2f87ee031a73eff4dc0fc6
+  md5: 80505a68783f01dc8d7308c075261b2f
+  depends:
+  - libcxx >=15.0.7
+  - libedit >=3.1.20191231,<3.2.0a0
+  - libedit >=3.1.20191231,<4.0a0
+  - openssl >=3.1.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1183568
+  timestamp: 1692098004387
+- kind: conda
+  name: krb5
+  version: 1.21.2
+  build: hc419048_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/krb5-1.21.2-hc419048_0.conda
+  sha256: c3f24ead49fb7d7c29fae491bec3f090f63d77a46954eadbc4463f137e2b42cd
+  md5: 55b51af37bf6fdcfe06f140e62e8c8db
+  depends:
+  - keyutils >=1.6.1,<2.0a0
+  - libedit >=3.1.20191231,<3.2.0a0
+  - libedit >=3.1.20191231,<4.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - openssl >=3.1.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1473397
+  timestamp: 1692097651347
+- kind: conda
+  name: krb5
+  version: 1.21.2
+  build: heb0366b_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/krb5-1.21.2-heb0366b_0.conda
+  sha256: 6002adff9e3dcfc9732b861730cb9e33d45fd76b2035b2cdb4e6daacb8262c0b
+  md5: 6e8b0f22b4eef3b3cb3849bb4c3d47f9
+  depends:
+  - openssl >=3.1.2,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 710894
+  timestamp: 1692098129546
+- kind: conda
+  name: lame
+  version: '3.100'
+  build: h166bdaf_1003
+  build_number: 1003
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/lame-3.100-h166bdaf_1003.tar.bz2
+  sha256: aad2a703b9d7b038c0f745b853c6bb5f122988fe1a7a096e0e606d9cbec4eaab
+  md5: a8832b479f93521a9e7b5b743803be51
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.0-only
+  license_family: LGPL
+  size: 508258
+  timestamp: 1664996250081
+- kind: conda
+  name: lame
+  version: '3.100'
+  build: h1a8c8d9_1003
+  build_number: 1003
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/lame-3.100-h1a8c8d9_1003.tar.bz2
+  sha256: f40ce7324b2cf5338b766d4cdb8e0453e4156a4f83c2f31bbfff750785de304c
+  md5: bff0e851d66725f78dc2fd8b032ddb7e
+  license: LGPL-2.0-only
+  license_family: LGPL
+  size: 528805
+  timestamp: 1664996399305
+- kind: conda
+  name: lame
+  version: '3.100'
+  build: h4e544f5_1003
+  build_number: 1003
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/lame-3.100-h4e544f5_1003.tar.bz2
+  sha256: 2502904a42df6d94bd743f7b73915415391dd6d31d5f50cb57c0a54a108e7b0a
+  md5: ab05bcf82d8509b4243f07e93bada144
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.0-only
+  license_family: LGPL
+  size: 604863
+  timestamp: 1664997611416
+- kind: conda
+  name: lame
+  version: '3.100'
+  build: hb7f2c08_1003
+  build_number: 1003
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/lame-3.100-hb7f2c08_1003.tar.bz2
+  sha256: 0f943b08abb4c748d73207594321b53bad47eea3e7d06b6078e0f6c59ce6771e
+  md5: 3342b33c9a0921b22b767ed68ee25861
+  license: LGPL-2.0-only
+  license_family: LGPL
+  size: 542681
+  timestamp: 1664996421531
+- kind: conda
+  name: ld64
+  version: '609'
+  build: h634c8be_16
+  build_number: 16
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ld64-609-h634c8be_16.conda
+  sha256: 50c54ec77602fd553d1ca7965bb63fee0983154bbc044fe3209575881be42310
+  md5: 82582e7ed6bb5db878d4a01d9b70aad7
+  depends:
+  - ld64_osx-arm64 609 ha4bd21c_16
+  - libllvm16 >=16.0.6,<16.1.0a0
+  constrains:
+  - cctools 973.0.1.*
+  - cctools_osx-arm64 973.0.1.*
+  license: APSL-2.0
+  license_family: Other
+  size: 19326
+  timestamp: 1706798204562
+- kind: conda
+  name: ld64
+  version: '609'
+  build: ha02d983_16
+  build_number: 16
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/ld64-609-ha02d983_16.conda
+  sha256: 63cd1976379a7e0ff8b0e57b0e16b112a0077acce83af364251ab309128a227d
+  md5: 6dfb00e6cab263fe598d48df153d3288
+  depends:
+  - ld64_osx-64 609 ha20a434_16
+  - libllvm16 >=16.0.6,<16.1.0a0
+  constrains:
+  - cctools_osx-64 973.0.1.*
+  - cctools 973.0.1.*
+  license: APSL-2.0
+  license_family: Other
+  size: 19310
+  timestamp: 1706798136816
+- kind: conda
+  name: ld64_osx-64
+  version: '609'
+  build: ha20a434_16
+  build_number: 16
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/ld64_osx-64-609-ha20a434_16.conda
+  sha256: eef540c95a418169617bdda1699d8f5441f819ed673d81f363c5c728a6273749
+  md5: db19844278d11471e5f4eddf50277f4f
+  depends:
+  - libcxx
+  - libllvm16 >=16.0.6,<16.1.0a0
+  - sigtool
+  - tapi >=1100.0.11,<1101.0a0
+  constrains:
+  - cctools_osx-64 973.0.1.*
+  - cctools 973.0.1.*
+  - clang >=16.0.6,<17.0a0
+  - ld 609.*
+  license: APSL-2.0
+  license_family: Other
+  size: 1055029
+  timestamp: 1706798033425
+- kind: conda
+  name: ld64_osx-arm64
+  version: '609'
+  build: ha4bd21c_16
+  build_number: 16
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ld64_osx-arm64-609-ha4bd21c_16.conda
+  sha256: 08acf7129ec9298d78943ecc913d09d500608ae7b3920fb88ec3aa4a052759c6
+  md5: 538b338b3a9f8712915ef9149606687b
+  depends:
+  - libcxx
+  - libllvm16 >=16.0.6,<16.1.0a0
+  - sigtool
+  - tapi >=1100.0.11,<1101.0a0
+  constrains:
+  - cctools 973.0.1.*
+  - ld 609.*
+  - clang >=16.0.6,<17.0a0
+  - cctools_osx-arm64 973.0.1.*
+  license: APSL-2.0
+  license_family: Other
+  size: 1047208
+  timestamp: 1706798110129
+- kind: conda
+  name: ld_impl_linux-64
+  version: '2.40'
+  build: h41732ed_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.40-h41732ed_0.conda
+  sha256: f6cc89d887555912d6c61b295d398cff9ec982a3417d38025c45d5dd9b9e79cd
+  md5: 7aca3059a1729aa76c597603f10b0dd3
+  constrains:
+  - binutils_impl_linux-64 2.40
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 704696
+  timestamp: 1674833944779
+- kind: conda
+  name: ld_impl_linux-aarch64
+  version: '2.40'
+  build: h2d8c526_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.40-h2d8c526_0.conda
+  sha256: 1ba06e8645094b340b4aee23603a6abb1b0383788180e65f3de34e655c5f577c
+  md5: 16246d69e945d0b1969a6099e7c5d457
+  constrains:
+  - binutils_impl_linux-aarch64 2.40
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 738776
+  timestamp: 1674833843183
+- kind: conda
+  name: lerc
+  version: 4.0.0
+  build: h27087fc_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h27087fc_0.tar.bz2
+  sha256: cb55f36dcd898203927133280ae1dc643368af041a48bcf7c026acb7c47b0c12
+  md5: 76bbff344f0134279f225174e9064c8f
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: Apache-2.0
+  license_family: Apache
+  size: 281798
+  timestamp: 1657977462600
+- kind: conda
+  name: lerc
+  version: 4.0.0
+  build: h4de3ea5_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/lerc-4.0.0-h4de3ea5_0.tar.bz2
+  sha256: 2d09ef9b7796d83364957e420b41c32d94e628c3f0520b61c332518a7b5cd586
+  md5: 1a0ffc65e03ce81559dbcb0695ad1476
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: Apache-2.0
+  license_family: Apache
+  size: 262096
+  timestamp: 1657978241894
+- kind: conda
+  name: lerc
+  version: 4.0.0
+  build: h63175ca_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/lerc-4.0.0-h63175ca_0.tar.bz2
+  sha256: f4f39d7f6a2f9b407f8fb567a6c25755270421731d70f0ff331f5de4fa367488
+  md5: 1900cb3cab5055833cfddb0ba233b074
+  depends:
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30037
+  license: Apache-2.0
+  license_family: Apache
+  size: 194365
+  timestamp: 1657977692274
+- kind: conda
+  name: lerc
+  version: 4.0.0
+  build: h9a09cb3_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/lerc-4.0.0-h9a09cb3_0.tar.bz2
+  sha256: 6f068bb53dfb6147d3147d981bb851bb5477e769407ad4e6a68edf482fdcb958
+  md5: de462d5aacda3b30721b512c5da4e742
+  depends:
+  - libcxx >=13.0.1
+  license: Apache-2.0
+  license_family: Apache
+  size: 215721
+  timestamp: 1657977558796
+- kind: conda
+  name: lerc
+  version: 4.0.0
+  build: hb486fe8_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/lerc-4.0.0-hb486fe8_0.tar.bz2
+  sha256: e41790fc0f4089726369b3c7f813117bbc14b533e0ed8b94cf75aba252e82497
+  md5: f9d6a4c82889d5ecedec1d90eb673c55
+  depends:
+  - libcxx >=13.0.1
+  license: Apache-2.0
+  license_family: Apache
+  size: 290319
+  timestamp: 1657977526749
+- kind: conda
+  name: libabseil
+  version: '20230802.1'
+  build: cxx17_h048a20a_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libabseil-20230802.1-cxx17_h048a20a_0.conda
+  sha256: 05431a6adb376a865e10d4ae673399d7890083c06f61cf18edb7c6629e75f39e
+  md5: 6554f5fb47c025273268bcdb7bf3cd48
+  depends:
+  - libcxx >=15.0.7
+  constrains:
+  - __osx >=10.13
+  - libabseil-static =20230802.1=cxx17*
+  - abseil-cpp =20230802.1
+  license: Apache-2.0
+  license_family: Apache
+  size: 1148356
+  timestamp: 1695064289396
+- kind: conda
+  name: libabseil
+  version: '20230802.1'
+  build: cxx17_h13dd4ca_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20230802.1-cxx17_h13dd4ca_0.conda
+  sha256: 459a58f36607246b4483d7a370c2d9a03e7f824e79da2c6e3e9d62abf80393e7
+  md5: fb6dfadc1898666616dfda242d8aea10
+  depends:
+  - libcxx >=15.0.7
+  constrains:
+  - libabseil-static =20230802.1=cxx17*
+  - abseil-cpp =20230802.1
+  license: Apache-2.0
+  license_family: Apache
+  size: 1173407
+  timestamp: 1695064439482
+- kind: conda
+  name: libabseil
+  version: '20230802.1'
+  build: cxx17_h2f0025b_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libabseil-20230802.1-cxx17_h2f0025b_0.conda
+  sha256: 7890ac8c806e63d2acf8b6917151ad80a17c63b832bf0926723a890d9861b856
+  md5: d1d7afab9c131b52ffe11aed370d06cd
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  constrains:
+  - libabseil-static =20230802.1=cxx17*
+  - abseil-cpp =20230802.1
+  license: Apache-2.0
+  license_family: Apache
+  size: 1280284
+  timestamp: 1695064063958
+- kind: conda
+  name: libabseil
+  version: '20230802.1'
+  build: cxx17_h59595ed_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20230802.1-cxx17_h59595ed_0.conda
+  sha256: 8729021a93e67bb93b4e73ef0a132499db516accfea11561b667635bcd0507e7
+  md5: 2785ddf4cb0e7e743477991d64353947
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  constrains:
+  - abseil-cpp =20230802.1
+  - libabseil-static =20230802.1=cxx17*
+  license: Apache-2.0
+  license_family: Apache
+  size: 1263396
+  timestamp: 1695063868515
+- kind: conda
+  name: libabseil
+  version: '20230802.1'
+  build: cxx17_h63175ca_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libabseil-20230802.1-cxx17_h63175ca_0.conda
+  sha256: 8a016d49fad3d4216ce5ae4a60869b5384d31b2009e1ed9f445b6551ce7ef9e8
+  md5: 02674c18394394ee4f76cdbd1012f526
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - abseil-cpp =20230802.1
+  - libabseil-static =20230802.1=cxx17*
+  license: Apache-2.0
+  license_family: Apache
+  size: 1733638
+  timestamp: 1695064265262
+- kind: conda
+  name: libaec
+  version: 1.1.2
+  build: h13dd4ca_1
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libaec-1.1.2-h13dd4ca_1.conda
+  sha256: c9d6f01d511bd3686ce590addf829f34031b95e3feb34418496cbb45924c5d17
+  md5: b7962cdc2cedcc9f8d12928824c11fbd
+  depends:
+  - libcxx >=15.0.7
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 29002
+  timestamp: 1696474168895
+- kind: conda
+  name: libaec
+  version: 1.1.2
+  build: h2f0025b_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libaec-1.1.2-h2f0025b_1.conda
+  sha256: faf1c20e0a0f823c01913ae0243a3fc5ebe822689c95896d24f80492903b497a
+  md5: 35cdc41045e1041d7f3bf29081b3d3cb
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 35153
+  timestamp: 1696474043418
+- kind: conda
+  name: libaec
+  version: 1.1.2
+  build: h59595ed_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libaec-1.1.2-h59595ed_1.conda
+  sha256: fdde15e74dc099ab1083823ec0f615958e53d9a8fae10405af977de251668bea
+  md5: 127b0be54c1c90760d7fe02ea7a56426
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 35228
+  timestamp: 1696474021700
+- kind: conda
+  name: libaec
+  version: 1.1.2
+  build: h63175ca_1
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libaec-1.1.2-h63175ca_1.conda
+  sha256: 731dc77bce7d6425e2113b902023fba146e827cfe301bac565f92cc4e749588a
+  md5: 0b252d2bf460364bccb1523bcdbe4af6
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 33554
+  timestamp: 1696474526588
+- kind: conda
+  name: libaec
+  version: 1.1.2
+  build: he965462_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libaec-1.1.2-he965462_1.conda
+  sha256: 1b0a0b9b67e8f155ebdc7205a7421c7aff4850a740fc9f88b3fa23282c98ed72
+  md5: faa179050abc6af1385e0fe9dd074f91
+  depends:
+  - libcxx >=15.0.7
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 29027
+  timestamp: 1696474151758
+- kind: conda
+  name: libass
+  version: 0.17.1
+  build: h36b5d3b_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libass-0.17.1-h36b5d3b_1.conda
+  sha256: 49e6709371fae03e2e1ee54914e8825511a1444b8a4e649cff7ffe565a20af35
+  md5: 9dd28617627c9ae4a0783402ab53e09f
+  depends:
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - fribidi >=1.0.10,<2.0a0
+  - harfbuzz >=8.1.1,<9.0a0
+  - libexpat >=2.5.0,<3.0a0
+  - libgcc-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
+  license: ISC
+  license_family: OTHER
+  size: 133027
+  timestamp: 1693027070371
+- kind: conda
+  name: libass
+  version: 0.17.1
+  build: h80904bb_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libass-0.17.1-h80904bb_1.conda
+  sha256: f97c70aa61ecc1b43907cf0322215a58f19e0723ee67b4ebd02146da24f03976
+  md5: 9ccad0aebe916aa3715fda9eefe92584
+  depends:
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - fribidi >=1.0.10,<2.0a0
+  - harfbuzz >=8.1.1,<9.0a0
+  - libexpat >=2.5.0,<3.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  license: ISC
+  license_family: OTHER
+  size: 125235
+  timestamp: 1693027259439
+- kind: conda
+  name: libass
+  version: 0.17.1
+  build: h8fe9dca_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libass-0.17.1-h8fe9dca_1.conda
+  sha256: 1bc3e44239a11613627488b7a9b6c021ec6b52c5925abd666832db0cb2a59f05
+  md5: c306fd9cc90c0585171167d09135a827
+  depends:
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - fribidi >=1.0.10,<2.0a0
+  - harfbuzz >=8.1.1,<9.0a0
+  - libexpat >=2.5.0,<3.0a0
+  - libgcc-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
+  license: ISC
+  license_family: OTHER
+  size: 126896
+  timestamp: 1693027051367
+- kind: conda
+  name: libass
+  version: 0.17.1
+  build: hf7da4fe_1
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libass-0.17.1-hf7da4fe_1.conda
+  sha256: 31b17bebadd114c6c3e4a647245888fd83ec93533b6ee8f6bfca0bbbc3a95c35
+  md5: 53fff6fc379154382f5121325c5fe2f5
+  depends:
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - fribidi >=1.0.10,<2.0a0
+  - harfbuzz >=8.1.1,<9.0a0
+  - libexpat >=2.5.0,<3.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  license: ISC
+  license_family: OTHER
+  size: 110763
+  timestamp: 1693027364342
+- kind: conda
+  name: libblas
+  version: 3.9.0
+  build: 21_linux64_openblas
+  build_number: 21
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-21_linux64_openblas.conda
+  sha256: ebd5c91f029f779fb88a1fcbd1e499559a9c258e3674ff58a2fbb4e375ae56d9
+  md5: 0ac9f44fc096772b0aa092119b00c3ca
+  depends:
+  - libopenblas >=0.3.26,<0.3.27.0a0
+  - libopenblas >=0.3.26,<1.0a0
+  constrains:
+  - liblapacke 3.9.0 21_linux64_openblas
+  - blas * openblas
+  - libcblas 3.9.0 21_linux64_openblas
+  - liblapack 3.9.0 21_linux64_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14691
+  timestamp: 1705979549006
+- kind: conda
+  name: libblas
+  version: 3.9.0
+  build: 21_linuxaarch64_openblas
+  build_number: 21
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libblas-3.9.0-21_linuxaarch64_openblas.conda
+  sha256: 5d1dcfc2ef54ce415ffabc8e2d94d10f8a24e10096193da24b0b62dbfe35bf32
+  md5: 7358230781e5d6e76e6adacf5201bcdf
+  depends:
+  - libopenblas >=0.3.26,<0.3.27.0a0
+  - libopenblas >=0.3.26,<1.0a0
+  constrains:
+  - liblapacke 3.9.0 21_linuxaarch64_openblas
+  - liblapack 3.9.0 21_linuxaarch64_openblas
+  - blas * openblas
+  - libcblas 3.9.0 21_linuxaarch64_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14650
+  timestamp: 1705979384501
+- kind: conda
+  name: libblas
+  version: 3.9.0
+  build: 21_osx64_openblas
+  build_number: 21
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-21_osx64_openblas.conda
+  sha256: 5381eab20f4793996cf22e58461ea8a3a4dff1442bb45663b5920f2d26288688
+  md5: 23286066c595986aa0df6452a8416c08
+  depends:
+  - libopenblas >=0.3.26,<0.3.27.0a0
+  - libopenblas >=0.3.26,<1.0a0
+  constrains:
+  - libcblas 3.9.0 21_osx64_openblas
+  - liblapacke 3.9.0 21_osx64_openblas
+  - blas * openblas
+  - liblapack 3.9.0 21_osx64_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14822
+  timestamp: 1705979699547
+- kind: conda
+  name: libblas
+  version: 3.9.0
+  build: 21_osxarm64_openblas
+  build_number: 21
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-21_osxarm64_openblas.conda
+  sha256: 9a553af92af9f241457f4d14eabb872bc341cd0ddea1da6e7939e9c6a7ee1a25
+  md5: b3804f4af39eca9d77360b12811e6d1d
+  depends:
+  - libopenblas >=0.3.26,<0.3.27.0a0
+  - libopenblas >=0.3.26,<1.0a0
+  constrains:
+  - libcblas 3.9.0 21_osxarm64_openblas
+  - liblapack 3.9.0 21_osxarm64_openblas
+  - blas * openblas
+  - liblapacke 3.9.0 21_osxarm64_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14915
+  timestamp: 1705980172730
+- kind: conda
+  name: libblas
+  version: 3.9.0
+  build: 21_win64_mkl
+  build_number: 21
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-21_win64_mkl.conda
+  sha256: ad47053cee17802df875203aba191b04d97a50d820dbf75a114a50972c517334
+  md5: ebba3846d11201fe54277e4965ba5250
+  depends:
+  - mkl 2024.0.0 h66d3029_49657
+  constrains:
+  - liblapack 3.9.0 21_win64_mkl
+  - blas * mkl
+  - libcblas 3.9.0 21_win64_mkl
+  - liblapacke 3.9.0 21_win64_mkl
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5017135
+  timestamp: 1705980415163
+- kind: conda
+  name: libboost
+  version: 1.82.0
+  build: h133f18d_6
+  build_number: 6
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libboost-1.82.0-h133f18d_6.conda
+  sha256: 2683675f71adaa9bd6a4090e2b2b0c2c5ebc77869479a06e8bbab1d550e1e759
+  md5: da652516f74f12d438ae9f5d315213f9
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - icu >=73.2,<74.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  constrains:
+  - boost-cpp =1.82.0
+  license: BSL-1.0
+  size: 2724395
+  timestamp: 1696732158233
+- kind: conda
+  name: libboost
+  version: 1.82.0
+  build: h489e689_6
+  build_number: 6
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libboost-1.82.0-h489e689_6.conda
+  sha256: c5c3c5511605809d01846df7dc971b9201939a9afd352cac00126f1db1029369
+  md5: baf3cf8cf993a572454175a3adf3a149
+  depends:
+  - __osx >=10.9
+  - bzip2 >=1.0.8,<2.0a0
+  - icu >=73.2,<74.0a0
+  - libcxx >=15.0.7
+  - libzlib >=1.2.13,<1.3.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  constrains:
+  - boost-cpp =1.82.0
+  license: BSL-1.0
+  size: 1989307
+  timestamp: 1700827660694
+- kind: conda
+  name: libboost
+  version: 1.82.0
+  build: h65993cd_6
+  build_number: 6
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libboost-1.82.0-h65993cd_6.conda
+  sha256: c0a5c77b136b1b57c09e8c86f96a30ab6213f009b4e9c0f0c7ca32bbf73d4f9e
+  md5: 99ac3b41fe8ddfe92a98642b51cae768
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  constrains:
+  - boost-cpp =1.82.0
+  license: BSL-1.0
+  size: 2377315
+  timestamp: 1696733646060
+- kind: conda
+  name: libboost
+  version: 1.82.0
+  build: h6fcfa73_6
+  build_number: 6
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libboost-1.82.0-h6fcfa73_6.conda
+  sha256: c820f1ca7a2844fc5589bb101cc33188e06205ccb022051e13a6398def22e8bf
+  md5: 05c40141d4184953616797d5c3d7947f
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - icu >=73.2,<74.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  constrains:
+  - boost-cpp =1.82.0
+  license: BSL-1.0
+  size: 2616318
+  timestamp: 1696732023030
+- kind: conda
+  name: libboost
+  version: 1.82.0
+  build: h99d8d82_6
+  build_number: 6
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libboost-1.82.0-h99d8d82_6.conda
+  sha256: f23c74c2b4d7f0f5770954013beb996e8bd6bbd42eb404740afd7c0280873629
+  md5: 83899678b0f5cc84a1b8d3e766de8983
+  depends:
+  - __osx >=10.9
+  - bzip2 >=1.0.8,<2.0a0
+  - icu >=73.2,<74.0a0
+  - libcxx >=15.0.7
+  - libzlib >=1.2.13,<1.3.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  constrains:
+  - boost-cpp =1.82.0
+  license: BSL-1.0
+  size: 2008092
+  timestamp: 1700827593029
+- kind: conda
+  name: libcap
+  version: '2.69'
+  build: h0f662aa_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libcap-2.69-h0f662aa_0.conda
+  sha256: 942f9564b4228609f017b6617425d29a74c43b8a030e12239fa4458e5cb6323c
+  md5: 25cb5999faa414e5ccb2c1388f62d3d5
+  depends:
+  - attr >=2.5.1,<2.6.0a0
+  - libgcc-ng >=12
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 100582
+  timestamp: 1684162447012
+- kind: conda
+  name: libcap
+  version: '2.69'
+  build: h883460d_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libcap-2.69-h883460d_0.conda
+  sha256: c0944a372d2d2d961cb86726fad17950219f10837bed281ac22127cb3889b06d
+  md5: fd395b538afc08d28c0db275a42c8078
+  depends:
+  - attr >=2.5.1,<2.6.0a0
+  - libgcc-ng >=12
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 103105
+  timestamp: 1684162437148
+- kind: conda
+  name: libcblas
+  version: 3.9.0
+  build: 21_linux64_openblas
+  build_number: 21
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-21_linux64_openblas.conda
+  sha256: 467bbfbfe1a1aeb8b1f9f6485eedd8ed1b6318941bf3702da72336ccf4dc25a6
+  md5: 4a3816d06451c4946e2db26b86472cb6
+  depends:
+  - libblas 3.9.0 21_linux64_openblas
+  constrains:
+  - liblapacke 3.9.0 21_linux64_openblas
+  - blas * openblas
+  - liblapack 3.9.0 21_linux64_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14614
+  timestamp: 1705979564122
+- kind: conda
+  name: libcblas
+  version: 3.9.0
+  build: 21_linuxaarch64_openblas
+  build_number: 21
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libcblas-3.9.0-21_linuxaarch64_openblas.conda
+  sha256: 86224669232944141f46b41d0ba18192c7f5af9cc3133fa89694f42701fe89fd
+  md5: 7eb9aa7a90f067f8dbfede586cdc55cd
+  depends:
+  - libblas 3.9.0 21_linuxaarch64_openblas
+  constrains:
+  - liblapacke 3.9.0 21_linuxaarch64_openblas
+  - liblapack 3.9.0 21_linuxaarch64_openblas
+  - blas * openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14575
+  timestamp: 1705979392590
+- kind: conda
+  name: libcblas
+  version: 3.9.0
+  build: 21_osx64_openblas
+  build_number: 21
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.9.0-21_osx64_openblas.conda
+  sha256: e2b1455612d4cfb3ac3170f0c538516ebd0b113780ac6603338245354e1b2f02
+  md5: 7a1b54774bad723e8ba01ca48eb301b5
+  depends:
+  - libblas 3.9.0 21_osx64_openblas
+  constrains:
+  - liblapacke 3.9.0 21_osx64_openblas
+  - blas * openblas
+  - liblapack 3.9.0 21_osx64_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14715
+  timestamp: 1705979715508
+- kind: conda
+  name: libcblas
+  version: 3.9.0
+  build: 21_osxarm64_openblas
+  build_number: 21
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-21_osxarm64_openblas.conda
+  sha256: 4510e3e4824693c3f80fc54e72d81dd89acaa6e6d68cd948af0870a640ea7eeb
+  md5: 48e9d42c65ce664d8fccef2ac6af853c
+  depends:
+  - libblas 3.9.0 21_osxarm64_openblas
+  constrains:
+  - liblapack 3.9.0 21_osxarm64_openblas
+  - blas * openblas
+  - liblapacke 3.9.0 21_osxarm64_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14800
+  timestamp: 1705980195551
+- kind: conda
+  name: libcblas
+  version: 3.9.0
+  build: 21_win64_mkl
+  build_number: 21
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-21_win64_mkl.conda
+  sha256: 886505d0a4a5b508b2255991395aadecdad140719ba0d413411fec86491a9283
+  md5: 38e5ec23bc2b62f9dd971143aa9dddb7
+  depends:
+  - libblas 3.9.0 21_win64_mkl
+  constrains:
+  - liblapack 3.9.0 21_win64_mkl
+  - blas * mkl
+  - liblapacke 3.9.0 21_win64_mkl
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5017024
+  timestamp: 1705980469944
+- kind: conda
+  name: libclang
+  version: 15.0.7
+  build: default_h65c9d4d_4
+  build_number: 4
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang-15.0.7-default_h65c9d4d_4.conda
+  sha256: 5c5494f7ccc2f06cbf3ae2169f8a9f1fb523d38ecbb1041db5468dd8c5c8a1c7
+  md5: 857fa5cd2d4920120f0d413457ed28e8
+  depends:
+  - libclang13 15.0.7 default_hf5d3afd_4
+  - libgcc-ng >=12
+  - libllvm15 >=15.0.7,<15.1.0a0
+  - libstdcxx-ng >=12
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 133451
+  timestamp: 1701414768968
+- kind: conda
+  name: libclang
+  version: 15.0.7
+  build: default_h6b1ee41_4
+  build_number: 4
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libclang-15.0.7-default_h6b1ee41_4.conda
+  sha256: 7ff11065d4706777ff18041e200715e512ea7313d424b1e04204e9291f836326
+  md5: 054a23b7162cadf8c7d7d54f90948c82
+  depends:
+  - libclang13 15.0.7 default_h89cd682_4
+  - libcxx >=16.0.6
+  - libllvm15 >=15.0.7,<15.1.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 133689
+  timestamp: 1701415540597
+- kind: conda
+  name: libclang
+  version: 15.0.7
+  build: default_hb11cfb5_4
+  build_number: 4
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libclang-15.0.7-default_hb11cfb5_4.conda
+  sha256: 0b80441f222a91074d0e5edb0fbc3b1ce16ca2cdf6ab899721afdcc3a3ff6302
+  md5: c90f4cbb57839c98fef8f830e4b9972f
+  depends:
+  - libclang13 15.0.7 default_ha2b6cf4_4
+  - libgcc-ng >=12
+  - libllvm15 >=15.0.7,<15.1.0a0
+  - libstdcxx-ng >=12
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 133384
+  timestamp: 1701412265788
+- kind: conda
+  name: libclang
+  version: 15.0.7
+  build: default_hd209bcb_4
+  build_number: 4
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libclang-15.0.7-default_hd209bcb_4.conda
+  sha256: 1c8d91209aedbdb36d3ec11e840f76b5c8119a627d78f2352b81bc034894320b
+  md5: 82102386cef9ba727456b16d37882b12
+  depends:
+  - libclang13 15.0.7 default_ha49e599_4
+  - libcxx >=16.0.6
+  - libllvm15 >=15.0.7,<15.1.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 133641
+  timestamp: 1701414923949
+- kind: conda
+  name: libclang
+  version: 15.0.7
+  build: default_hde6756a_4
+  build_number: 4
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libclang-15.0.7-default_hde6756a_4.conda
+  sha256: 1083e53f51b35c7a6769fafa2e7ab5bb85f953eb288eb4a62cddd8200db7c46d
+  md5: a621ea4ac3f826d02441369e73e53800
+  depends:
+  - libclang13 15.0.7 default_h85b4d89_4
+  - libxml2 >=2.12.1,<3.0.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zstd >=1.5.5,<1.6.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 148080
+  timestamp: 1701415503085
+- kind: conda
+  name: libclang-cpp16
+  version: 16.0.6
+  build: default_h7151d67_5
+  build_number: 5
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libclang-cpp16-16.0.6-default_h7151d67_5.conda
+  sha256: b308b6faee84c4646dca87221d8a0d1e293a8b9a2a1b83a4500abcd4dd6c8eca
+  md5: 3189f83f21974fa2a9204f949d2aff18
+  depends:
+  - libcxx >=16.0.6
+  - libllvm16 >=16.0.6,<16.1.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 12713468
+  timestamp: 1706894023056
+- kind: conda
+  name: libclang-cpp16
+  version: 16.0.6
+  build: default_he012953_5
+  build_number: 5
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libclang-cpp16-16.0.6-default_he012953_5.conda
+  sha256: a6b4c11571e3c20dc0e977d9a7b1670d991ef0cf807595b857405548706853eb
+  md5: 77908ba1789d35c808eeaae28b4c9dd4
+  depends:
+  - libcxx >=16.0.6
+  - libllvm16 >=16.0.6,<16.1.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 11813500
+  timestamp: 1706893965706
+- kind: conda
+  name: libclang13
+  version: 15.0.7
+  build: default_h85b4d89_4
+  build_number: 4
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libclang13-15.0.7-default_h85b4d89_4.conda
+  sha256: 37917f88ea5beb660a86b2325b727a03db125e25182d8186921a7cc53966df9d
+  md5: c6b0181860717a08469a324c4180ff2d
+  depends:
+  - libzlib >=1.2.13,<1.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zstd >=1.5.5,<1.6.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 21902269
+  timestamp: 1701415323912
+- kind: conda
+  name: libclang13
+  version: 15.0.7
+  build: default_h89cd682_4
+  build_number: 4
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libclang13-15.0.7-default_h89cd682_4.conda
+  sha256: bb710896ffcda1f3233e94a62c84f0c31ac062e17a723b7fa034449010c5d085
+  md5: 974a771460156182b1871585cf534532
+  depends:
+  - libcxx >=16.0.6
+  - libllvm15 >=15.0.7,<15.1.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 6952807
+  timestamp: 1701415435112
+- kind: conda
+  name: libclang13
+  version: 15.0.7
+  build: default_ha2b6cf4_4
+  build_number: 4
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libclang13-15.0.7-default_ha2b6cf4_4.conda
+  sha256: e1d34d415160b69a401dc0662bf1b5378655193ed1364bf7dd14f055e76e4b60
+  md5: 898e0dd993afbed0d871b60c2eb33b83
+  depends:
+  - libgcc-ng >=12
+  - libllvm15 >=15.0.7,<15.1.0a0
+  - libstdcxx-ng >=12
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 9581845
+  timestamp: 1701412208888
+- kind: conda
+  name: libclang13
+  version: 15.0.7
+  build: default_ha49e599_4
+  build_number: 4
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libclang13-15.0.7-default_ha49e599_4.conda
+  sha256: 900b46ae1f8341d292bffff01e2d24a859b1ed4cfbece33c391a8e4fc9b0bb9c
+  md5: 16014dc4b0f3b7f6530b8f82417f0b9e
+  depends:
+  - libcxx >=16.0.6
+  - libllvm15 >=15.0.7,<15.1.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 6461212
+  timestamp: 1701414820365
+- kind: conda
+  name: libclang13
+  version: 15.0.7
+  build: default_hf5d3afd_4
+  build_number: 4
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang13-15.0.7-default_hf5d3afd_4.conda
+  sha256: 788dcd2591009a217bf9533ede002ff3bc18a23966c17e3cc7332abdb44bf795
+  md5: 9c06f18affb9c9b011b367274116b364
+  depends:
+  - libgcc-ng >=12
+  - libllvm15 >=15.0.7,<15.1.0a0
+  - libstdcxx-ng >=12
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 9440025
+  timestamp: 1701414702096
+- kind: conda
+  name: libcups
+  version: 2.3.3
+  build: h405e4a8_4
+  build_number: 4
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libcups-2.3.3-h405e4a8_4.conda
+  sha256: f9007d5ca44741de72f9d7be03e74c911b61af062ed7a3761594675f30f5890c
+  md5: d42c670b0c96c1795fd859d5e0275a55
+  depends:
+  - krb5 >=1.21.1,<1.22.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 4551247
+  timestamp: 1689195336749
+- kind: conda
+  name: libcups
+  version: 2.3.3
+  build: h4637d8d_4
+  build_number: 4
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-h4637d8d_4.conda
+  sha256: bc67b9b21078c99c6bd8595fe7e1ed6da1f721007726e717f0449de7032798c4
+  md5: d4529f4dff3057982a7617c7ac58fde3
+  depends:
+  - krb5 >=1.21.1,<1.22.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 4519402
+  timestamp: 1689195353551
+- kind: conda
+  name: libcurl
+  version: 8.5.0
+  build: h2d989ff_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.5.0-h2d989ff_0.conda
+  sha256: f1c04be217aaf161ce3c99a8d618871295b5dc1eae2f7ff7b32078af50303f5b
+  md5: f1211ed00947a84e15a964a8f459f620
+  depends:
+  - krb5 >=1.21.2,<1.22.0a0
+  - libnghttp2 >=1.58.0,<2.0a0
+  - libssh2 >=1.11.0,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.2.0,<4.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: curl
+  license_family: MIT
+  size: 350298
+  timestamp: 1701860532373
+- kind: conda
+  name: libcurl
+  version: 8.5.0
+  build: h4e8248e_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurl-8.5.0-h4e8248e_0.conda
+  sha256: 4f4f8b884927d0c6fad4a8f5d7afaf789fe4f6554448ac8b416231f2f3dc7490
+  md5: fa0f5edc06ffc25a01eed005c6dc3d8c
+  depends:
+  - krb5 >=1.21.2,<1.22.0a0
+  - libgcc-ng >=12
+  - libnghttp2 >=1.58.0,<2.0a0
+  - libssh2 >=1.11.0,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.2.0,<4.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: curl
+  license_family: MIT
+  size: 399469
+  timestamp: 1701860213311
+- kind: conda
+  name: libcurl
+  version: 8.5.0
+  build: h726d00d_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.5.0-h726d00d_0.conda
+  sha256: 7ec7e026be90da0965dfa6b92bbc905c852c13b27f3f83c47156db66ed0668f0
+  md5: 86d749e27fe00fa6b7d790a6feaa22a2
+  depends:
+  - krb5 >=1.21.2,<1.22.0a0
+  - libnghttp2 >=1.58.0,<2.0a0
+  - libssh2 >=1.11.0,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.2.0,<4.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: curl
+  license_family: MIT
+  size: 367821
+  timestamp: 1701860630644
+- kind: conda
+  name: libcurl
+  version: 8.5.0
+  build: hca28451_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.5.0-hca28451_0.conda
+  sha256: 00a6bea5ff90ca58eeb15ebc98e08ffb88bddaff27396bb62640064f59d29cf0
+  md5: 7144d5a828e2cae218e0e3c98d8a0aeb
+  depends:
+  - krb5 >=1.21.2,<1.22.0a0
+  - libgcc-ng >=12
+  - libnghttp2 >=1.58.0,<2.0a0
+  - libssh2 >=1.11.0,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.2.0,<4.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: curl
+  license_family: MIT
+  size: 389164
+  timestamp: 1701860147844
+- kind: conda
+  name: libcurl
+  version: 8.5.0
+  build: hd5e4a3a_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.5.0-hd5e4a3a_0.conda
+  sha256: 8c933416c61445ab51515a5ca8c32ddc4f83180d5dc43684e4a80915022ffe1f
+  md5: c95eb3d60266dd47b8eb864e10d6bcf3
+  depends:
+  - krb5 >=1.21.2,<1.22.0a0
+  - libssh2 >=1.11.0,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: curl
+  license_family: MIT
+  size: 323619
+  timestamp: 1701860670113
+- kind: conda
+  name: libcxx
+  version: 16.0.6
+  build: h4653b0c_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-16.0.6-h4653b0c_0.conda
+  sha256: 11d3fb51c14832d9e4f6d84080a375dec21ea8a3a381a1910e67ff9cedc20355
+  md5: 9d7d724faf0413bf1dbc5a85935700c8
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 1160232
+  timestamp: 1686896993785
+- kind: conda
+  name: libcxx
+  version: 16.0.6
+  build: hd57cbcb_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libcxx-16.0.6-hd57cbcb_0.conda
+  sha256: 9063271847cf05f3a6cc6cae3e7f0ced032ab5f3a3c9d3f943f876f39c5c2549
+  md5: 7d6972792161077908b62971802f289a
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 1142172
+  timestamp: 1686896907750
+- kind: conda
+  name: libdeflate
+  version: '1.19'
+  build: h31becfc_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libdeflate-1.19-h31becfc_0.conda
+  sha256: 77f04fced83cf1da09ffb7ef16d531ac889d944dbffe8a4dc00b61e4bae076a5
+  md5: 014e57e35f2dc95c9a12f63d4378e093
+  depends:
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 68075
+  timestamp: 1694922340786
+- kind: conda
+  name: libdeflate
+  version: '1.19'
+  build: ha4e1b8e_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libdeflate-1.19-ha4e1b8e_0.conda
+  sha256: d0f789120fedd0881b129aba9993ec5dcf0ecca67a71ea20c74394e41adcb503
+  md5: 6a45f543c2beb40023df5ee7e3cedfbd
+  license: MIT
+  license_family: MIT
+  size: 68962
+  timestamp: 1694922440450
+- kind: conda
+  name: libdeflate
+  version: '1.19'
+  build: hb547adb_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.19-hb547adb_0.conda
+  sha256: 6a3d188a6ae845a742dc85c5fb3f7eb1e252726cd74f0b8a7fa25ec09db6b87a
+  md5: f8c1eb0e99e90b55965c6558578537cc
+  license: MIT
+  license_family: MIT
+  size: 52841
+  timestamp: 1694924330786
+- kind: conda
+  name: libdeflate
+  version: '1.19'
+  build: hcfcfb64_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.19-hcfcfb64_0.conda
+  sha256: e2886a84eaa0fbeca1d1d810270f234431d190402b4a79acf756ca2d16000354
+  md5: 002b1b723b44dbd286b9e3708762433c
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 153203
+  timestamp: 1694922596415
+- kind: conda
+  name: libdeflate
+  version: '1.19'
+  build: hd590300_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.19-hd590300_0.conda
+  sha256: 985ad27aa0ba7aad82afa88a8ede6a1aacb0aaca950d710f15d85360451e72fd
+  md5: 1635570038840ee3f9c71d22aa5b8b6d
+  depends:
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 67080
+  timestamp: 1694922285678
+- kind: conda
+  name: libdrm
+  version: 2.4.114
+  build: h166bdaf_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.114-h166bdaf_0.tar.bz2
+  sha256: 9316075084ad66f9f96d31836e83303a8199eec93c12d68661e41c44eed101e3
+  md5: efb58e80f5d0179a783c4e76c3df3b9c
+  depends:
+  - libgcc-ng >=12
+  - libpciaccess >=0.17,<0.18.0a0
+  license: MIT
+  license_family: MIT
+  size: 305197
+  timestamp: 1667566354412
+- kind: conda
+  name: libedit
+  version: 3.1.20191231
+  build: h0678c8f_2
+  build_number: 2
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libedit-3.1.20191231-h0678c8f_2.tar.bz2
+  sha256: dbd3c3f2eca1d21c52e4c03b21930bbce414c4592f8ce805801575b9e9256095
+  md5: 6016a8a1d0e63cac3de2c352cd40208b
+  depends:
+  - ncurses >=6.2,<7.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 105382
+  timestamp: 1597616576726
+- kind: conda
+  name: libedit
+  version: 3.1.20191231
+  build: hc8eb9b7_2
+  build_number: 2
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20191231-hc8eb9b7_2.tar.bz2
+  sha256: 3912636197933ecfe4692634119e8644904b41a58f30cad9d1fc02f6ba4d9fca
+  md5: 30e4362988a2623e9eb34337b83e01f9
+  depends:
+  - ncurses >=6.2,<7.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 96607
+  timestamp: 1597616630749
+- kind: conda
+  name: libedit
+  version: 3.1.20191231
+  build: he28a2e2_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
+  sha256: a57d37c236d8f7c886e01656f4949d9dcca131d2a0728609c6f7fa338b65f1cf
+  md5: 4d331e44109e3f0e19b4cb8f9b82f3e1
+  depends:
+  - libgcc-ng >=7.5.0
+  - ncurses >=6.2,<7.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 123878
+  timestamp: 1597616541093
+- kind: conda
+  name: libedit
+  version: 3.1.20191231
+  build: he28a2e2_2
+  build_number: 2
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
+  sha256: debc31fb2f07ba2b0363f90e455873670734082822926ba4a9556431ec0bf36d
+  md5: 29371161d77933a54fccf1bb66b96529
+  depends:
+  - libgcc-ng >=7.5.0
+  - ncurses >=6.2,<7.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 134104
+  timestamp: 1597617110769
+- kind: conda
+  name: libev
+  version: '4.33'
+  build: h10d778d_2
+  build_number: 2
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-h10d778d_2.conda
+  sha256: 0d238488564a7992942aa165ff994eca540f687753b4f0998b29b4e4d030ff43
+  md5: 899db79329439820b7e8f8de41bca902
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 106663
+  timestamp: 1702146352558
+- kind: conda
+  name: libev
+  version: '4.33'
+  build: h31becfc_2
+  build_number: 2
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libev-4.33-h31becfc_2.conda
+  sha256: 973af77e297f1955dd1f69c2cbdc5ab9dfc88388a5576cd152cda178af0fd006
+  md5: a9a13cb143bbaa477b1ebaefbe47a302
+  depends:
+  - libgcc-ng >=12
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 115123
+  timestamp: 1702146237623
+- kind: conda
+  name: libev
+  version: '4.33'
+  build: h93a5062_2
+  build_number: 2
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h93a5062_2.conda
+  sha256: 95cecb3902fbe0399c3a7e67a5bed1db813e5ab0e22f4023a5e0f722f2cc214f
+  md5: 36d33e440c31857372a72137f78bacf5
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 107458
+  timestamp: 1702146414478
+- kind: conda
+  name: libev
+  version: '4.33'
+  build: hd590300_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
+  sha256: 1cd6048169fa0395af74ed5d8f1716e22c19a81a8a36f934c110ca3ad4dd27b4
+  md5: 172bf1cd1ff8629f2b1179945ed45055
+  depends:
+  - libgcc-ng >=12
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 112766
+  timestamp: 1702146165126
+- kind: conda
+  name: libevent
+  version: 2.1.12
+  build: h4ba1bb4_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libevent-2.1.12-h4ba1bb4_1.conda
+  sha256: 01333cc7d6e6985dd5700b43660d90e9e58049182017fd24862088ecbe1458e4
+  md5: 96ae6083cd1ac9f6bc81631ac835b317
+  depends:
+  - libgcc-ng >=12
+  - openssl >=3.1.1,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 438992
+  timestamp: 1685726046519
+- kind: conda
+  name: libevent
+  version: 2.1.12
+  build: hf998b51_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.12-hf998b51_1.conda
+  sha256: 2e14399d81fb348e9d231a82ca4d816bf855206923759b69ad006ba482764131
+  md5: a1cfcc585f0c42bf8d5546bb1dfb668d
+  depends:
+  - libgcc-ng >=12
+  - openssl >=3.1.1,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 427426
+  timestamp: 1685725977222
+- kind: conda
+  name: libexpat
+  version: 2.5.0
+  build: h63175ca_1
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.5.0-h63175ca_1.conda
+  sha256: 794b2a9be72f176a2767c299574d330ffb76b2ed75d7fd20bee3bbadce5886cf
+  md5: 636cc3cbbd2e28bcfd2f73b2044aac2c
+  constrains:
+  - expat 2.5.0.*
+  license: MIT
+  license_family: MIT
+  size: 138689
+  timestamp: 1680190844101
+- kind: conda
+  name: libexpat
+  version: 2.5.0
+  build: hb7217d7_1
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.5.0-hb7217d7_1.conda
+  sha256: 7d143a9c991579ad4207f84c632650a571c66329090daa32b3c87cf7311c3381
+  md5: 5a097ad3d17e42c148c9566280481317
+  constrains:
+  - expat 2.5.0.*
+  license: MIT
+  license_family: MIT
+  size: 63442
+  timestamp: 1680190916539
+- kind: conda
+  name: libexpat
+  version: 2.5.0
+  build: hcb278e6_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.5.0-hcb278e6_1.conda
+  sha256: 74c98a563777ae2ad71f1f74d458a8ab043cee4a513467c159ccf159d0e461f3
+  md5: 6305a3dd2752c76335295da4e581f2fd
+  depends:
+  - libgcc-ng >=12
+  constrains:
+  - expat 2.5.0.*
+  license: MIT
+  license_family: MIT
+  size: 77980
+  timestamp: 1680190528313
+- kind: conda
+  name: libexpat
+  version: 2.5.0
+  build: hd600fc2_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libexpat-2.5.0-hd600fc2_1.conda
+  sha256: b4651d196d5adb0637c678d874160a318078d963caec264bda7ac07ff6a1cbc7
+  md5: 6cd3d0a28437b3845c260f9d71d434d7
+  depends:
+  - libgcc-ng >=12
+  constrains:
+  - expat 2.5.0.*
+  license: MIT
+  license_family: MIT
+  size: 77194
+  timestamp: 1680190675750
+- kind: conda
+  name: libexpat
+  version: 2.5.0
+  build: hf0c8a7f_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.5.0-hf0c8a7f_1.conda
+  sha256: 80024bd9f44d096c4cc07fb2bac76b5f1f7553390112dab3ad6acb16a05f0b96
+  md5: 6c81cb022780ee33435cca0127dd43c9
+  constrains:
+  - expat 2.5.0.*
+  license: MIT
+  license_family: MIT
+  size: 69602
+  timestamp: 1680191040160
+- kind: conda
+  name: libffi
+  version: 3.4.2
+  build: h0d85af4_5
+  build_number: 5
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.4.2-h0d85af4_5.tar.bz2
+  sha256: 7a2d27a936ceee6942ea4d397f9c7d136f12549d86f7617e8b6bad51e01a941f
+  md5: ccb34fb14960ad8b125962d3d79b31a9
+  license: MIT
+  license_family: MIT
+  size: 51348
+  timestamp: 1636488394370
+- kind: conda
+  name: libffi
+  version: 3.4.2
+  build: h3422bc3_5
+  build_number: 5
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2
+  sha256: 41b3d13efb775e340e4dba549ab5c029611ea6918703096b2eaa9c015c0750ca
+  md5: 086914b672be056eb70fd4285b6783b6
+  license: MIT
+  license_family: MIT
+  size: 39020
+  timestamp: 1636488587153
+- kind: conda
+  name: libffi
+  version: 3.4.2
+  build: h3557bc0_5
+  build_number: 5
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libffi-3.4.2-h3557bc0_5.tar.bz2
+  sha256: 7e9258a102480757fe3faeb225a3ca04dffd10fecd2a958c65cdb4cdf75f2c3c
+  md5: dddd85f4d52121fab0a8b099c5e06501
+  depends:
+  - libgcc-ng >=9.4.0
+  license: MIT
+  license_family: MIT
+  size: 59450
+  timestamp: 1636488255090
+- kind: conda
+  name: libffi
+  version: 3.4.2
+  build: h7f98852_5
+  build_number: 5
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
+  sha256: ab6e9856c21709b7b517e940ae7028ae0737546122f83c2aa5d692860c3b149e
+  md5: d645c6d2ac96843a2bfaccd2d62b3ac3
+  depends:
+  - libgcc-ng >=9.4.0
+  license: MIT
+  license_family: MIT
+  size: 58292
+  timestamp: 1636488182923
+- kind: conda
+  name: libffi
+  version: 3.4.2
+  build: h8ffe710_5
+  build_number: 5
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libffi-3.4.2-h8ffe710_5.tar.bz2
+  sha256: 1951ab740f80660e9bc07d2ed3aefb874d78c107264fd810f24a1a6211d4b1a5
+  md5: 2c96d1b6915b408893f9472569dee135
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
+  license: MIT
+  license_family: MIT
+  size: 42063
+  timestamp: 1636489106777
+- kind: conda
+  name: libflac
+  version: 1.4.3
+  build: h2f0025b_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libflac-1.4.3-h2f0025b_0.conda
+  sha256: b54935360349d3418b0663d787f20b3cba0b7ce3fcdf3ba5e7ef02b884759049
+  md5: 520b12eab32a92e19b1f239ac545ec03
+  depends:
+  - gettext >=0.21.1,<1.0a0
+  - libgcc-ng >=12
+  - libogg 1.3.*
+  - libogg >=1.3.4,<1.4.0a0
+  - libstdcxx-ng >=12
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 371550
+  timestamp: 1687765491794
+- kind: conda
+  name: libflac
+  version: 1.4.3
+  build: h59595ed_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libflac-1.4.3-h59595ed_0.conda
+  sha256: 65908b75fa7003167b8a8f0001e11e58ed5b1ef5e98b96ab2ba66d7c1b822c7d
+  md5: ee48bf17cc83a00f59ca1494d5646869
+  depends:
+  - gettext >=0.21.1,<1.0a0
+  - libgcc-ng >=12
+  - libogg 1.3.*
+  - libogg >=1.3.4,<1.4.0a0
+  - libstdcxx-ng >=12
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 394383
+  timestamp: 1687765514062
+- kind: conda
+  name: libflang
+  version: 5.0.0
+  build: h6538335_20180525
+  build_number: 20180525
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libflang-5.0.0-h6538335_20180525.tar.bz2
+  sha256: 0b893b511190332320f4a3e3d6424fbd350271ffbca34eb25b5cd8bc451f1a05
+  md5: 9f473a344e18668e99a93f7e21a54b69
+  depends:
+  - openmp 5.0.0
+  - vc >=14,<15.0a0
+  arch: x86_64
+  platform: win
+  track_features:
+  - flang
+  license: Apache 2.0
+  size: 531143
+  timestamp: 1527899216421
+- kind: conda
+  name: libgcc-devel_linux-64
+  version: 12.3.0
+  build: h8bca6fd_105
+  build_number: 105
+  subdir: noarch
+  noarch: generic
+  url: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-12.3.0-h8bca6fd_105.conda
+  sha256: ed2dfc6d959dc27e7668439e1ad31b127b43e99f9a7e77a2d34b958fa797316b
+  md5: e12ce6b051085b8f27e239f5e5f5bce5
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 2568967
+  timestamp: 1706819720613
+- kind: conda
+  name: libgcc-devel_linux-aarch64
+  version: 12.3.0
+  build: h8b5ab12_105
+  build_number: 105
+  subdir: noarch
+  noarch: generic
+  url: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-aarch64-12.3.0-h8b5ab12_105.conda
+  sha256: 1ff691733d28774c8f56e0159fe0fffc56b1cf4de64630501f6c3b8438aa893f
+  md5: cb2ce837146463f83f24f52face3ca9d
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 285097
+  timestamp: 1706819953671
+- kind: conda
+  name: libgcc-ng
+  version: 13.2.0
+  build: h807b86a_5
+  build_number: 5
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-13.2.0-h807b86a_5.conda
+  sha256: d32f78bfaac282cfe5205f46d558704ad737b8dbf71f9227788a5ca80facaba4
+  md5: d4ff227c46917d3b4565302a2bbb276b
+  depends:
+  - _libgcc_mutex 0.1 conda_forge
+  - _openmp_mutex >=4.5
+  constrains:
+  - libgomp 13.2.0 h807b86a_5
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 770506
+  timestamp: 1706819192021
+- kind: conda
+  name: libgcc-ng
+  version: 13.2.0
+  build: hf8544c7_5
+  build_number: 5
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-13.2.0-hf8544c7_5.conda
+  sha256: 869e44e1cf329198f5bea56c146207ed639b24b6281187159435b9499ecb3959
+  md5: dee934e640275d9e74e7bbd455f25162
+  depends:
+  - _openmp_mutex >=4.5
+  constrains:
+  - libgomp 13.2.0 hf8544c7_5
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 456795
+  timestamp: 1706820691781
+- kind: conda
+  name: libgcrypt
+  version: 1.10.3
+  build: h31becfc_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcrypt-1.10.3-h31becfc_0.conda
+  sha256: 226d94d89715cbb6aae4889e9fb5045add07739afce24a2a70b95d6cbdbd7966
+  md5: 53f21c62feaeba1633038bccc6dae679
+  depends:
+  - libgcc-ng >=12
+  - libgpg-error >=1.47,<2.0a0
+  license: LGPL-2.1-or-later AND GPL-2.0-or-later
+  license_family: GPL
+  size: 619842
+  timestamp: 1701383495049
+- kind: conda
+  name: libgcrypt
+  version: 1.10.3
+  build: hd590300_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgcrypt-1.10.3-hd590300_0.conda
+  sha256: d1bd47faa29fec7288c7b212198432b07f890d3d6f646078da93b059c2e9daff
+  md5: 32d16ad533c59bb0a3c5ffaf16110829
+  depends:
+  - libgcc-ng >=12
+  - libgpg-error >=1.47,<2.0a0
+  license: LGPL-2.1-or-later AND GPL-2.0-or-later
+  license_family: GPL
+  size: 634887
+  timestamp: 1701383493365
+- kind: conda
+  name: libgfortran
+  version: 5.0.0
+  build: 13_2_0_h97931a8_3
+  build_number: 3
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-5.0.0-13_2_0_h97931a8_3.conda
+  sha256: 4874422e567b68334705c135c17e5acdca1404de8255673ce30ad3510e00be0d
+  md5: 0b6e23a012ee7a9a5f6b244f5a92c1d5
+  depends:
+  - libgfortran5 13.2.0 h2873a65_3
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 110106
+  timestamp: 1707328956438
+- kind: conda
+  name: libgfortran
+  version: 5.0.0
+  build: 13_2_0_hd922786_3
+  build_number: 3
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-5.0.0-13_2_0_hd922786_3.conda
+  sha256: 44e541b4821c96b28b27fef5630883a60ce4fee91fd9c79f25a199f8f73f337b
+  md5: 4a55d9e169114b2b90d3ec4604cd7bbf
+  depends:
+  - libgfortran5 13.2.0 hf226fd6_3
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 110233
+  timestamp: 1707330749033
+- kind: conda
+  name: libgfortran-ng
+  version: 13.2.0
+  build: h69a702a_5
+  build_number: 5
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-13.2.0-h69a702a_5.conda
+  sha256: 238c16c84124d58307376715839aa152bd4a1bf5a043052938ad6c3137d30245
+  md5: e73e9cfd1191783392131e6238bdb3e9
+  depends:
+  - libgfortran5 13.2.0 ha4646dd_5
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 23829
+  timestamp: 1706819413770
+- kind: conda
+  name: libgfortran-ng
+  version: 13.2.0
+  build: he9431aa_5
+  build_number: 5
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-ng-13.2.0-he9431aa_5.conda
+  sha256: a7e5d1ac34118a4fad8286050af0146226d2fb2bd63e7a1066dc4dae7ba42daa
+  md5: fab7c6a8c84492e18cbe578820e97a56
+  depends:
+  - libgfortran5 13.2.0 h582850c_5
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 23994
+  timestamp: 1706820985230
+- kind: conda
+  name: libgfortran5
+  version: 13.2.0
+  build: h2873a65_3
+  build_number: 3
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-13.2.0-h2873a65_3.conda
+  sha256: da3db4b947e30aec7596a3ef92200d17e774cccbbf7efc47802529a4ca5ca31b
+  md5: e4fb4d23ec2870ff3c40d10afe305aec
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 13_2_0_*_3
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1571379
+  timestamp: 1707328880361
+- kind: conda
+  name: libgfortran5
+  version: 13.2.0
+  build: h582850c_5
+  build_number: 5
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-13.2.0-h582850c_5.conda
+  sha256: f778346e85eb19bca36d1a5c8cddf8e089dcd6799b8f3e1b3f2d5a3157920827
+  md5: 547486aac825d236de3beecb927b389c
+  depends:
+  - libgcc-ng >=13.2.0
+  constrains:
+  - libgfortran-ng 13.2.0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1082835
+  timestamp: 1706820715400
+- kind: conda
+  name: libgfortran5
+  version: 13.2.0
+  build: ha4646dd_5
+  build_number: 5
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-13.2.0-ha4646dd_5.conda
+  sha256: ba8d94e8493222ce155bb264d9de4200e41498a458e866fedf444de809bde8b6
+  md5: 7a6bd7a12a4bd359e2afe6c0fa1acace
+  depends:
+  - libgcc-ng >=13.2.0
+  constrains:
+  - libgfortran-ng 13.2.0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1442769
+  timestamp: 1706819209473
+- kind: conda
+  name: libgfortran5
+  version: 13.2.0
+  build: hf226fd6_3
+  build_number: 3
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-13.2.0-hf226fd6_3.conda
+  sha256: bafc679eedb468a86aa4636061c55966186399ee0a04b605920d208d97ac579a
+  md5: 66ac81d54e95c534ae488726c1f698ea
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 13_2_0_*_3
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 997381
+  timestamp: 1707330687590
+- kind: conda
+  name: libglib
+  version: 2.78.3
+  build: h16e383f_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libglib-2.78.3-h16e383f_0.conda
+  sha256: 33527a11321609064c649682e709ebede86e24f1264dac1d018aaa00fb3b90bf
+  md5: c295badd19494ac8476b36e9e9e47ace
+  depends:
+  - gettext >=0.21.1,<1.0a0
+  - libffi >=3.4,<4.0a0
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - pcre2 >=10.42,<10.43.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - glib 2.78.3 *_0
+  license: LGPL-2.1-or-later
+  size: 2620918
+  timestamp: 1702003409384
+- kind: conda
+  name: libglib
+  version: 2.78.3
+  build: h198397b_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libglib-2.78.3-h198397b_0.conda
+  sha256: 90e58879873b05617e0678ecfbf47bc740c1a2ed7840b8f7cd1241813b9037db
+  md5: e18624e441743b0d744116885b70f092
+  depends:
+  - __osx >=10.9
+  - gettext >=0.21.1,<1.0a0
+  - libcxx >=16.0.6
+  - libffi >=3.4,<4.0a0
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - pcre2 >=10.42,<10.43.0a0
+  constrains:
+  - glib 2.78.3 *_0
+  license: LGPL-2.1-or-later
+  size: 2489079
+  timestamp: 1702003188907
+- kind: conda
+  name: libglib
+  version: 2.78.3
+  build: h311d5f7_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libglib-2.78.3-h311d5f7_0.conda
+  sha256: 4e400e259c42abf2850c660d2f484630f60d71be1aa66f4c6e43effed68d6961
+  md5: 09e44253dee99895f02cfad44dd8fea4
+  depends:
+  - gettext >=0.21.1,<1.0a0
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=12
+  - libiconv >=1.17,<2.0a0
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
+  - pcre2 >=10.42,<10.43.0a0
+  constrains:
+  - glib 2.78.3 *_0
+  license: LGPL-2.1-or-later
+  size: 2780828
+  timestamp: 1702002826554
+- kind: conda
+  name: libglib
+  version: 2.78.3
+  build: h783c2da_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.78.3-h783c2da_0.conda
+  sha256: b1b594294a0fe4c9a51596ef027efed9268d60827e8ae61fb7545c521a631e33
+  md5: 9bd06b12bbfa6fd1740fd23af4b0f0c7
+  depends:
+  - gettext >=0.21.1,<1.0a0
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=12
+  - libiconv >=1.17,<2.0a0
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
+  - pcre2 >=10.42,<10.43.0a0
+  constrains:
+  - glib 2.78.3 *_0
+  license: LGPL-2.1-or-later
+  size: 2696351
+  timestamp: 1702003069863
+- kind: conda
+  name: libglib
+  version: 2.78.3
+  build: hb438215_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libglib-2.78.3-hb438215_0.conda
+  sha256: f26afb1003e810e768138b0c849e9408c0ae8635062aeaf7abae381903a84e53
+  md5: 8c98b7018b434236e2c0f14d7cf3c113
+  depends:
+  - __osx >=10.9
+  - gettext >=0.21.1,<1.0a0
+  - libcxx >=16.0.6
+  - libffi >=3.4,<4.0a0
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - pcre2 >=10.42,<10.43.0a0
+  constrains:
+  - glib 2.78.3 *_0
+  license: LGPL-2.1-or-later
+  size: 2452441
+  timestamp: 1702003179895
+- kind: conda
+  name: libglu
+  version: 9.0.0
+  build: hac7e632_1003
+  build_number: 1003
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libglu-9.0.0-hac7e632_1003.conda
+  sha256: 8368435c41105dc3e1c02896a02ecaa21b77d0b0d67fc8b06a16ba885c86f917
+  md5: 50c389a09b6b7babaef531eb7cb5e0ca
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libxcb >=1.15,<1.16.0a0
+  - xorg-libx11 >=1.8.6,<2.0a0
+  - xorg-libxext >=1.3.4,<2.0a0
+  - xorg-xextproto >=7.3.0,<8.0a0
+  license: SGI-2
+  size: 331249
+  timestamp: 1694431884320
+- kind: conda
+  name: libglu
+  version: 9.0.0
+  build: hf4b6fbe_1003
+  build_number: 1003
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libglu-9.0.0-hf4b6fbe_1003.conda
+  sha256: fdb8b42c6e2ad5c70d7f05c4f4d87d20fa38468146e61ddf66cc42fdc5e99ef7
+  md5: 815755517215132a05c485e748449a38
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libxcb >=1.15,<1.16.0a0
+  - xorg-libx11 >=1.8.6,<2.0a0
+  - xorg-libxau >=1.0.11,<2.0a0
+  - xorg-libxext >=1.3.4,<2.0a0
+  - xorg-xextproto >=7.3.0,<8.0a0
+  license: SGI-2
+  size: 317590
+  timestamp: 1694431968293
+- kind: conda
+  name: libgomp
+  version: 13.2.0
+  build: h807b86a_5
+  build_number: 5
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgomp-13.2.0-h807b86a_5.conda
+  sha256: 0d3d4b1b0134283ea02d58e8eb5accf3655464cf7159abf098cc694002f8d34e
+  md5: d211c42b9ce49aee3734fdc828731689
+  depends:
+  - _libgcc_mutex 0.1 conda_forge
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 419751
+  timestamp: 1706819107383
+- kind: conda
+  name: libgomp
+  version: 13.2.0
+  build: hf8544c7_5
+  build_number: 5
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-13.2.0-hf8544c7_5.conda
+  sha256: a98d4f242a351feb7983a28e7d6a0ca51da764c6233ea3dfc776975a3aba8a01
+  md5: 379be2f115ffb73860e4e260dd2170b7
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 423091
+  timestamp: 1706820564165
+- kind: conda
+  name: libgpg-error
+  version: '1.47'
+  build: h5ce24db_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgpg-error-1.47-h5ce24db_0.conda
+  sha256: 9cd58f2dc22bbcf485384f751369f6354b66e99d41daa3806cec1353fa321c31
+  md5: 95141e9738caf37c637ed073e79840f9
+  depends:
+  - gettext >=0.21.1,<1.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: GPL-2.0-only
+  license_family: GPL
+  size: 272783
+  timestamp: 1686979747950
+- kind: conda
+  name: libgpg-error
+  version: '1.47'
+  build: h71f35ed_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgpg-error-1.47-h71f35ed_0.conda
+  sha256: 0306b3c2d65863048983a50bd8b86f6f26e457ef55d1da745a5796af25093f5a
+  md5: c2097d0b46367996f09b4e8e4920384a
+  depends:
+  - gettext >=0.21.1,<1.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: GPL-2.0-only
+  license_family: GPL
+  size: 260794
+  timestamp: 1686979818648
+- kind: conda
+  name: libhwloc
+  version: 2.9.3
+  build: default_h24e0189_1009
+  build_number: 1009
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libhwloc-2.9.3-default_h24e0189_1009.conda
+  sha256: a9fc54b481d0477cdf5700d702d44fc04fe00ffe63fc253aa0c6d2944abe8f3f
+  md5: 22fcbfd2a4cdf941b074a00b773b43dd
+  depends:
+  - __osx >=10.9
+  - libcxx >=16.0.6
+  - libxml2 >=2.11.5,<3.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2555838
+  timestamp: 1699473547291
+- kind: conda
+  name: libhwloc
+  version: 2.9.3
+  build: default_h4394839_1009
+  build_number: 1009
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libhwloc-2.9.3-default_h4394839_1009.conda
+  sha256: b9a0574f8919f3943a4f5c81d2d40da94913afcbe02098685abce001a526141c
+  md5: 8c30d3b6ed7c46fce04cc623d83b6c22
+  depends:
+  - __osx >=10.9
+  - libcxx >=16.0.6
+  - libxml2 >=2.11.5,<3.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2530597
+  timestamp: 1699473469798
+- kind: conda
+  name: libhwloc
+  version: 2.9.3
+  build: default_h554bfaf_1009
+  build_number: 1009
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.9.3-default_h554bfaf_1009.conda
+  sha256: 6950fee24766d03406e0f6f965262a5d98829c71eed8d1004f313892423b559b
+  md5: f36ddc11ca46958197a45effdd286e45
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libxml2 >=2.11.5,<3.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2615665
+  timestamp: 1694532603730
+- kind: conda
+  name: libhwloc
+  version: 2.9.3
+  build: default_haede6df_1009
+  build_number: 1009
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.9.3-default_haede6df_1009.conda
+  sha256: 2e8c4bb7173f281a8e13f333a23c9fb7a1c86d342d7dccdd74f2eb583ddde450
+  md5: 87da045f6d26ce9fe20ad76a18f6a18a
+  depends:
+  - libxml2 >=2.11.5,<3.0.0a0
+  - pthreads-win32
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2578462
+  timestamp: 1694533393675
+- kind: conda
+  name: libhwloc
+  version: 2.9.3
+  build: default_hda148da_1009
+  build_number: 1009
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libhwloc-2.9.3-default_hda148da_1009.conda
+  sha256: 7eaf20be9a5a21bcc8ca3d6a9cddffb78f70ba9314e9149ac9add1b28dce5973
+  md5: 28766712d1b5eeb1d20b3e45facf3a72
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libxml2 >=2.11.5,<3.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2625499
+  timestamp: 1694532579760
+- kind: conda
+  name: libi2c
+  version: '4.3'
+  build: hcb278e6_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libi2c-4.3-hcb278e6_2.conda
+  sha256: 2b68ba469f267e7fc61fd41c22e9db16fd2bacf9039351a5f3a2572213d3184e
+  md5: 49280d75f186fd9121d19b9e2fe79def
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: LGPL-2.1-or-later
+  size: 18647
+  timestamp: 1681566579190
+- kind: conda
+  name: libi2c
+  version: '4.3'
+  build: hd600fc2_2
+  build_number: 2
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libi2c-4.3-hd600fc2_2.conda
+  sha256: 3355e3534d91067c6333d6379df13f9ff9635e661c541c65e12ed1b90cb3f239
+  md5: fa802d6ae1d5f9b37b86f4c2999caf8c
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: LGPL-2.1-or-later
+  size: 19075
+  timestamp: 1681566640303
+- kind: conda
+  name: libiconv
+  version: '1.17'
+  build: h0d3ecfb_2
+  build_number: 2
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.17-h0d3ecfb_2.conda
+  sha256: bc7de5097b97bcafcf7deaaed505f7ce02f648aac8eccc0d5a47cc599a1d0304
+  md5: 69bda57310071cf6d2b86caf11573d2d
+  license: LGPL-2.1-only
+  size: 676469
+  timestamp: 1702682458114
+- kind: conda
+  name: libiconv
+  version: '1.17'
+  build: h31becfc_2
+  build_number: 2
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libiconv-1.17-h31becfc_2.conda
+  sha256: a30e09d089cb75a0d5b8e5c354694c1317da98261185ed65aa3793e741060614
+  md5: 9a8eb13f14de7d761555a98712e6df65
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.1-only
+  size: 705787
+  timestamp: 1702684557134
+- kind: conda
+  name: libiconv
+  version: '1.17'
+  build: hcfcfb64_2
+  build_number: 2
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.17-hcfcfb64_2.conda
+  sha256: 5f844dd19b046d43174ad80c6ea75b5d504020e3b63cfbc4ace97b8730d35c7b
+  md5: e1eb10b1cca179f2baa3601e4efc8712
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: LGPL-2.1-only
+  size: 636146
+  timestamp: 1702682547199
+- kind: conda
+  name: libiconv
+  version: '1.17'
+  build: hd590300_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.17-hd590300_2.conda
+  sha256: 8ac2f6a9f186e76539439e50505d98581472fedb347a20e7d1f36429849f05c9
+  md5: d66573916ffcf376178462f1b61c941e
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.1-only
+  size: 705775
+  timestamp: 1702682170569
+- kind: conda
+  name: libiconv
+  version: '1.17'
+  build: hd75f5a5_2
+  build_number: 2
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.17-hd75f5a5_2.conda
+  sha256: 23d4923baeca359423a7347c2ed7aaf48c68603df0cf8b87cc94a10b0d4e9a23
+  md5: 6c3628d047e151efba7cf08c5e54d1ca
+  license: LGPL-2.1-only
+  size: 666538
+  timestamp: 1702682713201
+- kind: conda
+  name: libidn2
+  version: 2.3.7
+  build: h10d778d_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libidn2-2.3.7-h10d778d_0.conda
+  sha256: 54430e45dffa8cbe3cbf12a3f4376947e7e2d50c67db90a90e91c3350510823e
+  md5: a985867eae03167666bba45c2a297da1
+  depends:
+  - gettext >=0.21.1,<1.0a0
+  - libunistring >=0,<1.0a0
+  license: LGPLv2
+  size: 133237
+  timestamp: 1706368325339
+- kind: conda
+  name: libidn2
+  version: 2.3.7
+  build: h31becfc_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libidn2-2.3.7-h31becfc_0.conda
+  sha256: 0227930e1cf1d326cfe04a17392587840cf180a91c15fbc38da8ebd297cc4146
+  md5: 7b87508d7df33b9b0e68cea0fcfef12a
+  depends:
+  - gettext >=0.21.1,<1.0a0
+  - libgcc-ng >=12
+  - libunistring >=0,<1.0a0
+  license: LGPLv2
+  size: 138303
+  timestamp: 1706370220301
+- kind: conda
+  name: libidn2
+  version: 2.3.7
+  build: h93a5062_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libidn2-2.3.7-h93a5062_0.conda
+  sha256: ae6be1c42fa18cb76fb1d17093f5b467b7a9bcf402da91081a9126c8843c004d
+  md5: 6e4a21ef7a8e4c0cc65381854848e232
+  depends:
+  - gettext >=0.21.1,<1.0a0
+  - libunistring >=0,<1.0a0
+  license: LGPLv2
+  size: 134491
+  timestamp: 1706368362998
+- kind: conda
+  name: libidn2
+  version: 2.3.7
+  build: hd590300_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libidn2-2.3.7-hd590300_0.conda
+  sha256: 253f9be445c58bf07b39d8f67ac08bccc5010c75a8c2070cddfb6c20e1ca4f4f
+  md5: 2b7b0d827c6447cc1d85dc06d5b5de46
+  depends:
+  - gettext >=0.21.1,<1.0a0
+  - libgcc-ng >=12
+  - libunistring >=0,<1.0a0
+  license: LGPLv2
+  size: 126515
+  timestamp: 1706368269716
+- kind: conda
+  name: libjpeg-turbo
+  version: 3.0.0
+  build: h0dc2134_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libjpeg-turbo-3.0.0-h0dc2134_1.conda
+  sha256: d9572fd1024adc374aae7c247d0f29fdf4b122f1e3586fe62acc18067f40d02f
+  md5: 72507f8e3961bc968af17435060b6dd6
+  constrains:
+  - jpeg <0.0.0a
+  license: IJG AND BSD-3-Clause AND Zlib
+  size: 579748
+  timestamp: 1694475265912
+- kind: conda
+  name: libjpeg-turbo
+  version: 3.0.0
+  build: h31becfc_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libjpeg-turbo-3.0.0-h31becfc_1.conda
+  sha256: 675bc1f2a8581cd34a86c412663ec29c5f90c1d9f8d11866aa1ade5cdbdf8429
+  md5: ed24e702928be089d9ba3f05618515c6
+  depends:
+  - libgcc-ng >=12
+  constrains:
+  - jpeg <0.0.0a
+  license: IJG AND BSD-3-Clause AND Zlib
+  size: 647126
+  timestamp: 1694475003570
+- kind: conda
+  name: libjpeg-turbo
+  version: 3.0.0
+  build: hb547adb_1
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libjpeg-turbo-3.0.0-hb547adb_1.conda
+  sha256: a42054eaa38e84fc1e5ab443facac4bbc9d1b6b6f23f54b7bf4f1eb687e1d993
+  md5: 3ff1e053dc3a2b8e36b9bfa4256a58d1
+  constrains:
+  - jpeg <0.0.0a
+  license: IJG AND BSD-3-Clause AND Zlib
+  size: 547541
+  timestamp: 1694475104253
+- kind: conda
+  name: libjpeg-turbo
+  version: 3.0.0
+  build: hcfcfb64_1
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libjpeg-turbo-3.0.0-hcfcfb64_1.conda
+  sha256: 4e7808e3098b4b4ed7e287f63bb24f9045cc4d95bfd39f0db870fc2837d74dff
+  md5: 3f1b948619c45b1ca714d60c7389092c
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - jpeg <0.0.0a
+  license: IJG AND BSD-3-Clause AND Zlib
+  size: 822966
+  timestamp: 1694475223854
+- kind: conda
+  name: libjpeg-turbo
+  version: 3.0.0
+  build: hd590300_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.0.0-hd590300_1.conda
+  sha256: b954e09b7e49c2f2433d6f3bb73868eda5e378278b0f8c1dd10a7ef090e14f2f
+  md5: ea25936bb4080d843790b586850f82b8
+  depends:
+  - libgcc-ng >=12
+  constrains:
+  - jpeg <0.0.0a
+  license: IJG AND BSD-3-Clause AND Zlib
+  size: 618575
+  timestamp: 1694474974816
+- kind: conda
+  name: liblapack
+  version: 3.9.0
+  build: 21_linux64_openblas
+  build_number: 21
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-21_linux64_openblas.conda
+  sha256: 64b5c35dce00dd6f9f53178b2fe87116282e00967970bd6551a5a42923806ded
+  md5: 1a42f305615c3867684e049e85927531
+  depends:
+  - libblas 3.9.0 21_linux64_openblas
+  constrains:
+  - liblapacke 3.9.0 21_linux64_openblas
+  - libcblas 3.9.0 21_linux64_openblas
+  - blas * openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14599
+  timestamp: 1705979579648
+- kind: conda
+  name: liblapack
+  version: 3.9.0
+  build: 21_linuxaarch64_openblas
+  build_number: 21
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/liblapack-3.9.0-21_linuxaarch64_openblas.conda
+  sha256: 87c110c6a1171c62d6a8802098c4186dcc8eca0ee2d0376a843e0cd025096e4a
+  md5: ab08b651e3630c20d3032e59859f34f7
+  depends:
+  - libblas 3.9.0 21_linuxaarch64_openblas
+  constrains:
+  - liblapacke 3.9.0 21_linuxaarch64_openblas
+  - blas * openblas
+  - libcblas 3.9.0 21_linuxaarch64_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14583
+  timestamp: 1705979400733
+- kind: conda
+  name: liblapack
+  version: 3.9.0
+  build: 21_osx64_openblas
+  build_number: 21
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.9.0-21_osx64_openblas.conda
+  sha256: 5d0ef4743e8684ad436e31bd3c378d48642815a20c260d358668ba29cd80987a
+  md5: cf0e4d82cfca6cd9d6c9ed3df45907c9
+  depends:
+  - libblas 3.9.0 21_osx64_openblas
+  constrains:
+  - libcblas 3.9.0 21_osx64_openblas
+  - liblapacke 3.9.0 21_osx64_openblas
+  - blas * openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14738
+  timestamp: 1705979734819
+- kind: conda
+  name: liblapack
+  version: 3.9.0
+  build: 21_osxarm64_openblas
+  build_number: 21
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-21_osxarm64_openblas.conda
+  sha256: a917e99f26d205df1ec22d7a9fff0d2f2f3c7ba06ea2be886dc220a8340d5917
+  md5: a4510e3913ef552d69ab2080a0048523
+  depends:
+  - libblas 3.9.0 21_osxarm64_openblas
+  constrains:
+  - libcblas 3.9.0 21_osxarm64_openblas
+  - blas * openblas
+  - liblapacke 3.9.0 21_osxarm64_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14829
+  timestamp: 1705980215575
+- kind: conda
+  name: liblapack
+  version: 3.9.0
+  build: 21_win64_mkl
+  build_number: 21
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-21_win64_mkl.conda
+  sha256: 3fa7c08dd4edf59cb0907d2e5b74e6be890e0671f845e1bae892d212d118a7e9
+  md5: c4740f091cb75987390087934354a621
+  depends:
+  - libblas 3.9.0 21_win64_mkl
+  constrains:
+  - blas * mkl
+  - libcblas 3.9.0 21_win64_mkl
+  - liblapacke 3.9.0 21_win64_mkl
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5017043
+  timestamp: 1705980523462
+- kind: conda
+  name: liblapacke
+  version: 3.9.0
+  build: 21_linux64_openblas
+  build_number: 21
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/liblapacke-3.9.0-21_linux64_openblas.conda
+  sha256: 7e6281a788aa3e9a74eac95cce075634afb25a2cea0416a8b7c77e95de524044
+  md5: 854c3c762b25ccfbaa1aa24ee34288e3
+  depends:
+  - libblas 3.9.0 21_linux64_openblas
+  - libcblas 3.9.0 21_linux64_openblas
+  - liblapack 3.9.0 21_linux64_openblas
+  constrains:
+  - blas * openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14608
+  timestamp: 1705979594896
+- kind: conda
+  name: liblapacke
+  version: 3.9.0
+  build: 21_linuxaarch64_openblas
+  build_number: 21
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/liblapacke-3.9.0-21_linuxaarch64_openblas.conda
+  sha256: f3f7bf84968016797ff9831cf435edf9fd4271b52e8d3524e597789e6d2b2647
+  md5: be00a60ef5d88de133a28cb1fb6e0b31
+  depends:
+  - libblas 3.9.0 21_linuxaarch64_openblas
+  - libcblas 3.9.0 21_linuxaarch64_openblas
+  - liblapack 3.9.0 21_linuxaarch64_openblas
+  constrains:
+  - blas * openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14570
+  timestamp: 1705979408964
+- kind: conda
+  name: liblapacke
+  version: 3.9.0
+  build: 21_osx64_openblas
+  build_number: 21
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/liblapacke-3.9.0-21_osx64_openblas.conda
+  sha256: 8c1bd2654e70a642dcbea652a3a0b44995bbcbd37eebb39d5ade3b30da543d42
+  md5: 563b6afae21aed1e0df12cad7a0db2cf
+  depends:
+  - libblas 3.9.0 21_osx64_openblas
+  - libcblas 3.9.0 21_osx64_openblas
+  - liblapack 3.9.0 21_osx64_openblas
+  constrains:
+  - blas * openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14721
+  timestamp: 1705979752564
+- kind: conda
+  name: liblapacke
+  version: 3.9.0
+  build: 21_osxarm64_openblas
+  build_number: 21
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/liblapacke-3.9.0-21_osxarm64_openblas.conda
+  sha256: 5d75b998be9644ad8fcf8bc3acab2751911c4d8026a00ee006d0c00adde7882d
+  md5: 203ceef3c48a49ba914a12518bac7882
+  depends:
+  - libblas 3.9.0 21_osxarm64_openblas
+  - libcblas 3.9.0 21_osxarm64_openblas
+  - liblapack 3.9.0 21_osxarm64_openblas
+  constrains:
+  - blas * openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14827
+  timestamp: 1705980239523
+- kind: conda
+  name: liblapacke
+  version: 3.9.0
+  build: 21_win64_mkl
+  build_number: 21
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/liblapacke-3.9.0-21_win64_mkl.conda
+  sha256: 965820dbb7f0da76487b4682e045343543b78d63568007f1d66fa555d0011f0e
+  md5: a4844669ed07bb5b7f182e9ca4de2a70
+  depends:
+  - libblas 3.9.0 21_win64_mkl
+  - libcblas 3.9.0 21_win64_mkl
+  - liblapack 3.9.0 21_win64_mkl
+  constrains:
+  - blas * mkl
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5040017
+  timestamp: 1705980578057
+- kind: conda
+  name: libllvm15
+  version: 15.0.7
+  build: h2621b3d_4
+  build_number: 4
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm15-15.0.7-h2621b3d_4.conda
+  sha256: 63e22ccd4c1b80dfc7da169c65c62a878a46ef0e5771c3b0c091071e718ae1b1
+  md5: 8d7f7a7286d99a2671df2619cb3bfb2c
+  depends:
+  - libcxx >=16
+  - libxml2 >=2.12.1,<3.0.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 22049607
+  timestamp: 1701372072765
+- kind: conda
+  name: libllvm15
+  version: 15.0.7
+  build: hb3ce162_4
+  build_number: 4
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libllvm15-15.0.7-hb3ce162_4.conda
+  sha256: e71584c0f910140630580fdd0a013029a52fd31e435192aea2aa8d29005262d1
+  md5: 8a35df3cbc0c8b12cc8af9473ae75eef
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libxml2 >=2.12.1,<3.0.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 33321457
+  timestamp: 1701375836233
+- kind: conda
+  name: libllvm15
+  version: 15.0.7
+  build: hb4f23b0_4
+  build_number: 4
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libllvm15-15.0.7-hb4f23b0_4.conda
+  sha256: 12da3344f2ef37dcb80b4e2d106cf36ebc267c3be6211a8306dd1dbf07399d61
+  md5: 8d7aa8eae04dc19426a417528d7041eb
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libxml2 >=2.12.1,<3.0.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 32882415
+  timestamp: 1701366839578
+- kind: conda
+  name: libllvm15
+  version: 15.0.7
+  build: hbedff68_4
+  build_number: 4
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libllvm15-15.0.7-hbedff68_4.conda
+  sha256: a0598cc166e92c6c63e58a7eaa184fa0b8b467693b965dbe19f1c9ff37e134c3
+  md5: bdc80cf2aa69d6eb8dd101dfd804db07
+  depends:
+  - libcxx >=16
+  - libxml2 >=2.12.1,<3.0.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 23755109
+  timestamp: 1701376376564
+- kind: conda
+  name: libllvm16
+  version: 16.0.6
+  build: haab561b_3
+  build_number: 3
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm16-16.0.6-haab561b_3.conda
+  sha256: f240f3776b02c39a32ce7397d6f2de072510321c835f4def452fc62e5c3babc0
+  md5: 9900d62ede9ce25b569beeeab1da094e
+  depends:
+  - libcxx >=16
+  - libxml2 >=2.12.1,<3.0.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 23347663
+  timestamp: 1701374993634
+- kind: conda
+  name: libllvm16
+  version: 16.0.6
+  build: hbedff68_3
+  build_number: 3
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libllvm16-16.0.6-hbedff68_3.conda
+  sha256: ad848dc0bb02b1dbe54324ee5700b050a2e5f63c095f5229b2de58249a3e268e
+  md5: 8fd56c0adc07a37f93bd44aa61a97c90
+  depends:
+  - libcxx >=16
+  - libxml2 >=2.12.1,<3.0.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 25196932
+  timestamp: 1701379796962
+- kind: conda
+  name: libnghttp2
+  version: 1.58.0
+  build: h47da74e_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.58.0-h47da74e_1.conda
+  sha256: 1910c5306c6aa5bcbd623c3c930c440e9c77a5a019008e1487810e3c1d3716cb
+  md5: 700ac6ea6d53d5510591c4344d5c989a
+  depends:
+  - c-ares >=1.23.0,<2.0a0
+  - libev >=4.33,<4.34.0a0
+  - libev >=4.33,<5.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.2.0,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 631936
+  timestamp: 1702130036271
+- kind: conda
+  name: libnghttp2
+  version: 1.58.0
+  build: h64cf6d3_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.58.0-h64cf6d3_1.conda
+  sha256: 412fd768e787e586602f8e9ea52bf089f3460fc630f6987f0cbd89b70e9a4380
+  md5: faecc55c2a8155d9ff1c0ff9a0fef64f
+  depends:
+  - __osx >=10.9
+  - c-ares >=1.23.0,<2.0a0
+  - libcxx >=16.0.6
+  - libev >=4.33,<4.34.0a0
+  - libev >=4.33,<5.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.2.0,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 599736
+  timestamp: 1702130398536
+- kind: conda
+  name: libnghttp2
+  version: 1.58.0
+  build: ha4dd798_1
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.58.0-ha4dd798_1.conda
+  sha256: fc97aaaf0c6d0f508be313d86c2705b490998d382560df24be918b8e977802cd
+  md5: 1813e066bfcef82de579a0be8a766df4
+  depends:
+  - __osx >=10.9
+  - c-ares >=1.23.0,<2.0a0
+  - libcxx >=16.0.6
+  - libev >=4.33,<4.34.0a0
+  - libev >=4.33,<5.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.2.0,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 565451
+  timestamp: 1702130473930
+- kind: conda
+  name: libnghttp2
+  version: 1.58.0
+  build: hb0e430d_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libnghttp2-1.58.0-hb0e430d_1.conda
+  sha256: ecc11e4f92f9d5830a90d42b4db55c66c4ad531e00dcf30d55171d934a568cb5
+  md5: 8f724cdddffa79152de61f5564a3526b
+  depends:
+  - c-ares >=1.23.0,<2.0a0
+  - libev >=4.33,<4.34.0a0
+  - libev >=4.33,<5.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.2.0,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 677508
+  timestamp: 1702130071743
+- kind: conda
+  name: libnsl
+  version: 2.0.1
+  build: h31becfc_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libnsl-2.0.1-h31becfc_0.conda
+  sha256: fd18c2b75d7411096428d36a70b36b1a17e31f7b8956b6905d145792d49e97f8
+  md5: c14f32510f694e3185704d89967ec422
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.1-only
+  license_family: GPL
+  size: 34501
+  timestamp: 1697358973269
+- kind: conda
+  name: libnsl
+  version: 2.0.1
+  build: hd590300_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
+  sha256: 26d77a3bb4dceeedc2a41bd688564fe71bf2d149fdcf117049970bc02ff1add6
+  md5: 30fd6e37fe21f86f4bd26d6ee73eeec7
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.1-only
+  license_family: GPL
+  size: 33408
+  timestamp: 1697359010159
+- kind: conda
+  name: libogg
+  version: 1.3.4
+  build: h27ca646_1
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libogg-1.3.4-h27ca646_1.tar.bz2
+  sha256: 916bbd5b7da6c922d6a16dd7d396b8a4e862edaca045671692e35add58aace64
+  md5: fb211883ad5716e398b974a9cde9d78e
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 207390
+  timestamp: 1610382137160
+- kind: conda
+  name: libogg
+  version: 1.3.4
+  build: h3557bc0_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libogg-1.3.4-h3557bc0_1.tar.bz2
+  sha256: cc9ef00410ac723e3abb667afd65c049ea50eb91fd2ff06a33f51083f91da792
+  md5: a8b4ce49dbd48176e82c11ecf01ae588
+  depends:
+  - libgcc-ng >=9.3.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 213591
+  timestamp: 1610381911963
+- kind: conda
+  name: libogg
+  version: 1.3.4
+  build: h35c211d_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libogg-1.3.4-h35c211d_1.tar.bz2
+  sha256: e3cec0c66d352d822b7a90db8edbc62f237fca079b6044e5b27f6ca529f7d9d9
+  md5: a7ab4b53ef18c598ffaa597230bc3ba1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 207262
+  timestamp: 1610382038748
+- kind: conda
+  name: libogg
+  version: 1.3.4
+  build: h7f98852_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libogg-1.3.4-h7f98852_1.tar.bz2
+  sha256: b88afeb30620b11bed54dac4295aa57252321446ba4e6babd7dce4b9ffde9b25
+  md5: 6e8cc2173440d77708196c5b93771680
+  depends:
+  - libgcc-ng >=9.3.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 210550
+  timestamp: 1610382007814
+- kind: conda
+  name: libogg
+  version: 1.3.4
+  build: h8ffe710_1
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libogg-1.3.4-h8ffe710_1.tar.bz2
+  sha256: ef20f04ad2121a07e074b34bfc211587df18180e680963f5c02c54d1951b9ee6
+  md5: 04286d905a0dcb7f7d4a12bdfe02516d
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 35187
+  timestamp: 1610382533961
+- kind: conda
+  name: libopenblas
+  version: 0.3.26
+  build: openmp_h6c19121_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.26-openmp_h6c19121_0.conda
+  sha256: 2a59b92c412fd0f59a8079dfa21c561ae17e72e72e47d4d7aee474bf6fd642e1
+  md5: 000970261d954431ccca3cce68d873d8
+  depends:
+  - libgfortran 5.*
+  - libgfortran5 >=12.3.0
+  - llvm-openmp >=16.0.6
+  constrains:
+  - openblas >=0.3.26,<0.3.27.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2917606
+  timestamp: 1704950245195
+- kind: conda
+  name: libopenblas
+  version: 0.3.26
+  build: openmp_hfef2a42_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.26-openmp_hfef2a42_0.conda
+  sha256: 4a5994cc608708eca19b90b642a144bb073e4a1cd27b824281dfcae67917204e
+  md5: 9df60162aea811087267b515f359536c
+  depends:
+  - libgfortran 5.*
+  - libgfortran5 >=12.3.0
+  - llvm-openmp >=16.0.6
+  constrains:
+  - openblas >=0.3.26,<0.3.27.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6044576
+  timestamp: 1704951566923
+- kind: conda
+  name: libopenblas
+  version: 0.3.26
+  build: pthreads_h413a1c8_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.26-pthreads_h413a1c8_0.conda
+  sha256: b626954b5a1113dafec8df89fa8bf18ce9b4701464d9f084ddd7fc9fac404bbd
+  md5: 760ae35415f5ba8b15d09df5afe8b23a
+  depends:
+  - libgcc-ng >=12
+  - libgfortran-ng
+  - libgfortran5 >=12.3.0
+  constrains:
+  - openblas >=0.3.26,<0.3.27.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5578031
+  timestamp: 1704950143521
+- kind: conda
+  name: libopenblas
+  version: 0.3.26
+  build: pthreads_h5a5ec62_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenblas-0.3.26-pthreads_h5a5ec62_0.conda
+  sha256: b72719014a86f69162398fc32af0f23e6e1746ec795f7c5d38ad5998a78eb6f8
+  md5: 2ea496754b596063335b3aeaa2b982ac
+  depends:
+  - libgcc-ng >=12
+  - libgfortran-ng
+  - libgfortran5 >=12.3.0
+  constrains:
+  - openblas >=0.3.26,<0.3.27.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4306237
+  timestamp: 1704951018697
+- kind: conda
+  name: libopencv
+  version: 4.9.0
+  build: py310ha3ab171_7
+  build_number: 7
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libopencv-4.9.0-py310ha3ab171_7.conda
+  sha256: f2703b20a2aa03a9a13b98928e78c1e4f1f3b16c804bfcf7d8c0b06af9c1e819
+  md5: 8f03be3b70b58a1ebe3ef46cc8a3fd35
+  depends:
+  - __osx >=10.13
+  - ffmpeg >=6.1.1,<7.0a0
+  - freetype >=2.12.1,<3.0a0
+  - harfbuzz >=8.3.0,<9.0a0
+  - hdf5 >=1.14.3,<1.14.4.0a0
+  - jasper >=4.1.2,<5.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=15
+  - libglib >=2.78.3,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - liblapacke >=3.9.0,<4.0a0
+  - libopenvino >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-auto-batch-plugin >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-auto-plugin >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-hetero-plugin >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-intel-cpu-plugin >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-ir-frontend >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-onnx-frontend >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-paddle-frontend >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-pytorch-frontend >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-tensorflow-frontend >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-tensorflow-lite-frontend >=2023.3.0,<2023.3.1.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libprotobuf >=4.25.1,<4.25.2.0a0
+  - libtiff >=4.6.0,<4.7.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - numpy >=1.22.4,<2.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 27391293
+  timestamp: 1706397604033
+- kind: conda
+  name: libopencv
+  version: 4.9.0
+  build: py311h5435783_7
+  build_number: 7
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopencv-4.9.0-py311h5435783_7.conda
+  sha256: bf57201c92ce99fc399744ac58f63f2563a794a8b0d920ec0f3b674959273308
+  md5: d9a6dc8d0c90694c488dfdeb7fed8c68
+  depends:
+  - _openmp_mutex >=4.5
+  - ffmpeg >=6.1.1,<7.0a0
+  - freetype >=2.12.1,<3.0a0
+  - harfbuzz >=8.3.0,<9.0a0
+  - hdf5 >=1.14.3,<1.14.4.0a0
+  - jasper >=4.1.2,<5.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgcc-ng >=12
+  - libglib >=2.78.3,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - liblapacke >=3.9.0,<4.0a0
+  - libopenvino >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-arm-cpu-plugin >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-auto-batch-plugin >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-auto-plugin >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-hetero-plugin >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-ir-frontend >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-onnx-frontend >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-paddle-frontend >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-pytorch-frontend >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-tensorflow-frontend >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-tensorflow-lite-frontend >=2023.3.0,<2023.3.1.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libprotobuf >=4.25.1,<4.25.2.0a0
+  - libstdcxx-ng >=12
+  - libtiff >=4.6.0,<4.7.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - qt-main >=5.15.8,<5.16.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 20400937
+  timestamp: 1706396912816
+- kind: conda
+  name: libopencv
+  version: 4.9.0
+  build: py311haea74c2_7
+  build_number: 7
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopencv-4.9.0-py311haea74c2_7.conda
+  sha256: 479107680fe980f41ff9f7e3f3457099126ca5aff537eee3ce2c4a31ae4643a2
+  md5: 4e3ad778805793f14107592be0e710a5
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - _openmp_mutex >=4.5
+  - ffmpeg >=6.1.1,<7.0a0
+  - freetype >=2.12.1,<3.0a0
+  - harfbuzz >=8.3.0,<9.0a0
+  - hdf5 >=1.14.3,<1.14.4.0a0
+  - jasper >=4.1.2,<5.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgcc-ng >=12
+  - libglib >=2.78.3,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - liblapacke >=3.9.0,<4.0a0
+  - libopenvino >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-auto-batch-plugin >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-auto-plugin >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-hetero-plugin >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-intel-cpu-plugin >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-intel-gpu-plugin >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-ir-frontend >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-onnx-frontend >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-paddle-frontend >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-pytorch-frontend >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-tensorflow-frontend >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-tensorflow-lite-frontend >=2023.3.0,<2023.3.1.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libprotobuf >=4.25.1,<4.25.2.0a0
+  - libstdcxx-ng >=12
+  - libtiff >=4.6.0,<4.7.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - numpy >=1.23.5,<2.0a0
+  - qt-main >=5.15.8,<5.16.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 30804850
+  timestamp: 1706397265285
+- kind: conda
+  name: libopencv
+  version: 4.9.0
+  build: py311hdccf81a_7
+  build_number: 7
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopencv-4.9.0-py311hdccf81a_7.conda
+  sha256: c2e197325e3e017d0426ead900d5ac1bb1249ff7bbb10f234e8ebeae67bf5eea
+  md5: 1249d406db539eec581152f8c0ad21f7
+  depends:
+  - ffmpeg >=6.1.1,<7.0a0
+  - freetype >=2.12.1,<3.0a0
+  - harfbuzz >=8.3.0,<9.0a0
+  - hdf5 >=1.14.3,<1.14.4.0a0
+  - jasper >=4.1.2,<5.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=15
+  - libglib >=2.78.3,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - liblapacke >=3.9.0,<4.0a0
+  - libopenvino >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-arm-cpu-plugin >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-auto-batch-plugin >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-auto-plugin >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-hetero-plugin >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-ir-frontend >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-onnx-frontend >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-paddle-frontend >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-pytorch-frontend >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-tensorflow-frontend >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-tensorflow-lite-frontend >=2023.3.0,<2023.3.1.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libprotobuf >=4.25.1,<4.25.2.0a0
+  - libtiff >=4.6.0,<4.7.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  license: Apache-2.0
+  license_family: Apache
+  size: 17202313
+  timestamp: 1706400635073
+- kind: conda
+  name: libopencv
+  version: 4.9.0
+  build: py312h766d233_7
+  build_number: 7
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libopencv-4.9.0-py312h766d233_7.conda
+  sha256: 5bca0ab39f5219d4c028918ca5cb0190b1ebee6acac7b58c64a997bdf275633a
+  md5: 41bbd33d4d69b2dd5200bfd86bd5f5fe
+  depends:
+  - ffmpeg >=6.1.1,<7.0a0
+  - freetype >=2.12.1,<3.0a0
+  - harfbuzz >=8.3.0,<9.0a0
+  - hdf5 >=1.14.3,<1.14.4.0a0
+  - jasper >=4.1.2,<5.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - liblapacke >=3.9.0,<4.0a0
+  - libopenvino >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-auto-batch-plugin >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-auto-plugin >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-hetero-plugin >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-intel-cpu-plugin >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-intel-gpu-plugin >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-ir-frontend >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-onnx-frontend >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-paddle-frontend >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-pytorch-frontend >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-tensorflow-frontend >=2023.3.0,<2023.3.1.0a0
+  - libopenvino-tensorflow-lite-frontend >=2023.3.0,<2023.3.1.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libprotobuf >=4.25.1,<4.25.2.0a0
+  - libtiff >=4.6.0,<4.7.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - numpy >=1.26.3,<2.0a0
+  - qt-main >=5.15.8,<5.16.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 33383534
+  timestamp: 1706398847318
+- kind: conda
+  name: libopenvino
+  version: 2023.3.0
+  build: h113ac47_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-2023.3.0-h113ac47_0.conda
+  sha256: eed5300bb5ff993f35ba57c5f589c13e5d1e1204536f707cee5b08d41cfde5fe
+  md5: 1ef3c484b1ab71894b1fc34ebacdd43d
+  depends:
+  - libcxx >=15
+  - pugixml >=1.14,<1.15.0a0
+  - tbb >=2021.11.0
+  size: 4740618
+  timestamp: 1706098076272
+- kind: conda
+  name: libopenvino
+  version: 2023.3.0
+  build: h2e90f83_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-2023.3.0-h2e90f83_0.conda
+  sha256: 0cf752211e89e534b7ca2b5faa2f1e696b436bcedee78f1200a59ee02920f04f
+  md5: 1cd43b2caa22f51118294978876502f7
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - pugixml >=1.14,<1.15.0a0
+  - tbb >=2021.11.0
+  size: 5932555
+  timestamp: 1706095513626
+- kind: conda
+  name: libopenvino
+  version: 2023.3.0
+  build: h3e0449b_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-2023.3.0-h3e0449b_0.conda
+  sha256: 9cc473727e91301c45419ca75b92a7dfba5a871e26d2703cf63ae1ef179417ec
+  md5: dc8efb968fdca4aefb1f96de4cdea22c
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - pugixml >=1.14,<1.15.0a0
+  - tbb >=2021.11.0
+  size: 5316412
+  timestamp: 1706093593445
+- kind: conda
+  name: libopenvino
+  version: 2023.3.0
+  build: hc2557fa_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-2023.3.0-hc2557fa_0.conda
+  sha256: d4e27af57d18763172c9b899f4f23e85abb4584a22868f6dd93749b159cd13fd
+  md5: 7b5f4e3ecc0c7eeaf5d66629a822e87f
+  depends:
+  - pugixml >=1.14,<1.15.0a0
+  - tbb >=2021.11.0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  size: 4150455
+  timestamp: 1706100273686
+- kind: conda
+  name: libopenvino
+  version: 2023.3.0
+  build: he6dadac_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-2023.3.0-he6dadac_0.conda
+  sha256: c2dba5092411a76e168ae0beadfbfceb33c9a696a5e0adfa0293d61e8dc242f6
+  md5: 64b41dbbfc0a08866016bece25c76753
+  depends:
+  - libcxx >=15
+  - pugixml >=1.14,<1.15.0a0
+  - tbb >=2021.11.0
+  size: 4317458
+  timestamp: 1706096927739
+- kind: conda
+  name: libopenvino-arm-cpu-plugin
+  version: 2023.3.0
+  build: h3e0449b_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-arm-cpu-plugin-2023.3.0-h3e0449b_0.conda
+  sha256: 5a4b3581fd2a24dd0357431214f43423d9fb56ba93627474a0da5855c1a00d4d
+  md5: 64c7b64c5cfd3d2064f5efd92bf33c69
+  depends:
+  - libgcc-ng >=12
+  - libopenvino 2023.3.0 h3e0449b_0
+  - libstdcxx-ng >=12
+  - pugixml >=1.14,<1.15.0a0
+  - tbb >=2021.11.0
+  size: 5884633
+  timestamp: 1706093620063
+- kind: conda
+  name: libopenvino-arm-cpu-plugin
+  version: 2023.3.0
+  build: he6dadac_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-arm-cpu-plugin-2023.3.0-he6dadac_0.conda
+  sha256: f73216881199749215e71b4627287b38d2b14a8702a3ebfde73095eb0fb530db
+  md5: c60046d907690ae42c0ef55e3bf9a2b6
+  depends:
+  - libcxx >=15
+  - libopenvino 2023.3.0 he6dadac_0
+  - pugixml >=1.14,<1.15.0a0
+  - tbb >=2021.11.0
+  size: 5707756
+  timestamp: 1706096983291
+- kind: conda
+  name: libopenvino-auto-batch-plugin
+  version: 2023.3.0
+  build: h002f227_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-auto-batch-plugin-2023.3.0-h002f227_0.conda
+  sha256: d4b6e02ee94a60992d571809486627dfe538591da89a52573a516fb280144cda
+  md5: 7c93c18b73c7a3b2411a30b4a6479a95
+  depends:
+  - libopenvino 2023.3.0 hc2557fa_0
+  - tbb >=2021.11.0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  size: 102785
+  timestamp: 1706100336403
+- kind: conda
+  name: libopenvino-auto-batch-plugin
+  version: 2023.3.0
+  build: h9adb129_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-auto-batch-plugin-2023.3.0-h9adb129_0.conda
+  sha256: 725e19359a52d7883b75b5e30490546ba0ddc3bbb9d13726439cdc910e3de02d
+  md5: 1674861af8450baa042c9ec5ec5fb259
+  depends:
+  - libcxx >=15
+  - libopenvino 2023.3.0 h113ac47_0
+  - tbb >=2021.11.0
+  size: 110495
+  timestamp: 1706098126610
+- kind: conda
+  name: libopenvino-auto-batch-plugin
+  version: 2023.3.0
+  build: hc9f00d9_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-auto-batch-plugin-2023.3.0-hc9f00d9_0.conda
+  sha256: bfdf1b76d4b89a6a612e0b675220881e07ccf28379bf6ad0713659b2709690a6
+  md5: 58741ce7d3318ccf685a2d6d50a86e59
+  depends:
+  - libcxx >=15
+  - libopenvino 2023.3.0 he6dadac_0
+  - tbb >=2021.11.0
+  size: 108058
+  timestamp: 1706097052472
+- kind: conda
+  name: libopenvino-auto-batch-plugin
+  version: 2023.3.0
+  build: hd429f41_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-auto-batch-plugin-2023.3.0-hd429f41_0.conda
+  sha256: d9f133140e9eff3b597791f30e03f310d64a71ae7800935f2ecb0a26830f348c
+  md5: 1511c331f949c2f1cdc27ddca841e65c
+  depends:
+  - libgcc-ng >=12
+  - libopenvino 2023.3.0 h3e0449b_0
+  - libstdcxx-ng >=12
+  - tbb >=2021.11.0
+  size: 109577
+  timestamp: 1706093647899
+- kind: conda
+  name: libopenvino-auto-batch-plugin
+  version: 2023.3.0
+  build: hd5fc58b_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-batch-plugin-2023.3.0-hd5fc58b_0.conda
+  sha256: 7cae505b43001f8097c932fb791cf84450d406b3f8ecce1a775469c59194aa8a
+  md5: c246b3ce9b6976d3b31ebc0a107c4486
+  depends:
+  - libgcc-ng >=12
+  - libopenvino 2023.3.0 h2e90f83_0
+  - libstdcxx-ng >=12
+  - tbb >=2021.11.0
+  size: 115304
+  timestamp: 1706095539905
+- kind: conda
+  name: libopenvino-auto-plugin
+  version: 2023.3.0
+  build: h002f227_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-auto-plugin-2023.3.0-h002f227_0.conda
+  sha256: 82c050c3fcd3dc030f3cdff04da6b54376a5abc7bcc9a4e62fd20eadaf3f1fe7
+  md5: fa0859641deb58647147b8c9c993d4e6
+  depends:
+  - libopenvino 2023.3.0 hc2557fa_0
+  - tbb >=2021.11.0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  size: 193732
+  timestamp: 1706100383207
+- kind: conda
+  name: libopenvino-auto-plugin
+  version: 2023.3.0
+  build: h9adb129_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-auto-plugin-2023.3.0-h9adb129_0.conda
+  sha256: b1ceb32c3d8c2a99fdf883b55d53c3097dcf5e94450292b1434fd62eb7dc1afa
+  md5: 10900b86dcad9ce1dd2b8ae208854339
+  depends:
+  - libcxx >=15
+  - libopenvino 2023.3.0 h113ac47_0
+  - tbb >=2021.11.0
+  size: 213888
+  timestamp: 1706098165163
+- kind: conda
+  name: libopenvino-auto-plugin
+  version: 2023.3.0
+  build: hc9f00d9_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-auto-plugin-2023.3.0-hc9f00d9_0.conda
+  sha256: ec1afea9273cdd4c1f77bd6786dfc56a2af5989c92d27a3d7e9ea5e16afbbdb5
+  md5: 896dc7a361e0082c7570b7865d7deff6
+  depends:
+  - libcxx >=15
+  - libopenvino 2023.3.0 he6dadac_0
+  - tbb >=2021.11.0
+  size: 207024
+  timestamp: 1706097093752
+- kind: conda
+  name: libopenvino-auto-plugin
+  version: 2023.3.0
+  build: hd429f41_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-auto-plugin-2023.3.0-hd429f41_0.conda
+  sha256: 52b7dfebd749348efd8686ae505a02742464699d0c498701bb864c60901e5d8e
+  md5: a456a02824e3cfed081efb907f95e993
+  depends:
+  - libgcc-ng >=12
+  - libopenvino 2023.3.0 h3e0449b_0
+  - libstdcxx-ng >=12
+  - tbb >=2021.11.0
+  size: 218748
+  timestamp: 1706093665867
+- kind: conda
+  name: libopenvino-auto-plugin
+  version: 2023.3.0
+  build: hd5fc58b_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-plugin-2023.3.0-hd5fc58b_0.conda
+  sha256: dd41e78515edc6497d9a12258fead3a3fe55c36b1c420dc45754697a021a3a1c
+  md5: bbdfe24aec88f9cded013e24da5a3cec
+  depends:
+  - libgcc-ng >=12
+  - libopenvino 2023.3.0 h2e90f83_0
+  - libstdcxx-ng >=12
+  - tbb >=2021.11.0
+  size: 238546
+  timestamp: 1706095555063
+- kind: conda
+  name: libopenvino-hetero-plugin
+  version: 2023.3.0
+  build: h3ecfda7_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-hetero-plugin-2023.3.0-h3ecfda7_0.conda
+  sha256: 8a9cd139d5680093fcdf9e3c30db6983a0d2702d0fb848741bd8ccf2656fe00a
+  md5: 93068e7b80a145689dfdd4b182957020
+  depends:
+  - libgcc-ng >=12
+  - libopenvino 2023.3.0 h2e90f83_0
+  - libstdcxx-ng >=12
+  - pugixml >=1.14,<1.15.0a0
+  size: 181775
+  timestamp: 1706095570201
+- kind: conda
+  name: libopenvino-hetero-plugin
+  version: 2023.3.0
+  build: h7e3b17c_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-hetero-plugin-2023.3.0-h7e3b17c_0.conda
+  sha256: 349aa190e4cc6690ff992f2ed44ac1ee77c8107d81e810940cc3b518f823825f
+  md5: 936abcc23c58dbab1a94c98e607c3ed0
+  depends:
+  - libopenvino 2023.3.0 hc2557fa_0
+  - pugixml >=1.14,<1.15.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  size: 150827
+  timestamp: 1706100429322
+- kind: conda
+  name: libopenvino-hetero-plugin
+  version: 2023.3.0
+  build: hc6dd956_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-hetero-plugin-2023.3.0-hc6dd956_0.conda
+  sha256: 5d4f26a39fb7506aab81d97fe1559c8638469b36f279d93437d222c3c5332966
+  md5: 0b36cf3dfe0cfd0570043d02500888e9
+  depends:
+  - libgcc-ng >=12
+  - libopenvino 2023.3.0 h3e0449b_0
+  - libstdcxx-ng >=12
+  - pugixml >=1.14,<1.15.0a0
+  size: 170271
+  timestamp: 1706093683826
+- kind: conda
+  name: libopenvino-hetero-plugin
+  version: 2023.3.0
+  build: hf483cef_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-hetero-plugin-2023.3.0-hf483cef_0.conda
+  sha256: 3e7d5548f662ebf15f17fb777ed07ce158e39fdd2d939f00b08c869867efe4df
+  md5: 0131f1038f2cee5e5589c046aa8476f4
+  depends:
+  - libcxx >=15
+  - libopenvino 2023.3.0 he6dadac_0
+  - pugixml >=1.14,<1.15.0a0
+  size: 161036
+  timestamp: 1706097137423
+- kind: conda
+  name: libopenvino-hetero-plugin
+  version: 2023.3.0
+  build: hfe2fe54_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-hetero-plugin-2023.3.0-hfe2fe54_0.conda
+  sha256: 2c909ff017f3d1a6f47da215e3c753b0630812b69a69613a0b7d261a0249be1c
+  md5: 937cc0b9c147f091e8de503fd9f87b76
+  depends:
+  - libcxx >=15
+  - libopenvino 2023.3.0 h113ac47_0
+  - pugixml >=1.14,<1.15.0a0
+  size: 168632
+  timestamp: 1706098201368
+- kind: conda
+  name: libopenvino-intel-cpu-plugin
+  version: 2023.3.0
+  build: h113ac47_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-intel-cpu-plugin-2023.3.0-h113ac47_0.conda
+  sha256: a91bc764f25d540155ec751e4857a42dd2c3dcbf0e1beece618a8674f0f37d08
+  md5: 68e1bdc75b56222b6212e521813c6b11
+  depends:
+  - libcxx >=15
+  - libopenvino 2023.3.0 h113ac47_0
+  - pugixml >=1.14,<1.15.0a0
+  - tbb >=2021.11.0
+  size: 9583651
+  timestamp: 1706098242445
+- kind: conda
+  name: libopenvino-intel-cpu-plugin
+  version: 2023.3.0
+  build: h2e90f83_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-cpu-plugin-2023.3.0-h2e90f83_0.conda
+  sha256: e2ed3d21349c9e6c8de576e7401396c76de5d004a8d8523ef78fa747a4117c87
+  md5: 2c2735c63288953e2108dc804fe52adf
+  depends:
+  - libgcc-ng >=12
+  - libopenvino 2023.3.0 h2e90f83_0
+  - libstdcxx-ng >=12
+  - pugixml >=1.14,<1.15.0a0
+  - tbb >=2021.11.0
+  size: 10201476
+  timestamp: 1706095585804
+- kind: conda
+  name: libopenvino-intel-cpu-plugin
+  version: 2023.3.0
+  build: hc2557fa_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-intel-cpu-plugin-2023.3.0-hc2557fa_0.conda
+  sha256: 1192cc95b6785372ebd9b13e4fca3db778208dbefd80171538379b967afc9106
+  md5: c000572da97636f5015116b8de0144fd
+  depends:
+  - libopenvino 2023.3.0 hc2557fa_0
+  - pugixml >=1.14,<1.15.0a0
+  - tbb >=2021.11.0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  size: 7048158
+  timestamp: 1706100492731
+- kind: conda
+  name: libopenvino-intel-gpu-plugin
+  version: 2023.3.0
+  build: h2e90f83_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-gpu-plugin-2023.3.0-h2e90f83_0.conda
+  sha256: 1bc8193fcf33072e2078a4dbbd86c5ebcc7cae5258b7a9d1ade0d5742e4efb06
+  md5: ee3930030324235a2e3ec5171b418481
+  depends:
+  - libgcc-ng >=12
+  - libopenvino 2023.3.0 h2e90f83_0
+  - libstdcxx-ng >=12
+  - ocl-icd >=2.3.1,<3.0a0
+  - ocl-icd-system
+  - pugixml >=1.14,<1.15.0a0
+  - tbb >=2021.11.0
+  size: 8210562
+  timestamp: 1706095622466
+- kind: conda
+  name: libopenvino-intel-gpu-plugin
+  version: 2023.3.0
+  build: hc2557fa_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-intel-gpu-plugin-2023.3.0-hc2557fa_0.conda
+  sha256: 77acef2554a38d7a2c572dd7f1d778f689d6f34c3558bd4cc9c4521b1be737a8
+  md5: cddcf24ede63c8d6483a0442ca2e578b
+  depends:
+  - khronos-opencl-icd-loader >=2023.4.17
+  - libopenvino 2023.3.0 hc2557fa_0
+  - pugixml >=1.14,<1.15.0a0
+  - tbb >=2021.11.0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  size: 7076471
+  timestamp: 1706100563024
+- kind: conda
+  name: libopenvino-ir-frontend
+  version: 2023.3.0
+  build: h3ecfda7_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-ir-frontend-2023.3.0-h3ecfda7_0.conda
+  sha256: 59a40ec23729ec8c23592246caf24ce72d7497fca2721a5434591e258fb50594
+  md5: a3e2922d58b4cd9ee51ba8dbb80dfcc6
+  depends:
+  - libgcc-ng >=12
+  - libopenvino 2023.3.0 h2e90f83_0
+  - libstdcxx-ng >=12
+  - pugixml >=1.14,<1.15.0a0
+  size: 199008
+  timestamp: 1706095653420
+- kind: conda
+  name: libopenvino-ir-frontend
+  version: 2023.3.0
+  build: h7e3b17c_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-ir-frontend-2023.3.0-h7e3b17c_0.conda
+  sha256: 7865a129bad4ded35f24ab510a02aa8a1914ddc71087103b928012076530b6dc
+  md5: 2cb21bc1584658d2896ce31efdfb57f6
+  depends:
+  - libopenvino 2023.3.0 hc2557fa_0
+  - pugixml >=1.14,<1.15.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  size: 157357
+  timestamp: 1706100624978
+- kind: conda
+  name: libopenvino-ir-frontend
+  version: 2023.3.0
+  build: hc6dd956_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-ir-frontend-2023.3.0-hc6dd956_0.conda
+  sha256: 5172f715fbc38a22a837277c1205ab61489f5cfd6db72583cd07ba43399559ea
+  md5: 9c421cbe7ae8b91e67f50a0536a70a25
+  depends:
+  - libgcc-ng >=12
+  - libopenvino 2023.3.0 h3e0449b_0
+  - libstdcxx-ng >=12
+  - pugixml >=1.14,<1.15.0a0
+  size: 185300
+  timestamp: 1706093704008
+- kind: conda
+  name: libopenvino-ir-frontend
+  version: 2023.3.0
+  build: hf483cef_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-ir-frontend-2023.3.0-hf483cef_0.conda
+  sha256: 6457872a91895efecadccbd22e11a7498f353fa036349d93f2930b58d4d0fc4a
+  md5: '05097639405108128773486888481e00'
+  depends:
+  - libcxx >=15
+  - libopenvino 2023.3.0 he6dadac_0
+  - pugixml >=1.14,<1.15.0a0
+  size: 168367
+  timestamp: 1706097179506
+- kind: conda
+  name: libopenvino-ir-frontend
+  version: 2023.3.0
+  build: hfe2fe54_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-ir-frontend-2023.3.0-hfe2fe54_0.conda
+  sha256: 5d12548a64a8606f3240e014f188cd42e540f91cade3f5561bb24fd41efef8f0
+  md5: 6ca936beb0a1675e1431c875432da7d7
+  depends:
+  - libcxx >=15
+  - libopenvino 2023.3.0 h113ac47_0
+  - pugixml >=1.14,<1.15.0a0
+  size: 176467
+  timestamp: 1706098326344
+- kind: conda
+  name: libopenvino-onnx-frontend
+  version: 2023.3.0
+  build: h8f0bfdc_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-onnx-frontend-2023.3.0-h8f0bfdc_0.conda
+  sha256: 7b600d8bc35f4c3f627a9585c05f7e7fb921135c1be6600aab2d19f8798b6560
+  md5: ff4b819d7d69ddfe92199b5212470865
+  depends:
+  - libopenvino 2023.3.0 hc2557fa_0
+  - libprotobuf >=4.25.1,<4.25.2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  size: 997950
+  timestamp: 1706100679612
+- kind: conda
+  name: libopenvino-onnx-frontend
+  version: 2023.3.0
+  build: h98f6304_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-onnx-frontend-2023.3.0-h98f6304_0.conda
+  sha256: 3ef80a0e9f216a244dbdfdefc55e02f8898bec34c38abc44237d2b022b03f2c5
+  md5: 197ea4d75d03fb4948d616850511f502
+  depends:
+  - libcxx >=15
+  - libopenvino 2023.3.0 he6dadac_0
+  - libprotobuf >=4.25.1,<4.25.2.0a0
+  size: 1198274
+  timestamp: 1706097221621
+- kind: conda
+  name: libopenvino-onnx-frontend
+  version: 2023.3.0
+  build: hb0b24c1_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-onnx-frontend-2023.3.0-hb0b24c1_0.conda
+  sha256: b460a6361a0c6a2fbd1a2aa59b15875c6f2d110bd1b217a57c0e64f8e0e7e967
+  md5: ba7e384a8b055243ae0293362b13ffa8
+  depends:
+  - libgcc-ng >=12
+  - libopenvino 2023.3.0 h3e0449b_0
+  - libprotobuf >=4.25.1,<4.25.2.0a0
+  - libstdcxx-ng >=12
+  size: 1375405
+  timestamp: 1706093722570
+- kind: conda
+  name: libopenvino-onnx-frontend
+  version: 2023.3.0
+  build: hd0b7f58_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-onnx-frontend-2023.3.0-hd0b7f58_0.conda
+  sha256: 621c32065ed8fc38dd0777b9a04d8d039c1a6220f0ce29509619867b97441923
+  md5: 9583b4293844c3500c9718f06fad8b63
+  depends:
+  - __osx >=10.13
+  - libcxx >=15
+  - libopenvino 2023.3.0 h113ac47_0
+  - libprotobuf >=4.25.1,<4.25.2.0a0
+  size: 1264771
+  timestamp: 1706098366523
+- kind: conda
+  name: libopenvino-onnx-frontend
+  version: 2023.3.0
+  build: hfbc7f12_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-onnx-frontend-2023.3.0-hfbc7f12_0.conda
+  sha256: 7fa26c36f4bb3a636af8923ff1313061845b1b0e1bc03a206017e4bcd3f00c23
+  md5: da9b47d41e0357f66af895327a8ac72d
+  depends:
+  - libgcc-ng >=12
+  - libopenvino 2023.3.0 h2e90f83_0
+  - libprotobuf >=4.25.1,<4.25.2.0a0
+  - libstdcxx-ng >=12
+  size: 1543070
+  timestamp: 1706095670120
+- kind: conda
+  name: libopenvino-paddle-frontend
+  version: 2023.3.0
+  build: h8f0bfdc_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-paddle-frontend-2023.3.0-h8f0bfdc_0.conda
+  sha256: 6116aef26283f27ec6c8937e09e71b9c8ba3bc666799585420bd3c80ea0767d9
+  md5: 9f5751793f2023ff946f8f6bb6053c0f
+  depends:
+  - libopenvino 2023.3.0 hc2557fa_0
+  - libprotobuf >=4.25.1,<4.25.2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  size: 410988
+  timestamp: 1706100731323
+- kind: conda
+  name: libopenvino-paddle-frontend
+  version: 2023.3.0
+  build: h98f6304_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-paddle-frontend-2023.3.0-h98f6304_0.conda
+  sha256: 4012373cd35caaa3fdf36e4f67a9793e0f1f7fedf3e27e15c9fe8598b0d56d04
+  md5: edf222dbe2a2718760db3d8cc851b63a
+  depends:
+  - libcxx >=15
+  - libopenvino 2023.3.0 he6dadac_0
+  - libprotobuf >=4.25.1,<4.25.2.0a0
+  size: 405107
+  timestamp: 1706097264140
+- kind: conda
+  name: libopenvino-paddle-frontend
+  version: 2023.3.0
+  build: hb0b24c1_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-paddle-frontend-2023.3.0-hb0b24c1_0.conda
+  sha256: e9587d1265fab8ef64ec029b653e28543cebe70eade4e6964dd7ed647d1661ff
+  md5: 2716736ca82bc23b7dea0ee950388b7d
+  depends:
+  - libgcc-ng >=12
+  - libopenvino 2023.3.0 h3e0449b_0
+  - libprotobuf >=4.25.1,<4.25.2.0a0
+  - libstdcxx-ng >=12
+  size: 604273
+  timestamp: 1706093742456
+- kind: conda
+  name: libopenvino-paddle-frontend
+  version: 2023.3.0
+  build: hd0b7f58_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-paddle-frontend-2023.3.0-hd0b7f58_0.conda
+  sha256: 804f203f5ce5d34a4994e26af13ef511391807c4720015dc3df0049e8d856aef
+  md5: 4a6d3b571cc6826e6a0432a677ab7749
+  depends:
+  - __osx >=10.13
+  - libcxx >=15
+  - libopenvino 2023.3.0 h113ac47_0
+  - libprotobuf >=4.25.1,<4.25.2.0a0
+  size: 416094
+  timestamp: 1706098409186
+- kind: conda
+  name: libopenvino-paddle-frontend
+  version: 2023.3.0
+  build: hfbc7f12_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-paddle-frontend-2023.3.0-hfbc7f12_0.conda
+  sha256: 2eed3087da14d60d6d81df7c89239e16bf2b123daa9d8b6947ab82d5f792d553
+  md5: 6860072c5ee02bb11f287416b73a0ff8
+  depends:
+  - libgcc-ng >=12
+  - libopenvino 2023.3.0 h2e90f83_0
+  - libprotobuf >=4.25.1,<4.25.2.0a0
+  - libstdcxx-ng >=12
+  size: 659697
+  timestamp: 1706095687275
+- kind: conda
+  name: libopenvino-pytorch-frontend
+  version: 2023.3.0
+  build: h2f0025b_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-pytorch-frontend-2023.3.0-h2f0025b_0.conda
+  sha256: ae8854f7ed7d7b702a27f8587cda110a5a38921c4e3c299d7ba9e6b12ebc2f09
+  md5: 00f03d9aa56a6471683e0247280bc7e8
+  depends:
+  - libgcc-ng >=12
+  - libopenvino 2023.3.0 h3e0449b_0
+  - libstdcxx-ng >=12
+  size: 874762
+  timestamp: 1706093760950
+- kind: conda
+  name: libopenvino-pytorch-frontend
+  version: 2023.3.0
+  build: h59595ed_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-pytorch-frontend-2023.3.0-h59595ed_0.conda
+  sha256: d8be2b27aca1772af542c7842e8f2b9f2de07d3d54ae3d59a4207645b0954882
+  md5: 69676390abdff86e57c0d50b82ee72ad
+  depends:
+  - libgcc-ng >=12
+  - libopenvino 2023.3.0 h2e90f83_0
+  - libstdcxx-ng >=12
+  size: 960370
+  timestamp: 1706095703121
+- kind: conda
+  name: libopenvino-pytorch-frontend
+  version: 2023.3.0
+  build: h63175ca_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-pytorch-frontend-2023.3.0-h63175ca_0.conda
+  sha256: 446c000a2041c08752c4388630759a6129ec2773f869f2a021a197ab747c6b71
+  md5: a85cb5c01026e9c67ea41a8a619b062d
+  depends:
+  - libopenvino 2023.3.0 hc2557fa_0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  size: 604900
+  timestamp: 1706100778676
+- kind: conda
+  name: libopenvino-pytorch-frontend
+  version: 2023.3.0
+  build: hd427752_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-pytorch-frontend-2023.3.0-hd427752_0.conda
+  sha256: 0f529e073945e3cbe8220248de25f5bb45c29c6512495dfe28c759333833148e
+  md5: 521c6bef6f50deab4278fcda50480dbd
+  depends:
+  - libcxx >=15
+  - libopenvino 2023.3.0 h113ac47_0
+  size: 703094
+  timestamp: 1706098450272
+- kind: conda
+  name: libopenvino-pytorch-frontend
+  version: 2023.3.0
+  build: hebf3989_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-pytorch-frontend-2023.3.0-hebf3989_0.conda
+  sha256: 8662e1ada217c18742f435df07d7170d52fd1d2d3d555173ae3b965de443891c
+  md5: d3b0f4df56099d925542c338418023e3
+  depends:
+  - libcxx >=15
+  - libopenvino 2023.3.0 he6dadac_0
+  size: 677798
+  timestamp: 1706097305598
+- kind: conda
+  name: libopenvino-tensorflow-frontend
+  version: 2023.3.0
+  build: h0bff32c_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-frontend-2023.3.0-h0bff32c_0.conda
+  sha256: 4692a237546819b040e269bfbf87b57503905cba38d091e96322fd7abccdf3fd
+  md5: 9d3772f3ae8e4dfa31287bde490238de
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20230802.1,<20230803.0a0
+  - libgcc-ng >=12
+  - libopenvino 2023.3.0 h2e90f83_0
+  - libprotobuf >=4.25.1,<4.25.2.0a0
+  - libstdcxx-ng >=12
+  - snappy >=1.1.10,<2.0a0
+  size: 1192939
+  timestamp: 1706095719842
+- kind: conda
+  name: libopenvino-tensorflow-frontend
+  version: 2023.3.0
+  build: h35b5a9d_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-tensorflow-frontend-2023.3.0-h35b5a9d_0.conda
+  sha256: aca81a3fa98c27b62443a7d0dc3b5d6d606c7052116e7895bb3b713d6a65a871
+  md5: cc379db1bd5be47167514f4a3b987a89
+  depends:
+  - __osx >=10.13
+  - libabseil * cxx17*
+  - libabseil >=20230802.1,<20230803.0a0
+  - libcxx >=15
+  - libopenvino 2023.3.0 h113ac47_0
+  - libprotobuf >=4.25.1,<4.25.2.0a0
+  - snappy >=1.1.10,<2.0a0
+  size: 893375
+  timestamp: 1706098490465
+- kind: conda
+  name: libopenvino-tensorflow-frontend
+  version: 2023.3.0
+  build: h5dc61ae_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-tensorflow-frontend-2023.3.0-h5dc61ae_0.conda
+  sha256: 5654ad3e3ee34a64f6dbf51e8f0ef20f351133514b08e22f3426d619be847b8e
+  md5: 12a0bb0a1a4de97a762b8e46a8b4114b
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20230802.1,<20230803.0a0
+  - libgcc-ng >=12
+  - libopenvino 2023.3.0 h3e0449b_0
+  - libprotobuf >=4.25.1,<4.25.2.0a0
+  - libstdcxx-ng >=12
+  - snappy >=1.1.10,<2.0a0
+  size: 1106336
+  timestamp: 1706093780445
+- kind: conda
+  name: libopenvino-tensorflow-frontend
+  version: 2023.3.0
+  build: h815df86_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-tensorflow-frontend-2023.3.0-h815df86_0.conda
+  sha256: 6af901c8e8bf0bfe925d15444f04ea772bae150ecbcebef678764080007500de
+  md5: f12c31bcaf8b7830b6a4dd8b8929a37e
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20230802.1,<20230803.0a0
+  - libopenvino 2023.3.0 hc2557fa_0
+  - libprotobuf >=4.25.1,<4.25.2.0a0
+  - snappy >=1.1.10,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  size: 807202
+  timestamp: 1706100834430
+- kind: conda
+  name: libopenvino-tensorflow-frontend
+  version: 2023.3.0
+  build: hb5ee477_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-tensorflow-frontend-2023.3.0-hb5ee477_0.conda
+  sha256: 2a44ee24f1c4ce3f31689ba506736b41324e6e422ad19d35025fe1d45a0c9722
+  md5: 5ba9b522b7ce160a27f7baad0e063013
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20230802.1,<20230803.0a0
+  - libcxx >=15
+  - libopenvino 2023.3.0 he6dadac_0
+  - libprotobuf >=4.25.1,<4.25.2.0a0
+  - snappy >=1.1.10,<2.0a0
+  size: 844788
+  timestamp: 1706097348161
+- kind: conda
+  name: libopenvino-tensorflow-lite-frontend
+  version: 2023.3.0
+  build: h2f0025b_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-tensorflow-lite-frontend-2023.3.0-h2f0025b_0.conda
+  sha256: 0610b710ef93a723bea0ca1ba9fb80d5afe2d5d2590844e5868a435959a19a0d
+  md5: 2f9a22c836a0deae69cd5cd0ee6b1173
+  depends:
+  - libgcc-ng >=12
+  - libopenvino 2023.3.0 h3e0449b_0
+  - libstdcxx-ng >=12
+  size: 420513
+  timestamp: 1706093799611
+- kind: conda
+  name: libopenvino-tensorflow-lite-frontend
+  version: 2023.3.0
+  build: h59595ed_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-lite-frontend-2023.3.0-h59595ed_0.conda
+  sha256: 66d7a1481979a834d0707fdb6a41ecf76595f443614902414876ebaaf8dcf050
+  md5: c1cec95aa4db6e625e2659c0ab31a9c5
+  depends:
+  - libgcc-ng >=12
+  - libopenvino 2023.3.0 h2e90f83_0
+  - libstdcxx-ng >=12
+  size: 456367
+  timestamp: 1706095736363
+- kind: conda
+  name: libopenvino-tensorflow-lite-frontend
+  version: 2023.3.0
+  build: h63175ca_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-tensorflow-lite-frontend-2023.3.0-h63175ca_0.conda
+  sha256: 69f7f4886d7edd39a35c0d549a4fed7e4a22e707207caedfbdec978b3b9bca7d
+  md5: ef6ecc61c4bfd7997a3f647351a1d018
+  depends:
+  - libopenvino 2023.3.0 hc2557fa_0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  size: 323258
+  timestamp: 1706100881832
+- kind: conda
+  name: libopenvino-tensorflow-lite-frontend
+  version: 2023.3.0
+  build: hd427752_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-tensorflow-lite-frontend-2023.3.0-hd427752_0.conda
+  sha256: 0c2a9e2c13ffe49444060073a4d124d6ec401aa67389ce45a4b729ae24fc0083
+  md5: 97edd4f94d7f32eb811b4a880e16831e
+  depends:
+  - libcxx >=15
+  - libopenvino 2023.3.0 h113ac47_0
+  size: 367556
+  timestamp: 1706098529605
+- kind: conda
+  name: libopenvino-tensorflow-lite-frontend
+  version: 2023.3.0
+  build: hebf3989_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-tensorflow-lite-frontend-2023.3.0-hebf3989_0.conda
+  sha256: c842fd83ea2b003d4d09f811e149c59468b2db96d3b2dfb21cb627c274ea86b5
+  md5: 540f0272a0f13bda3964ac450694a5d8
+  depends:
+  - libcxx >=15
+  - libopenvino 2023.3.0 he6dadac_0
+  size: 365463
+  timestamp: 1706097391896
+- kind: conda
+  name: libopus
+  version: 1.3.1
+  build: h27ca646_1
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopus-1.3.1-h27ca646_1.tar.bz2
+  sha256: e9912101a58cbc609a1917c5289f3bd1f600c82ed3a1c90a6dd4ca02df77958a
+  md5: 3d0dbee0ccd2f6d6781d270313627b62
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 252854
+  timestamp: 1606823635137
+- kind: conda
+  name: libopus
+  version: 1.3.1
+  build: h7f98852_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopus-1.3.1-h7f98852_1.tar.bz2
+  sha256: 0e1c2740ebd1c93226dc5387461bbcf8142c518f2092f3ea7551f77755decc8f
+  md5: 15345e56d527b330e1cacbdf58676e8f
+  depends:
+  - libgcc-ng >=9.3.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 260658
+  timestamp: 1606823578035
+- kind: conda
+  name: libopus
+  version: 1.3.1
+  build: h8ffe710_1
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libopus-1.3.1-h8ffe710_1.tar.bz2
+  sha256: b2e5ec193762a5b4f905f8100437370e164df3db0ea5c18b4ce09390f5d3d525
+  md5: e35a6bcfeb20ea83aab21dfc50ae62a4
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 260615
+  timestamp: 1606824019288
+- kind: conda
+  name: libopus
+  version: 1.3.1
+  build: hc929b4f_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libopus-1.3.1-hc929b4f_1.tar.bz2
+  sha256: c126fc225bece591a8f010e95ca7d010ea2d02df9251830bec24a19bf823fc31
+  md5: 380b9ea5f6a7a277e6c1ac27d034369b
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 279983
+  timestamp: 1606823633642
+- kind: conda
+  name: libopus
+  version: 1.3.1
+  build: hf897c2e_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopus-1.3.1-hf897c2e_1.tar.bz2
+  sha256: 92a87ade11af2cff41c35cf941f1a79390fde1f113f8e51e1cce30d31b7c8305
+  md5: ac7534c50934ed25e4749d74b04c667a
+  depends:
+  - libgcc-ng >=9.3.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 328825
+  timestamp: 1606823775764
+- kind: conda
+  name: libosqp
+  version: 0.6.3
+  build: h13dd4ca_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libosqp-0.6.3-h13dd4ca_0.conda
+  sha256: fd38d8b20d904b3246db888fb26e7400a0a0ef50f1816a85c951ff47a570e392
+  md5: 3b83415bfa90262647c2cab6d25c4618
+  depends:
+  - libcxx >=15.0.7
+  - libqdldl >=0.1.5,<0.1.6.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 64026
+  timestamp: 1685065777386
+- kind: conda
+  name: libosqp
+  version: 0.6.3
+  build: h2f0025b_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libosqp-0.6.3-h2f0025b_0.conda
+  sha256: 6e11bc7b8130617f0cf5f0613ec486cab2c5c0703b38549540299242206c39d6
+  md5: a6abebd4a87589b7bdc65a5b870c52ae
+  depends:
+  - libgcc-ng >=12
+  - libqdldl >=0.1.5,<0.1.6.0a0
+  - libstdcxx-ng >=12
+  license: Apache-2.0
+  license_family: APACHE
+  size: 69789
+  timestamp: 1685065325043
+- kind: conda
+  name: libosqp
+  version: 0.6.3
+  build: h59595ed_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libosqp-0.6.3-h59595ed_0.conda
+  sha256: 9ae82670f53a43b119ecb137de53f17822b772360a1083817d4fcc178f60b6fe
+  md5: af90a98ba90a4063f252848e2f3aa5e6
+  depends:
+  - libgcc-ng >=12
+  - libqdldl >=0.1.5,<0.1.6.0a0
+  - libstdcxx-ng >=12
+  license: Apache-2.0
+  license_family: APACHE
+  size: 72079
+  timestamp: 1685065354843
+- kind: conda
+  name: libosqp
+  version: 0.6.3
+  build: h63175ca_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libosqp-0.6.3-h63175ca_0.conda
+  sha256: fc1e4e277e1e4572195f0ac9ce3dc93af8a0945f905977535af4924c5bcee84c
+  md5: 641bca9e7d6915ec4ffb338bf020423d
+  depends:
+  - libqdldl >=0.1.5,<0.1.6.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: APACHE
+  size: 73439
+  timestamp: 1685065686169
+- kind: conda
+  name: libosqp
+  version: 0.6.3
+  build: he965462_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libosqp-0.6.3-he965462_0.conda
+  sha256: 3be2e8c56fcfba797f04631e53fe23a1e9e9f9ccfa9c7c79ccfae4c9e3f258dd
+  md5: c416acec68a3ddeb7b6a65ce6de0eab7
+  depends:
+  - libcxx >=15.0.7
+  - libqdldl >=0.1.5,<0.1.6.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 74045
+  timestamp: 1685065544324
+- kind: conda
+  name: libpciaccess
+  version: '0.17'
+  build: h166bdaf_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.17-h166bdaf_0.tar.bz2
+  sha256: 9fe4aaf5629b4848d9407b9ed4da941ba7e5cebada63ee0becb9aa82259dc6e2
+  md5: b7463391cf284065294e2941dd41ab95
+  depends:
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 39750
+  timestamp: 1666091838440
+- kind: conda
+  name: libpng
+  version: 1.6.42
+  build: h091b4b1_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.42-h091b4b1_0.conda
+  sha256: 6df48b05868437377a0717b486d9f57396a45cb6e3a044453944c8e597b03370
+  md5: 308b6746e691265c21cb013960c74ae6
+  depends:
+  - libzlib >=1.2.13,<1.3.0a0
+  license: zlib-acknowledgement
+  size: 263699
+  timestamp: 1706789057076
+- kind: conda
+  name: libpng
+  version: 1.6.42
+  build: h194ca79_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libpng-1.6.42-h194ca79_0.conda
+  sha256: 035ab9c6a38dedd8ffc28f7c1ca0bed4196f7f8631e9ac74695a3630d2bb527b
+  md5: b8ff00cc9a5184726baea61244f8bec3
+  depends:
+  - libgcc-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
+  license: zlib-acknowledgement
+  size: 296479
+  timestamp: 1706791406271
+- kind: conda
+  name: libpng
+  version: 1.6.42
+  build: h19919ed_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.42-h19919ed_0.conda
+  sha256: 92a7f54585bac3b5f90e89bb674be1bd2e66e281206ec056a125eec7e32bb85f
+  md5: 9d97d0e6a5d51a7fd03c3398bc752890
+  depends:
+  - libzlib >=1.2.13,<1.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: zlib-acknowledgement
+  size: 346387
+  timestamp: 1706789602418
+- kind: conda
+  name: libpng
+  version: 1.6.42
+  build: h2797004_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.42-h2797004_0.conda
+  sha256: 1a0c3a4b7fd1e101cb37dd6d2f8b5ec93409c8cae422f04470fe39a01ef59024
+  md5: d67729828dc6ff7ba44a61062ad79880
+  depends:
+  - libgcc-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
+  license: zlib-acknowledgement
+  size: 289100
+  timestamp: 1706788935660
+- kind: conda
+  name: libpng
+  version: 1.6.42
+  build: h92b6c6a_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.42-h92b6c6a_0.conda
+  sha256: 57c816e3b8cd0aaca7b85e79c0cc2211789ce0729a581d006faf8daeebf51f8d
+  md5: 7654da21e9d7ca6a8c87fbc77448588e
+  depends:
+  - libzlib >=1.2.13,<1.3.0a0
+  license: zlib-acknowledgement
+  size: 268963
+  timestamp: 1706789121898
+- kind: conda
+  name: libpq
+  version: '16.2'
+  build: h0f8b458_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libpq-16.2-h0f8b458_0.conda
+  sha256: 0ad2265131a6d79fcfe8c5b7a04884f7377f981d18af775ebb71bc61b0c938b6
+  md5: fea5d30234a7158f4eaa915b5a6e0c9c
+  depends:
+  - krb5 >=1.21.2,<1.22.0a0
+  - openssl >=3.2.1,<4.0a0
+  license: PostgreSQL
+  size: 2408453
+  timestamp: 1707416268983
+- kind: conda
+  name: libpq
+  version: '16.2'
+  build: h33b98f1_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libpq-16.2-h33b98f1_0.conda
+  sha256: 352748b0499a22e2a8e103f071b8d9357e1fb710c0aec0f79895d3ba03dccb03
+  md5: fe0e297faf462ee579c95071a5211665
+  depends:
+  - krb5 >=1.21.2,<1.22.0a0
+  - libgcc-ng >=12
+  - openssl >=3.2.1,<4.0a0
+  license: PostgreSQL
+  size: 2474825
+  timestamp: 1707415138154
+- kind: conda
+  name: libpq
+  version: '16.2'
+  build: h58720eb_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libpq-16.2-h58720eb_0.conda
+  sha256: 439633fee193ad250d97da135a7fb1c497b4f496ec6baabcb73bdba554926943
+  md5: ca0572c11209701741812f657ebeef82
+  depends:
+  - krb5 >=1.21.2,<1.22.0a0
+  - libgcc-ng >=12
+  - openssl >=3.2.1,<4.0a0
+  license: PostgreSQL
+  size: 2528613
+  timestamp: 1707415354953
+- kind: conda
+  name: libpq
+  version: '16.2'
+  build: ha925e61_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libpq-16.2-ha925e61_0.conda
+  sha256: 537b3816ac66f12c56fc62a67d896703b68f7588a5d83ab98009731de82eb742
+  md5: 8b81f4feaa3744271fcf2822ad1489f1
+  depends:
+  - krb5 >=1.21.2,<1.22.0a0
+  - openssl >=3.2.1,<4.0a0
+  license: PostgreSQL
+  size: 2336821
+  timestamp: 1707415890165
+- kind: conda
+  name: libprotobuf
+  version: 4.25.1
+  build: h810fc01_1
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-4.25.1-h810fc01_1.conda
+  sha256: bdaff15489c9a64ae150ba9fba29c2f019c86c36fc2828aa6edfffdd32313830
+  md5: 3e1535cfcf9d0f8e1141e021248c721e
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20230802.1,<20230803.0a0
+  - libcxx >=16
+  - libzlib >=1.2.13,<1.3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2159882
+  timestamp: 1706891704812
+- kind: conda
+  name: libprotobuf
+  version: 4.25.1
+  build: h87e877f_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libprotobuf-4.25.1-h87e877f_1.conda
+  sha256: 826bee292ebf91b1cb3e809683d9b6bdbc2398d0a41a1b4d3e64d98f3db14d75
+  md5: c129f45da1472e472c28304046a92d9d
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20230802.1,<20230803.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2582348
+  timestamp: 1706890811006
+- kind: conda
+  name: libprotobuf
+  version: 4.25.1
+  build: hb8276f3_1
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libprotobuf-4.25.1-hb8276f3_1.conda
+  sha256: 980d7736424a5750fbec3ca454fc5654096eb93fc4cc5f44598919ce3710b951
+  md5: 6fac1decbb9591b391c124dc7bc39905
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20230802.1,<20230803.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5548805
+  timestamp: 1707169970392
+- kind: conda
+  name: libprotobuf
+  version: 4.25.1
+  build: hc4f2305_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libprotobuf-4.25.1-hc4f2305_1.conda
+  sha256: 9f0eccde6aabded86225d60166c93544f138aa0fad7478e4811879dbd61bffbc
+  md5: e75c3761805ceb70bbc28b8109f67d85
+  depends:
+  - __osx >=10.13
+  - libabseil * cxx17*
+  - libabseil >=20230802.1,<20230803.0a0
+  - libcxx >=16
+  - libzlib >=1.2.13,<1.3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2225893
+  timestamp: 1706891832837
+- kind: conda
+  name: libprotobuf
+  version: 4.25.1
+  build: hf27288f_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-4.25.1-hf27288f_1.conda
+  sha256: 4f3f6db5fb502ae1392d3f8d66639154b8ba7bf5c0547be988ec9236a5a784b2
+  md5: 78ad06185133494138cd5e922ed73ac7
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20230802.1,<20230803.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2735654
+  timestamp: 1706891328749
+- kind: conda
+  name: libqdldl
+  version: 0.1.5
+  build: h27087fc_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libqdldl-0.1.5-h27087fc_1.tar.bz2
+  sha256: 367c6a2d87dedfa03db0024956c4343fdf88b004dfb0831163d67e17680b547f
+  md5: 931d743c4d1219d5efc3a97bdb578053
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: Apache-2.0
+  license_family: APACHE
+  size: 16905
+  timestamp: 1667006397176
+- kind: conda
+  name: libqdldl
+  version: 0.1.5
+  build: h4de3ea5_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libqdldl-0.1.5-h4de3ea5_1.tar.bz2
+  sha256: 02dd6747f15d482c2a76288340353f1a08d77f68a5083e1a41df4b767448508a
+  md5: 9ebc5a9309c3300c7f8afc229587618e
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: Apache-2.0
+  license_family: APACHE
+  size: 16947
+  timestamp: 1667006172086
+- kind: conda
+  name: libqdldl
+  version: 0.1.5
+  build: h63175ca_1
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libqdldl-0.1.5-h63175ca_1.tar.bz2
+  sha256: 5d2050ea36f32b009712accc9eeb34d731a56f2d5dd27eb40f64870eb0f9d901
+  md5: 6a8beb414077e9aa543c0897541f69ad
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: APACHE
+  size: 20960
+  timestamp: 1667007089765
+- kind: conda
+  name: libqdldl
+  version: 0.1.5
+  build: hb7217d7_1
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libqdldl-0.1.5-hb7217d7_1.tar.bz2
+  sha256: 826f50f825f6029c5b2b98cf864e9b2b5161a21b1838840df5b58845c7b7abba
+  md5: 22291aad1e4ad0f4904c4435bac91f15
+  depends:
+  - libcxx >=14.0.4
+  license: Apache-2.0
+  license_family: APACHE
+  size: 15863
+  timestamp: 1667006613955
+- kind: conda
+  name: libqdldl
+  version: 0.1.5
+  build: hf0c8a7f_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libqdldl-0.1.5-hf0c8a7f_1.tar.bz2
+  sha256: 82b4100f17c858d24c94cbe7da602d6faa13ddecef0a88801b9a124fb415a268
+  md5: 65b35a6648f6e566d230f9af0d2735ae
+  depends:
+  - libcxx >=14.0.4
+  license: Apache-2.0
+  license_family: APACHE
+  size: 16242
+  timestamp: 1667006655420
+- kind: conda
+  name: libsanitizer
+  version: 12.3.0
+  build: h0f45ef3_5
+  build_number: 5
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-12.3.0-h0f45ef3_5.conda
+  sha256: 70329cb8b0604273521cdae63520cb364a8d5477e156e65cdbd810984caeabee
+  md5: 11d1ceacff40054d5a74b12975d76f20
+  depends:
+  - libgcc-ng >=12.3.0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 3890717
+  timestamp: 1706819904612
+- kind: conda
+  name: libsanitizer
+  version: 12.3.0
+  build: h8ebda82_5
+  build_number: 5
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libsanitizer-12.3.0-h8ebda82_5.conda
+  sha256: a30e1e297218c097ee715cc52bf4711e3f21d6f4fcf2a7e3e1ebae9a65903d04
+  md5: b23f5de2b160df4b83a5b16f4deab34a
+  depends:
+  - libgcc-ng >=12.3.0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 3912550
+  timestamp: 1706820192702
+- kind: conda
+  name: libscotch
+  version: 7.0.4
+  build: h16908e7_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libscotch-7.0.4-h16908e7_1.conda
+  sha256: 75df1476d9d5a4dddd6a599e23619602b91c005ccc54b39f8fea1b5567301da2
+  md5: 8ffa038b339d3194d8197d723acedd69
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc-ng >=12
+  - libgfortran-ng
+  - libgfortran5 >=12.3.0
+  - libzlib >=1.2.13,<1.3.0a0
+  - xz >=5.2.6,<6.0a0
+  - zlib
+  license: CECILL-C
+  size: 354651
+  timestamp: 1702326088455
+- kind: conda
+  name: libscotch
+  version: 7.0.4
+  build: h91e35bf_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libscotch-7.0.4-h91e35bf_1.conda
+  sha256: 7113e233da8f2cd73e838ed914045c3d3cee970d1eb99551288446af668177ea
+  md5: 5716a9d2428758c0b7d3ad3d62491918
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc-ng >=12
+  - libgfortran-ng
+  - libgfortran5 >=12.3.0
+  - libzlib >=1.2.13,<1.3.0a0
+  - xz >=5.2.6,<6.0a0
+  - zlib
+  license: CECILL-C
+  size: 339683
+  timestamp: 1702323132649
+- kind: conda
+  name: libscotch
+  version: 7.0.4
+  build: hc2ac6e5_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libscotch-7.0.4-hc2ac6e5_1.conda
+  sha256: a04a5618dc77705c050c42ba79d283321a1d95ddb46506115da3a82913fb199d
+  md5: 09bac22f45db314b1ad5774b336f27c7
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libgfortran 5.*
+  - libgfortran5 >=12.3.0
+  - libgfortran5 >=13.2.0
+  - libzlib >=1.2.13,<1.3.0a0
+  - xz >=5.2.6,<6.0a0
+  - zlib
+  license: CECILL-C
+  size: 300388
+  timestamp: 1702323427663
+- kind: conda
+  name: libscotch
+  version: 7.0.4
+  build: hc938e73_1
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libscotch-7.0.4-hc938e73_1.conda
+  sha256: 7144f8d48a5d495d66d30d775ba0e04e885cee47f7ae45202a2f56f54d59e199
+  md5: 9e6ba692678598a5471087831d8db21e
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libgfortran 5.*
+  - libgfortran5 >=12.3.0
+  - libgfortran5 >=13.2.0
+  - libzlib >=1.2.13,<1.3.0a0
+  - xz >=5.2.6,<6.0a0
+  - zlib
+  license: CECILL-C
+  size: 280127
+  timestamp: 1702323402640
+- kind: conda
+  name: libsndfile
+  version: 1.2.2
+  build: h79657aa_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libsndfile-1.2.2-h79657aa_1.conda
+  sha256: 8fcd5e45d6fb071e8baf492ebb8710203fd5eedf0cb791e007265db373c89942
+  md5: ad8e62c0faec46b1442f960489c80b49
+  depends:
+  - lame >=3.100,<3.101.0a0
+  - libflac >=1.4.3,<1.5.0a0
+  - libgcc-ng >=12
+  - libogg >=1.3.4,<1.4.0a0
+  - libopus >=1.3.1,<2.0a0
+  - libstdcxx-ng >=12
+  - libvorbis >=1.3.7,<1.4.0a0
+  - mpg123 >=1.32.1,<1.33.0a0
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 396501
+  timestamp: 1695747749825
+- kind: conda
+  name: libsndfile
+  version: 1.2.2
+  build: hc60ed4a_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libsndfile-1.2.2-hc60ed4a_1.conda
+  sha256: f709cbede3d4f3aee4e2f8d60bd9e256057f410bd60b8964cb8cf82ec1457573
+  md5: ef1910918dd895516a769ed36b5b3a4e
+  depends:
+  - lame >=3.100,<3.101.0a0
+  - libflac >=1.4.3,<1.5.0a0
+  - libgcc-ng >=12
+  - libogg >=1.3.4,<1.4.0a0
+  - libopus >=1.3.1,<2.0a0
+  - libstdcxx-ng >=12
+  - libvorbis >=1.3.7,<1.4.0a0
+  - mpg123 >=1.32.1,<1.33.0a0
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 354372
+  timestamp: 1695747735668
+- kind: conda
+  name: libspral
+  version: 2023.09.07
+  build: h6aa6db2_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libspral-2023.09.07-h6aa6db2_2.conda
+  sha256: 9f6ead98e3048f9f834e27701cbd460dc180b66da674077282efedc33c2e4385
+  md5: f6edcc565451deb910b65fc670991bfb
+  depends:
+  - _openmp_mutex >=4.5
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgcc-ng >=12
+  - libgfortran-ng
+  - libgfortran5 >=12.3.0
+  - libhwloc >=2.9.3,<2.9.4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
+  - metis >=5.1.0,<5.1.1.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 284486
+  timestamp: 1706172132015
+- kind: conda
+  name: libspral
+  version: 2023.09.07
+  build: h98a5362_2
+  build_number: 2
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libspral-2023.09.07-h98a5362_2.conda
+  sha256: dd90d120301994da5ec3d3b9bfbd431e2fd035e88e234e3f523e9a66c285b318
+  md5: b922d0858beaaaa81bcbe37d3b50d3d0
+  depends:
+  - _openmp_mutex >=4.5
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgcc-ng >=12
+  - libgfortran-ng
+  - libgfortran5 >=12.3.0
+  - libhwloc >=2.9.3,<2.9.4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
+  - metis >=5.1.0,<5.1.1.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 277170
+  timestamp: 1706177768929
+- kind: conda
+  name: libsqlite
+  version: 3.45.1
+  build: h091b4b1_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.45.1-h091b4b1_0.conda
+  sha256: 64befc456a38907d1334fb58eb604a96625d3a23a2f34fbd203e0b307a4a141e
+  md5: a153a40a253962373b5330eb9d182da9
+  depends:
+  - libzlib >=1.2.13,<1.3.0a0
+  license: Unlicense
+  size: 824677
+  timestamp: 1707495428497
+- kind: conda
+  name: libsqlite
+  version: 3.45.1
+  build: h194ca79_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libsqlite-3.45.1-h194ca79_0.conda
+  sha256: 2aeb33230d074c9c91605def8296475dc0c064c23bd50ccfacb8336ec4bfc422
+  md5: 4190198deb1ed253eb938f6a6d92ff4f
+  depends:
+  - libgcc-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
+  license: Unlicense
+  size: 1034865
+  timestamp: 1707495102245
+- kind: conda
+  name: libsqlite
+  version: 3.45.1
+  build: h2797004_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.45.1-h2797004_0.conda
+  sha256: 1b379d1c652b25d0540251d422ef767472e768fd36b77261045e97f9ba6d3faa
+  md5: fc4ccadfbf6d4784de88c41704792562
+  depends:
+  - libgcc-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
+  license: Unlicense
+  size: 859346
+  timestamp: 1707495156652
+- kind: conda
+  name: libsqlite
+  version: 3.45.1
+  build: h92b6c6a_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.45.1-h92b6c6a_0.conda
+  sha256: d65ce7093ecf5884b241a5ca8d26f80d21eaebf14ca67923b50c249f47a84cf9
+  md5: e451d14a5412cdc68be50493df251f55
+  depends:
+  - libzlib >=1.2.13,<1.3.0a0
+  license: Unlicense
+  size: 902313
+  timestamp: 1707495366004
+- kind: conda
+  name: libsqlite
+  version: 3.45.1
+  build: hcfcfb64_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.45.1-hcfcfb64_0.conda
+  sha256: e1010f4ac7b056d85d91e6cb6137ef118f920eba88059261689e543780b230df
+  md5: c583c1d6999b7aa148eff3089e13c44b
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Unlicense
+  size: 870045
+  timestamp: 1707495642340
+- kind: conda
+  name: libssh2
+  version: 1.11.0
+  build: h0841786_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.0-h0841786_0.conda
+  sha256: 50e47fd9c4f7bf841a11647ae7486f65220cfc988ec422a4475fe8d5a823824d
+  md5: 1f5a58e686b13bcfde88b93f547d23fe
+  depends:
+  - libgcc-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.1.1,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 271133
+  timestamp: 1685837707056
+- kind: conda
+  name: libssh2
+  version: 1.11.0
+  build: h492db2e_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libssh2-1.11.0-h492db2e_0.conda
+  sha256: 409163dd4a888b9266369f1bce57b5ca56c216e34249637c3e10eb404e356171
+  md5: 45532845e121677ad328c9af9953f161
+  depends:
+  - libgcc-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.1.1,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 284335
+  timestamp: 1685837600415
+- kind: conda
+  name: libssh2
+  version: 1.11.0
+  build: h7a5bd25_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libssh2-1.11.0-h7a5bd25_0.conda
+  sha256: bb57d0c53289721fff1eeb3103a1c6a988178e88d8a8f4345b0b91a35f0e0015
+  md5: 029f7dc931a3b626b94823bc77830b01
+  depends:
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.1.1,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 255610
+  timestamp: 1685837894256
+- kind: conda
+  name: libssh2
+  version: 1.11.0
+  build: h7dfc565_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libssh2-1.11.0-h7dfc565_0.conda
+  sha256: 813fd04eed2a2d5d9c36e53c554f9c1f08e9324e2922bd60c9c52dbbed2dbcec
+  md5: dc262d03aae04fe26825062879141a41
+  depends:
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.1.1,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 266806
+  timestamp: 1685838242099
+- kind: conda
+  name: libssh2
+  version: 1.11.0
+  build: hd019ec5_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libssh2-1.11.0-hd019ec5_0.conda
+  sha256: f3886763b88f4b24265db6036535ef77b7b77ce91b1cbe588c0fbdd861eec515
+  md5: ca3a72efba692c59a90d4b9fc0dfe774
+  depends:
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.1.1,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 259556
+  timestamp: 1685837820566
+- kind: conda
+  name: libstdcxx-devel_linux-64
+  version: 12.3.0
+  build: h8bca6fd_105
+  build_number: 105
+  subdir: noarch
+  noarch: generic
+  url: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-12.3.0-h8bca6fd_105.conda
+  sha256: efcd4b4cba79cd0fb5a87757c7ca63171cf3b7b06446192364bae7defb50b94c
+  md5: b3c6062c84a8e172555ee104ea6a01ab
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 11597918
+  timestamp: 1706819775415
+- kind: conda
+  name: libstdcxx-devel_linux-aarch64
+  version: 12.3.0
+  build: h8b5ab12_105
+  build_number: 105
+  subdir: noarch
+  noarch: generic
+  url: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-aarch64-12.3.0-h8b5ab12_105.conda
+  sha256: f38714920c850eac02b4b8175146188a3657c7ea5a3be22ae644b9d5e2356663
+  md5: 47f23759d39c3d993dc189ce4ab7f79c
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 10380824
+  timestamp: 1706820045043
+- kind: conda
+  name: libstdcxx-ng
+  version: 13.2.0
+  build: h7e041cc_5
+  build_number: 5
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-13.2.0-h7e041cc_5.conda
+  sha256: a56c5b11f1e73a86e120e6141a42d9e935a99a2098491ac9e15347a1476ce777
+  md5: f6f6600d18a4047b54f803cf708b868a
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 3834139
+  timestamp: 1706819252496
+- kind: conda
+  name: libstdcxx-ng
+  version: 13.2.0
+  build: h9a76618_5
+  build_number: 5
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-ng-13.2.0-h9a76618_5.conda
+  sha256: c209f23a8a497fc87107a68b6bbc8d2089cf15fd4015b558dfdce63544379b05
+  md5: 1b79d37dce0fad96bdf3de03925f43b4
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 3752658
+  timestamp: 1706820778418
+- kind: conda
+  name: libsystemd0
+  version: '255'
+  build: h3516f8a_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-255-h3516f8a_0.conda
+  sha256: 9306eafe761a758e0c2efa92025bfc0684c66ef500efdea4fbe4687b59e8099e
+  md5: 24e2649ebd432e652aa72cfd05f23a8e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libcap >=2.69,<2.70.0a0
+  - libgcc-ng >=12
+  - libgcrypt >=1.10.3,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: LGPL-2.1-or-later
+  size: 404326
+  timestamp: 1701982703751
+- kind: conda
+  name: libsystemd0
+  version: '255'
+  build: h91e93f8_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libsystemd0-255-h91e93f8_0.conda
+  sha256: c49c1dad8881cb518412f8e56fa251afbde1887e82d197cbb27ab39afafd39af
+  md5: 7834e7d37b2e4b65b96a75634e45c304
+  depends:
+  - libcap >=2.69,<2.70.0a0
+  - libgcc-ng >=12
+  - libgcrypt >=1.10.3,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: LGPL-2.1-or-later
+  size: 423120
+  timestamp: 1701982603040
+- kind: conda
+  name: libtasn1
+  version: 4.19.0
+  build: h166bdaf_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libtasn1-4.19.0-h166bdaf_0.tar.bz2
+  sha256: 5bfeada0e1c6ec2574afe2d17cdbc39994d693a41431338a6cb9dfa7c4d7bfc8
+  md5: 93840744a8552e9ebf6bb1a5dffc125a
+  depends:
+  - libgcc-ng >=12
+  license: GPL-3.0-or-later
+  license_family: GPL
+  size: 116878
+  timestamp: 1661325701583
+- kind: conda
+  name: libtasn1
+  version: 4.19.0
+  build: h1a8c8d9_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libtasn1-4.19.0-h1a8c8d9_0.tar.bz2
+  sha256: 912e96644ea22b49921c71c9c94bcdd2b6463e9313da895c2fcee298a8c0e44c
+  md5: c35bc17c31579789c76739486fc6d27a
+  license: GPL-3.0-or-later
+  license_family: GPL
+  size: 116745
+  timestamp: 1661325945767
+- kind: conda
+  name: libtasn1
+  version: 4.19.0
+  build: h4e544f5_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libtasn1-4.19.0-h4e544f5_0.tar.bz2
+  sha256: 96310724113f6f2ed2f3e55e19e87fe29e1678d0ee21386e4037c3703d542743
+  md5: a94c6aaaaac3c2c9dcff6967ed1064be
+  depends:
+  - libgcc-ng >=12
+  license: GPL-3.0-or-later
+  license_family: GPL
+  size: 124954
+  timestamp: 1661325677442
+- kind: conda
+  name: libtasn1
+  version: 4.19.0
+  build: hb7f2c08_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libtasn1-4.19.0-hb7f2c08_0.tar.bz2
+  sha256: 4197c155fb460fae65288c6c098c39f22495a53838356d29b79b31b8e33486dc
+  md5: 73f67fb011b4477b101a95a082c74f0a
+  license: GPL-3.0-or-later
+  license_family: GPL
+  size: 118785
+  timestamp: 1661325967954
+- kind: conda
+  name: libtiff
+  version: 4.6.0
+  build: h1708d11_2
+  build_number: 2
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libtiff-4.6.0-h1708d11_2.conda
+  sha256: e6aecca5bbf354ab34fb04d8d6ef4a50477f64997c368d734cc5d1d8b1a21d3a
+  md5: d5638e110e7f22e2602a8edd20656720
+  depends:
+  - lerc >=4.0.0,<5.0a0
+  - libdeflate >=1.19,<1.20.0a0
+  - libgcc-ng >=12
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libstdcxx-ng >=12
+  - libwebp-base >=1.3.2,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: HPND
+  size: 316074
+  timestamp: 1695664604579
+- kind: conda
+  name: libtiff
+  version: 4.6.0
+  build: h684deea_2
+  build_number: 2
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libtiff-4.6.0-h684deea_2.conda
+  sha256: 1ef5bd7295f4316b111f70ad21356fb9f0de50b85a341cac9e3a61ac6487fdf1
+  md5: 2ca10a325063e000ad6d2a5900061e0d
+  depends:
+  - lerc >=4.0.0,<5.0a0
+  - libcxx >=15.0.7
+  - libdeflate >=1.19,<1.20.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: HPND
+  size: 266501
+  timestamp: 1695661828714
+- kind: conda
+  name: libtiff
+  version: 4.6.0
+  build: h6e2ebb7_2
+  build_number: 2
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.6.0-h6e2ebb7_2.conda
+  sha256: f7b50b71840a5d8edd74a8bccf0c173ca2599bd136e366c35722272b4afa0500
+  md5: 08d653b74ee2dec0131ad4259ffbb126
+  depends:
+  - lerc >=4.0.0,<5.0a0
+  - libdeflate >=1.19,<1.20.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: HPND
+  size: 787430
+  timestamp: 1695662030293
+- kind: conda
+  name: libtiff
+  version: 4.6.0
+  build: ha8a6c65_2
+  build_number: 2
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.6.0-ha8a6c65_2.conda
+  sha256: b18ef36eb90f190db22c56ae5a080bccc16669c8f5b795a6211d7b0c00c18ff7
+  md5: 596d6d949bab9a75a492d451f521f457
+  depends:
+  - lerc >=4.0.0,<5.0a0
+  - libcxx >=15.0.7
+  - libdeflate >=1.19,<1.20.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: HPND
+  size: 246265
+  timestamp: 1695661829324
+- kind: conda
+  name: libtiff
+  version: 4.6.0
+  build: ha9c0a0a_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.6.0-ha9c0a0a_2.conda
+  sha256: 45158f5fbee7ee3e257e6b9f51b9f1c919ed5518a94a9973fe7fa4764330473e
+  md5: 55ed21669b2015f77c180feb1dd41930
+  depends:
+  - lerc >=4.0.0,<5.0a0
+  - libdeflate >=1.19,<1.20.0a0
+  - libgcc-ng >=12
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libstdcxx-ng >=12
+  - libwebp-base >=1.3.2,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: HPND
+  size: 283198
+  timestamp: 1695661593314
+- kind: conda
+  name: libunistring
+  version: 0.9.10
+  build: h0d85af4_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libunistring-0.9.10-h0d85af4_0.tar.bz2
+  sha256: c5805a58cd2b211bffdc8b7cdeba9af3cee456196ab52ab9a30e0353bc95beb7
+  md5: 40f27dc16f73256d7b93e53c4f03d92f
+  license: GPL-3.0-only OR LGPL-3.0-only
+  size: 1392865
+  timestamp: 1626955817826
+- kind: conda
+  name: libunistring
+  version: 0.9.10
+  build: h3422bc3_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libunistring-0.9.10-h3422bc3_0.tar.bz2
+  sha256: a1afe12ab199f82f339eae83405d293d197f2485d45346a709703bc7e8299949
+  md5: d88e77a4861e20bd96bde6628ee7a5ae
+  license: GPL-3.0-only OR LGPL-3.0-only
+  size: 1577561
+  timestamp: 1626955172521
+- kind: conda
+  name: libunistring
+  version: 0.9.10
+  build: h7f98852_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libunistring-0.9.10-h7f98852_0.tar.bz2
+  sha256: e88c45505921db29c08df3439ddb7f771bbff35f95e7d3103bf365d5d6ce2a6d
+  md5: 7245a044b4a1980ed83196176b78b73a
+  depends:
+  - libgcc-ng >=9.3.0
+  license: GPL-3.0-only OR LGPL-3.0-only
+  size: 1433436
+  timestamp: 1626955018689
+- kind: conda
+  name: libunistring
+  version: 0.9.10
+  build: hf897c2e_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libunistring-0.9.10-hf897c2e_0.tar.bz2
+  sha256: 03acebd5a01a255fe40d47f941c6cab4dc7829206d86d990b0c88cf0ff66e646
+  md5: 7c68521243dc20afba4c4c05eb09586e
+  depends:
+  - libgcc-ng >=9.3.0
+  license: GPL-3.0-only OR LGPL-3.0-only
+  size: 1409624
+  timestamp: 1626959749923
+- kind: conda
+  name: libuuid
+  version: 2.38.1
+  build: h0b41bf4_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
+  sha256: 787eb542f055a2b3de553614b25f09eefb0a0931b0c87dbcce6efdfd92f04f18
+  md5: 40b61aab5c7ba9ff276c41cfffe6b80b
+  depends:
+  - libgcc-ng >=12
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 33601
+  timestamp: 1680112270483
+- kind: conda
+  name: libuuid
+  version: 2.38.1
+  build: hb4cce97_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libuuid-2.38.1-hb4cce97_0.conda
+  sha256: 616277b0c5f7616c2cdf36f6c316ea3f9aa5bb35f2d4476a349ab58b9b91675f
+  md5: 000e30b09db0b7c775b21695dff30969
+  depends:
+  - libgcc-ng >=12
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 35720
+  timestamp: 1680113474501
+- kind: conda
+  name: libva
+  version: 2.20.0
+  build: hd590300_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libva-2.20.0-hd590300_0.conda
+  sha256: 972d6f67d854d0f0fc2593f8bddc8d411859437ace7248c374e1a85a9ea9d410
+  md5: 933bcea637569c6cea6084957028cb53
+  depends:
+  - libdrm >=2.4.114,<2.5.0a0
+  - libgcc-ng >=12
+  - xorg-libx11 >=1.8.6,<2.0a0
+  - xorg-libxext >=1.3.4,<2.0a0
+  - xorg-libxfixes
+  license: MIT
+  license_family: MIT
+  size: 188151
+  timestamp: 1694689905260
+- kind: conda
+  name: libvorbis
+  version: 1.3.7
+  build: h01db608_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libvorbis-1.3.7-h01db608_0.tar.bz2
+  sha256: 1ade4727be5c52b287001b8094d02af66342dfe0ba13ef69222aaaf2e9be4342
+  md5: c2863ff72c6d8a59054f8b9102c206e9
+  depends:
+  - libgcc-ng >=9.3.0
+  - libogg >=1.3.4,<1.4.0a0
+  - libstdcxx-ng >=9.3.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 292082
+  timestamp: 1610616294416
+- kind: conda
+  name: libvorbis
+  version: 1.3.7
+  build: h046ec9c_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libvorbis-1.3.7-h046ec9c_0.tar.bz2
+  sha256: fbcce1005efcd616e452dea07fe34893d8dd13c65628e74920eeb68ac549faf7
+  md5: fbbda1fede0aadaa252f6919148c4ce1
+  depends:
+  - libcxx >=11.0.0
+  - libogg >=1.3.4,<1.4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 254208
+  timestamp: 1610609857389
+- kind: conda
+  name: libvorbis
+  version: 1.3.7
+  build: h0e60522_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libvorbis-1.3.7-h0e60522_0.tar.bz2
+  sha256: 6cdc018a024908270205d8512d92f92cf0adaaa5401c2b403757189b138bf56a
+  md5: e1a22282de0169c93e4ffe6ce6acc212
+  depends:
+  - libogg >=1.3.4,<1.4.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 273721
+  timestamp: 1610610022421
+- kind: conda
+  name: libvorbis
+  version: 1.3.7
+  build: h9c3ff4c_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libvorbis-1.3.7-h9c3ff4c_0.tar.bz2
+  sha256: 53080d72388a57b3c31ad5805c93a7328e46ff22fab7c44ad2a86d712740af33
+  md5: 309dec04b70a3cc0f1e84a4013683bc0
+  depends:
+  - libgcc-ng >=9.3.0
+  - libogg >=1.3.4,<1.4.0a0
+  - libstdcxx-ng >=9.3.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 286280
+  timestamp: 1610609811627
+- kind: conda
+  name: libvorbis
+  version: 1.3.7
+  build: h9f76cd9_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libvorbis-1.3.7-h9f76cd9_0.tar.bz2
+  sha256: 60457217e20d8b24a8390c81338a8fa69c8656b440c067cd82f802a09da93cb9
+  md5: 92a1a88d1a1d468c19d9e1659ac8d3df
+  depends:
+  - libcxx >=11.0.0
+  - libogg >=1.3.4,<1.4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 254839
+  timestamp: 1610609991029
+- kind: conda
+  name: libvpx
+  version: 1.13.1
+  build: h2f0025b_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libvpx-1.13.1-h2f0025b_0.conda
+  sha256: c403cd479dc5acd86d9b62ddb2fb4756d7775e6c2f25db79c9efa187b759af4f
+  md5: 9a6ce789667dfdbea886b5d9e7f268a0
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1193429
+  timestamp: 1696342120210
+- kind: conda
+  name: libvpx
+  version: 1.13.1
+  build: h59595ed_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libvpx-1.13.1-h59595ed_0.conda
+  sha256: 8067e73d6e4f82eae158cb86acdc2d1cf18dd7f13807f0b93e13a07ee4c04b79
+  md5: 0974a6d3432e10bae02bcab0cce1b308
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1006029
+  timestamp: 1696342275863
+- kind: conda
+  name: libvpx
+  version: 1.13.1
+  build: hb765f3a_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libvpx-1.13.1-hb765f3a_0.conda
+  sha256: 3a9c5e903cc212f426bb4515293b45c84cb6173fd9ecc5bdba144e07c817d84c
+  md5: d62a0d3d8c01bd9fad3fd17d720d0cf5
+  depends:
+  - libcxx >=15.0.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1134986
+  timestamp: 1696342737036
+- kind: conda
+  name: libvpx
+  version: 1.13.1
+  build: he965462_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libvpx-1.13.1-he965462_0.conda
+  sha256: cc3d921861e4ac760b1f54caef0fae7ce2e94faca51bcb438696bfbf16e42b54
+  md5: 217e20148014ce0118f7d10852ac2fec
+  depends:
+  - libcxx >=15.0.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1285936
+  timestamp: 1696342600631
+- kind: conda
+  name: libwebp-base
+  version: 1.3.2
+  build: h0dc2134_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libwebp-base-1.3.2-h0dc2134_0.conda
+  sha256: fa7580f26fec4c28321ec2ece1257f3293e0c646c635e9904679f4a8369be401
+  md5: 4e7e9d244e87d66c18d36894fd6a8ae5
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 346599
+  timestamp: 1694709233836
+- kind: conda
+  name: libwebp-base
+  version: 1.3.2
+  build: h31becfc_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libwebp-base-1.3.2-h31becfc_0.conda
+  sha256: a85484d8399bfa310512fe94863c8da3b224ac13f5e97736da65be6f509a8bf8
+  md5: 1490de434d2a2c06a98af27641a2ffff
+  depends:
+  - libgcc-ng >=12
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 363462
+  timestamp: 1694710436617
+- kind: conda
+  name: libwebp-base
+  version: 1.3.2
+  build: hb547adb_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libwebp-base-1.3.2-hb547adb_0.conda
+  sha256: a159b848193043fb58465ae6a449361615dadcf27babfe0b18db2bd3eb59e958
+  md5: 85dbc11098cdbe4244cd73f29a3ab795
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 273844
+  timestamp: 1694709510635
+- kind: conda
+  name: libwebp-base
+  version: 1.3.2
+  build: hcfcfb64_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libwebp-base-1.3.2-hcfcfb64_0.conda
+  sha256: af1453fab10d1fb8b379c61a78882614051a8bac37307d7ac4fb58eac667709e
+  md5: dcde8820959e64378d4e06147ffecfdd
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 268870
+  timestamp: 1694709461733
+- kind: conda
+  name: libwebp-base
+  version: 1.3.2
+  build: hd590300_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.3.2-hd590300_0.conda
+  sha256: 68764a760fa81ef35dacb067fe8ace452bbb41476536a4a147a1051df29525f0
+  md5: 30de3fd9b3b602f7473f30e684eeea8c
+  depends:
+  - libgcc-ng >=12
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 401830
+  timestamp: 1694709121323
+- kind: conda
+  name: libxcb
+  version: '1.15'
+  build: h0b41bf4_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.15-h0b41bf4_0.conda
+  sha256: a670902f0a3173a466c058d2ac22ca1dd0df0453d3a80e0212815c20a16b0485
+  md5: 33277193f5b92bad9fdd230eb700929c
+  depends:
+  - libgcc-ng >=12
+  - pthread-stubs
+  - xorg-libxau
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  size: 384238
+  timestamp: 1682082368177
+- kind: conda
+  name: libxcb
+  version: '1.15'
+  build: h2a766a3_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libxcb-1.15-h2a766a3_0.conda
+  sha256: d159fcdb8b74187b0bd32f2d9b3a9191bc8b786a97e413aa66e19c39ba7050a0
+  md5: eb3d8c8170e3d03f2564ed2024aa00c8
+  depends:
+  - libgcc-ng >=12
+  - pthread-stubs
+  - xorg-libxau
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  size: 388526
+  timestamp: 1682083614077
+- kind: conda
+  name: libxcb
+  version: '1.15'
+  build: hb7f2c08_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libxcb-1.15-hb7f2c08_0.conda
+  sha256: f41904f466acc8b3197f37f2dd3a08da75720c7f7464d9267635debc4ac1902b
+  md5: 5513f57e0238c87c12dffedbcc9c1a4a
+  depends:
+  - pthread-stubs
+  - xorg-libxau
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  size: 313793
+  timestamp: 1682083036825
+- kind: conda
+  name: libxcb
+  version: '1.15'
+  build: hf346824_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libxcb-1.15-hf346824_0.conda
+  sha256: 6eaa87760ff3e91bb5524189700139db46f8946ff6331f4e571e4a9356edbb0d
+  md5: 988d5f86ab60fa6de91b3ee3a88a3af9
+  depends:
+  - pthread-stubs
+  - xorg-libxau
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  size: 334770
+  timestamp: 1682082734262
+- kind: conda
+  name: libxcrypt
+  version: 4.4.36
+  build: h31becfc_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libxcrypt-4.4.36-h31becfc_1.conda
+  sha256: 6b46c397644091b8a26a3048636d10b989b1bf266d4be5e9474bf763f828f41f
+  md5: b4df5d7d4b63579d081fd3a4cf99740e
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.1-or-later
+  size: 114269
+  timestamp: 1702724369203
+- kind: conda
+  name: libxcrypt
+  version: 4.4.36
+  build: hd590300_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
+  sha256: 6ae68e0b86423ef188196fff6207ed0c8195dd84273cb5623b85aa08033a410c
+  md5: 5aa797f8787fe7a17d1b0821485b5adc
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.1-or-later
+  size: 100393
+  timestamp: 1702724383534
+- kind: conda
+  name: libxkbcommon
+  version: 1.6.0
+  build: h217f472_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libxkbcommon-1.6.0-h217f472_1.conda
+  sha256: 1d027bfb83ca1dd2007a5e0f8f96e8abe0e5b0fbccb26393d354d40301e37998
+  md5: 2517505a8ffdf02518e3ccb67e1ec30b
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libxcb >=1.15,<1.16.0a0
+  - libxml2 >=2.12.1,<3.0.0a0
+  - xkeyboard-config
+  - xorg-libxau >=1.0.11,<2.0a0
+  license: MIT/X11 Derivative
+  license_family: MIT
+  size: 578444
+  timestamp: 1701352615055
+- kind: conda
+  name: libxkbcommon
+  version: 1.6.0
+  build: hd429924_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libxkbcommon-1.6.0-hd429924_1.conda
+  sha256: 213a4c927618198fd5fb5e7b0a76b89310a9c04a3ea025d59771754ee8a89451
+  md5: 1dbcc04604fdf1e526e6d1b0b6938396
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libxcb >=1.15,<1.16.0a0
+  - libxml2 >=2.12.1,<3.0.0a0
+  - xkeyboard-config
+  - xorg-libxau >=1.0.11,<2.0a0
+  license: MIT/X11 Derivative
+  license_family: MIT
+  size: 574868
+  timestamp: 1701352639132
+- kind: conda
+  name: libxml2
+  version: 2.12.5
+  build: h0d0cfa8_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.12.5-h0d0cfa8_0.conda
+  sha256: 34daea04dc08af703effe424527505789f8a50fa71b447c7cac6f0d36a02cce3
+  md5: 6aef67f18bef799926bc05948a1239e3
+  depends:
+  - icu >=73.2,<74.0a0
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - xz >=5.2.6,<6.0a0
+  license: MIT
+  license_family: MIT
+  size: 587894
+  timestamp: 1707084537489
+- kind: conda
+  name: libxml2
+  version: 2.12.5
+  build: h232c23b_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.12.5-h232c23b_0.conda
+  sha256: db9bf97e9e367985204331b58a059ebd5a4e0cb9e1c8754e9ecb23046b7b7bc1
+  md5: c442ebfda7a475f5e78f1c8e45f1e919
+  depends:
+  - icu >=73.2,<74.0a0
+  - libgcc-ng >=12
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - xz >=5.2.6,<6.0a0
+  license: MIT
+  license_family: MIT
+  size: 704829
+  timestamp: 1707084502281
+- kind: conda
+  name: libxml2
+  version: 2.12.5
+  build: h3091e33_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libxml2-2.12.5-h3091e33_0.conda
+  sha256: 34f7a007fa23b70c56358738d7ba801df9a923422f2dcd23f3b2ca790ea2460a
+  md5: 2fcb5d64474a337f2a4213ec1dd40ce2
+  depends:
+  - icu >=73.2,<74.0a0
+  - libgcc-ng >=12
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - xz >=5.2.6,<6.0a0
+  license: MIT
+  license_family: MIT
+  size: 752149
+  timestamp: 1707084726972
+- kind: conda
+  name: libxml2
+  version: 2.12.5
+  build: hc0ae0f7_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.12.5-hc0ae0f7_0.conda
+  sha256: a84f355dcf9039ae54e21bf8833c16200f848fd333a5e68c143e142cc55dc07d
+  md5: abe27e7ab68b95e8d0e41cd5018ec8ae
+  depends:
+  - icu >=73.2,<74.0a0
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - xz >=5.2.6,<6.0a0
+  license: MIT
+  license_family: MIT
+  size: 619351
+  timestamp: 1707084558935
+- kind: conda
+  name: libxml2
+  version: 2.12.5
+  build: hc3477c8_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.12.5-hc3477c8_0.conda
+  sha256: 15696b049911b3ea5d37672408e500fb27e375d865f8cceac9cb02f9349e6804
+  md5: d8c3c1c8242db352f38cd1dc0bf44f77
+  depends:
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 1567894
+  timestamp: 1707084720091
+- kind: conda
+  name: libxslt
+  version: 1.1.39
+  build: h03b04e6_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libxslt-1.1.39-h03b04e6_0.conda
+  sha256: decfc5614a10231a17543b7366616fb2d88c14be6dd9dd5ecde63aa9a5acfb9e
+  md5: a6e0cec6b3517ffc6b5d36a920fc9312
+  depends:
+  - libxml2 >=2.12.1,<3.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 231368
+  timestamp: 1701628933115
+- kind: conda
+  name: libxslt
+  version: 1.1.39
+  build: h1cc9640_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libxslt-1.1.39-h1cc9640_0.conda
+  sha256: 89ce87b5f594b2ddcd3ddf66dd3f36f85bbe3562b3f408409ccec787d7ed36a3
+  md5: 13e1d3f9188e85c6d59a98651aced002
+  depends:
+  - libgcc-ng >=12
+  - libxml2 >=2.12.1,<3.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 260979
+  timestamp: 1701628809171
+- kind: conda
+  name: libxslt
+  version: 1.1.39
+  build: h223e5b9_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libxslt-1.1.39-h223e5b9_0.conda
+  sha256: 2f1d99ef3fb960f23a63f06cf65ee621a5594a8b4616f35d9805be44617a92af
+  md5: 560c9cacc33e927f55b998eaa0cb1732
+  depends:
+  - libxml2 >=2.12.1,<3.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 225705
+  timestamp: 1701628966565
+- kind: conda
+  name: libxslt
+  version: 1.1.39
+  build: h3df6e99_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libxslt-1.1.39-h3df6e99_0.conda
+  sha256: 6e3d99466d2076c35e7ac8dcdfe604da3d593f55b74a5b8e96c2b2ff63c247aa
+  md5: 279ee338c9b34871d578cb3c7aa68f70
+  depends:
+  - libxml2 >=2.12.1,<3.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 418542
+  timestamp: 1701629338549
+- kind: conda
+  name: libxslt
+  version: 1.1.39
+  build: h76b75d6_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libxslt-1.1.39-h76b75d6_0.conda
+  sha256: 684e9b67ef7b9ca0ca993762eeb39705ec58e2e7f958555c758da7ef416db9f3
+  md5: e71f31f8cfb0a91439f2086fc8aa0461
+  depends:
+  - libgcc-ng >=12
+  - libxml2 >=2.12.1,<3.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 254297
+  timestamp: 1701628814990
+- kind: conda
+  name: libyarp
+  version: 3.9.0
+  build: h6d2be9b_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libyarp-3.9.0-h6d2be9b_1.conda
+  sha256: 05db9ab7b0109a8276a90655328192c3cca8e2325662754f2378f95d5f99ac48
+  md5: 340e8d819db339d5b13f0799f4073bfb
+  depends:
+  - ace >=7.1.3,<7.1.4.0a0
+  - eigen
+  - ffmpeg >=6.1.1,<7.0a0
+  - libedit >=3.1.20191231,<3.2.0a0
+  - libgcc-ng >=12
+  - libi2c >=4.3,<5.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libopencv >=4.9.0,<4.9.1.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libsqlite >=3.44.2,<4.0a0
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
+  - portaudio >=19.6.0,<19.7.0a0
+  - qt-main >=5.15.8,<5.16.0a0
+  - robot-testing-framework >=2.0.1,<2.0.2.0a0
+  - sdl >=1.2.68,<1.3.0a0
+  - soxr >=0.1.3,<0.1.4.0a0
+  - tinyxml
+  - ycm-cmake-modules
+  license: BSD-3-Clause AND MIT AND GPL-3.0-or-later
+  size: 10700707
+  timestamp: 1706034748012
+- kind: conda
+  name: libyarp
+  version: 3.9.0
+  build: h9c0c770_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libyarp-3.9.0-h9c0c770_1.conda
+  sha256: 156cb9750ba2fc4b145f401cfaf5144c51188dc7e72c283d1f627693cd080b3c
+  md5: 952b04298dc0bf83604e9cdd9be491c2
+  depends:
+  - ace >=7.1.3,<7.1.4.0a0
+  - eigen
+  - ffmpeg >=6.1.1,<7.0a0
+  - libcxx >=15
+  - libedit >=3.1.20191231,<3.2.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libopencv >=4.9.0,<4.9.1.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libsqlite >=3.44.2,<4.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - portaudio >=19.6.0,<19.7.0a0
+  - qt-main >=5.15.8,<5.16.0a0
+  - robot-testing-framework >=2.0.1,<2.0.2.0a0
+  - sdl >=1.2.68,<1.3.0a0
+  - soxr >=0.1.3,<0.1.4.0a0
+  - tinyxml
+  - ycm-cmake-modules
+  license: BSD-3-Clause AND MIT AND GPL-3.0-or-later
+  size: 7620958
+  timestamp: 1706034947951
+- kind: conda
+  name: libyarp
+  version: 3.9.0
+  build: ha0ae21b_1
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libyarp-3.9.0-ha0ae21b_1.conda
+  sha256: 94d50ef201d8d7c401031af6421584e9e0262eb98301071956cdd91be0ac671f
+  md5: 0e33a632f0577b35a30965c5cee6a8fc
+  depends:
+  - ace >=7.1.3,<7.1.4.0a0
+  - eigen
+  - ffmpeg >=6.1.1,<7.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libopencv >=4.9.0,<4.9.1.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libsqlite >=3.44.2,<4.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - portaudio >=19.6.0,<19.7.0a0
+  - qt-main >=5.15.8,<5.16.0a0
+  - robot-testing-framework >=2.0.1,<2.0.2.0a0
+  - sdl >=1.2.68,<1.3.0a0
+  - soxr >=0.1.3,<0.1.4.0a0
+  - tinyxml
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - ycm-cmake-modules
+  license: BSD-3-Clause AND MIT AND GPL-3.0-or-later
+  size: 9242887
+  timestamp: 1706035547672
+- kind: conda
+  name: libyarp
+  version: 3.9.0
+  build: ha614a09_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libyarp-3.9.0-ha614a09_1.conda
+  sha256: 40e4ffb64d5964951576795559121a8da363c139b522b16c1540412d5024f320
+  md5: 77bab65488a974247a640ec1d1b8ab7e
+  depends:
+  - ace >=7.1.3,<7.1.4.0a0
+  - eigen
+  - ffmpeg >=6.1.1,<7.0a0
+  - libedit >=3.1.20191231,<3.2.0a0
+  - libgcc-ng >=12
+  - libi2c >=4.3,<5.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libopencv >=4.9.0,<4.9.1.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libsqlite >=3.44.2,<4.0a0
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
+  - portaudio >=19.6.0,<19.7.0a0
+  - qt-main >=5.15.8,<5.16.0a0
+  - robot-testing-framework >=2.0.1,<2.0.2.0a0
+  - sdl >=1.2.68,<1.3.0a0
+  - soxr >=0.1.3,<0.1.4.0a0
+  - tinyxml
+  - ycm-cmake-modules
+  license: BSD-3-Clause AND MIT AND GPL-3.0-or-later
+  size: 10150570
+  timestamp: 1706034146006
+- kind: conda
+  name: libyarp
+  version: 3.9.0
+  build: hff4382b_1
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libyarp-3.9.0-hff4382b_1.conda
+  sha256: b7015046d5fae7c5c555be09b24b4805b454d162c27a845eee04ac9e41d08549
+  md5: 7aad3a8158920c3f16dcb4e49d401149
+  depends:
+  - eigen
+  - ffmpeg >=6.1.1,<7.0a0
+  - libcxx >=15
+  - libedit >=3.1.20191231,<3.2.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libopencv >=4.9.0,<4.9.1.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libsqlite >=3.44.2,<4.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - portaudio >=19.6.0,<19.7.0a0
+  - qt-main >=5.15.8,<5.16.0a0
+  - robot-testing-framework >=2.0.1,<2.0.2.0a0
+  - sdl >=1.2.68,<1.3.0a0
+  - soxr >=0.1.3,<0.1.4.0a0
+  - tinyxml
+  - ycm-cmake-modules
+  license: BSD-3-Clause AND MIT AND GPL-3.0-or-later
+  size: 7452384
+  timestamp: 1706035278536
+- kind: conda
+  name: libzlib
+  version: 1.2.13
+  build: h31becfc_5
+  build_number: 5
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libzlib-1.2.13-h31becfc_5.conda
+  sha256: aeeefbb61e5e8227e53566d5e42dbb49e120eb99109996bf0dbfde8f180747a7
+  md5: b213aa87eea9491ef7b129179322e955
+  depends:
+  - libgcc-ng >=12
+  constrains:
+  - zlib 1.2.13 *_5
+  license: Zlib
+  license_family: Other
+  size: 67036
+  timestamp: 1686575148440
+- kind: conda
+  name: libzlib
+  version: 1.2.13
+  build: h53f4e23_5
+  build_number: 5
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.2.13-h53f4e23_5.conda
+  sha256: ab1c8aefa2d54322a63aaeeefe9cf877411851738616c4068e0dccc66b9c758a
+  md5: 1a47f5236db2e06a320ffa0392f81bd8
+  constrains:
+  - zlib 1.2.13 *_5
+  license: Zlib
+  license_family: Other
+  size: 48102
+  timestamp: 1686575426584
+- kind: conda
+  name: libzlib
+  version: 1.2.13
+  build: h8a1eda9_5
+  build_number: 5
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.2.13-h8a1eda9_5.conda
+  sha256: fc58ad7f47ffea10df1f2165369978fba0a1cc32594aad778f5eec725f334867
+  md5: 4a3ad23f6e16f99c04e166767193d700
+  constrains:
+  - zlib 1.2.13 *_5
+  license: Zlib
+  license_family: Other
+  size: 59404
+  timestamp: 1686575566695
+- kind: conda
+  name: libzlib
+  version: 1.2.13
+  build: hcfcfb64_5
+  build_number: 5
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.2.13-hcfcfb64_5.conda
+  sha256: c161822ee8130b71e08b6d282b9919c1de2c5274b29921a867bca0f7d30cad26
+  md5: 5fdb9c6a113b6b6cb5e517fd972d5f41
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - zlib 1.2.13 *_5
+  license: Zlib
+  license_family: Other
+  size: 55800
+  timestamp: 1686575452215
+- kind: conda
+  name: libzlib
+  version: 1.2.13
+  build: hd590300_5
+  build_number: 5
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.2.13-hd590300_5.conda
+  sha256: 370c7c5893b737596fd6ca0d9190c9715d89d888b8c88537ae1ef168c25e82e4
+  md5: f36c115f1ee199da648e0597ec2047ad
+  depends:
+  - libgcc-ng >=12
+  constrains:
+  - zlib 1.2.13 *_5
+  license: Zlib
+  license_family: Other
+  size: 61588
+  timestamp: 1686575217516
+- kind: conda
+  name: llvm-meta
+  version: 5.0.0
+  build: '0'
+  subdir: noarch
+  noarch: generic
+  url: https://conda.anaconda.org/conda-forge/noarch/llvm-meta-5.0.0-0.tar.bz2
+  sha256: 090bbeacc3297ff579b53f55ad184f05c30e316fe9d5d7df63df1d2ad4578b79
+  md5: 213b5b5ad34008147a824460e50a691c
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2667
+- kind: conda
+  name: llvm-openmp
+  version: 17.0.6
+  build: hb6ac08f_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-17.0.6-hb6ac08f_0.conda
+  sha256: 9ea2f7018f335fdc55bc9b21a388eb94ea47a243d9cbf6ec3d8862d4df9fb49b
+  md5: f260ab897df05f729fc3e65dbb0850ef
+  constrains:
+  - openmp 17.0.6|17.0.6.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  size: 299706
+  timestamp: 1701222810938
+- kind: conda
+  name: llvm-openmp
+  version: 17.0.6
+  build: hcd81f8e_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-17.0.6-hcd81f8e_0.conda
+  sha256: 0c217326c5931c1416b82f98169b8a8a52139f6f5f299dbb2efa7b21f65f225a
+  md5: 52019d2fa0eddbbc4e6dcd30fae0c0a4
+  constrains:
+  - openmp 17.0.6|17.0.6.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  size: 274631
+  timestamp: 1701222947083
+- kind: conda
+  name: llvm-tools
+  version: 16.0.6
+  build: haab561b_3
+  build_number: 3
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-tools-16.0.6-haab561b_3.conda
+  sha256: 64cc3547a2b0a3700a9fa0bd1fd3258156900b48ae73fc1a4b391002ca1462bf
+  md5: ca8e3771122c520fbe72af7c83d6d4cd
+  depends:
+  - libllvm16 16.0.6 haab561b_3
+  - libxml2 >=2.12.1,<3.0.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  constrains:
+  - llvmdev   16.0.6
+  - clang 16.0.6.*
+  - clang-tools 16.0.6.*
+  - llvm 16.0.6.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 20685770
+  timestamp: 1701375136405
+- kind: conda
+  name: llvm-tools
+  version: 16.0.6
+  build: hbedff68_3
+  build_number: 3
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/llvm-tools-16.0.6-hbedff68_3.conda
+  sha256: dff3ca83c6945f020ee6d3c62ddb3ed175ae8a357be3689a8836bcfe25ad9882
+  md5: e9356b0807462e8f84c1384a8da539a5
+  depends:
+  - libllvm16 16.0.6 hbedff68_3
+  - libxml2 >=2.12.1,<3.0.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  constrains:
+  - llvmdev   16.0.6
+  - clang 16.0.6.*
+  - clang-tools 16.0.6.*
+  - llvm 16.0.6.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 22221159
+  timestamp: 1701379965425
+- kind: conda
+  name: lxml
+  version: 4.9.4
+  build: py311h033124e_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/lxml-4.9.4-py311h033124e_0.conda
+  sha256: 66583aecc21d6d043e21b2a2592e288ebe23b6682ce4a9660997367b0dc1ddde
+  md5: 765a8652a55ee009a8d28c337d880be0
+  depends:
+  - libxml2 >=2.12.3,<3.0.0a0
+  - libxslt >=1.1.39,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause and MIT-CMU
+  size: 1267386
+  timestamp: 1704590876649
+- kind: conda
+  name: lxml
+  version: 4.9.4
+  build: py311h064e5ff_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/lxml-4.9.4-py311h064e5ff_0.conda
+  sha256: aa59e2fbb82d501e56609766fc9f2cb8d385574bafea5638b741f36aaf924a82
+  md5: e6bea9c0e67b2355b385f0f6f67886b2
+  depends:
+  - libxml2 >=2.12.3,<3.0.0a0
+  - libxslt >=1.1.39,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause and MIT-CMU
+  size: 1033431
+  timestamp: 1704591075918
+- kind: conda
+  name: lxml
+  version: 4.9.4
+  build: py311h30c7647_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/lxml-4.9.4-py311h30c7647_0.conda
+  sha256: 6ae727e29ac8739a07f5a3f89d89d111ca257b2117cb6fcf9d4a472e7704fac1
+  md5: 6781cd8b231af47160f516082344ed5e
+  depends:
+  - libgcc-ng >=12
+  - libxml2 >=2.12.3,<3.0.0a0
+  - libxslt >=1.1.39,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause and MIT-CMU
+  size: 1381756
+  timestamp: 1704590910919
+- kind: conda
+  name: lxml
+  version: 4.9.4
+  build: py311h85df328_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/lxml-4.9.4-py311h85df328_0.conda
+  sha256: 82449d2cfd3d83407638272eafebd223f5a96847dd694fc4376861b938465ac4
+  md5: dc0d20e98833e8dec4a4d5bc042e525e
+  depends:
+  - libxml2 >=2.12.3,<3.0.0a0
+  - libxslt >=1.1.39,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause and MIT-CMU
+  size: 1218122
+  timestamp: 1704590962704
+- kind: conda
+  name: lxml
+  version: 4.9.4
+  build: py311h9691dec_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/lxml-4.9.4-py311h9691dec_0.conda
+  sha256: 64f534335fcac332d978cd60b6dea778df8e017e016c04ad3f3a203d76ef34c5
+  md5: bf616b82576b9a7c65ba3611cce36c23
+  depends:
+  - libgcc-ng >=12
+  - libxml2 >=2.12.3,<3.0.0a0
+  - libxslt >=1.1.39,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause and MIT-CMU
+  size: 1445535
+  timestamp: 1704590627957
+- kind: conda
+  name: lz4-c
+  version: 1.9.4
+  build: hcb278e6_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.9.4-hcb278e6_0.conda
+  sha256: 1b4c105a887f9b2041219d57036f72c4739ab9e9fe5a1486f094e58c76b31f5f
+  md5: 318b08df404f9c9be5712aaa5a6f0bb0
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 143402
+  timestamp: 1674727076728
+- kind: conda
+  name: lz4-c
+  version: 1.9.4
+  build: hd600fc2_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/lz4-c-1.9.4-hd600fc2_0.conda
+  sha256: 076870eb72411f41c46598c7582a2f3f42ba94c526a2d60a0c8f70a0a7a64429
+  md5: 500145a83ed07ce79c8cef24252f366b
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 163770
+  timestamp: 1674727020254
+- kind: conda
+  name: metis
+  version: 5.1.0
+  build: h13dd4ca_1007
+  build_number: 1007
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/metis-5.1.0-h13dd4ca_1007.conda
+  sha256: fae516bee76df367128cf81dae13e7d11ce039ff61665ca59a1c57dee0731973
+  md5: afefade086a45ae6703dffe83516010a
+  license: Apache-2.0
+  license_family: APACHE
+  size: 3832170
+  timestamp: 1693403045166
+- kind: conda
+  name: metis
+  version: 5.1.0
+  build: h2f0025b_1007
+  build_number: 1007
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/metis-5.1.0-h2f0025b_1007.conda
+  sha256: e6f99a2a253a6bad928267789a8357a7fead6f56c33bb7377459c935b99c7d33
+  md5: 9d5f344e56601a9de6ea09121049881d
+  depends:
+  - libgcc-ng >=12
+  license: Apache-2.0
+  license_family: APACHE
+  size: 3861349
+  timestamp: 1693403154007
+- kind: conda
+  name: metis
+  version: 5.1.0
+  build: h59595ed_1007
+  build_number: 1007
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/metis-5.1.0-h59595ed_1007.conda
+  sha256: 446bf794497284e2ffa28ab9191d70c38d372c51e3fd073f0d8b35efb51e7e02
+  md5: 40ccb8318df2500f83bd868dd8fcd201
+  depends:
+  - libgcc-ng >=12
+  license: Apache-2.0
+  license_family: APACHE
+  size: 3890263
+  timestamp: 1693402645559
+- kind: conda
+  name: metis
+  version: 5.1.0
+  build: h63175ca_1007
+  build_number: 1007
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/metis-5.1.0-h63175ca_1007.conda
+  sha256: 08279c753d27e5bce681fa00d2c599a808cb82f2b569fa7d3e5a2d9daaa76f4f
+  md5: da23929d48643d80504f80f00a455e87
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: APACHE
+  size: 4052316
+  timestamp: 1693403006265
+- kind: conda
+  name: metis
+  version: 5.1.0
+  build: he965462_1007
+  build_number: 1007
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/metis-5.1.0-he965462_1007.conda
+  sha256: a79b36e0c623dfab95cc2c0fce1870e90de5f2328fefa9a1b17351eb0f3ac02e
+  md5: 0c64ad59bbcae7772c16a55cbd353e25
+  license: Apache-2.0
+  license_family: APACHE
+  size: 3881273
+  timestamp: 1693402943049
+- kind: conda
+  name: mkl
+  version: 2024.0.0
+  build: h66d3029_49657
+  build_number: 49657
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/mkl-2024.0.0-h66d3029_49657.conda
+  sha256: 928bed978827e4c891d0879d79ecda6c9104ed7df1f1d4e2e392c9c80b471be7
+  md5: 006b65d9cd436247dfe053df772e041d
+  depends:
+  - intel-openmp 2024.*
+  - tbb 2021.*
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 108505947
+  timestamp: 1701973497498
+- kind: conda
+  name: mpg123
+  version: 1.32.4
+  build: h2f0025b_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/mpg123-1.32.4-h2f0025b_0.conda
+  sha256: 5e0e3585a050b4e0412a55521ab7a739275f33aaed38f97a537edcb2fa6c4c54
+  md5: 6ccb0eb784f3c544f6c1f48e61787de4
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: LGPL-2.1-only
+  license_family: LGPL
+  size: 559635
+  timestamp: 1704980202901
+- kind: conda
+  name: mpg123
+  version: 1.32.4
+  build: h59595ed_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/mpg123-1.32.4-h59595ed_0.conda
+  sha256: 512f4ad7eda3b2c9a1cc9f7931932aefa6e79567e35b76de03895e769cb3b43c
+  md5: 3f1017b4141e943d9bc8739237f749e8
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: LGPL-2.1-only
+  license_family: LGPL
+  size: 491061
+  timestamp: 1704980200966
+- kind: conda
+  name: mumps-include
+  version: 5.6.2
+  build: h694c41f_4
+  build_number: 4
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/mumps-include-5.6.2-h694c41f_4.conda
+  sha256: 4fc4b6a338fb27135407a92a059d8d3336804398b6bae05366bbf483221ec9ab
+  md5: a2d3c3b01692735b48d280a2e37036be
+  license: CECILL-C
+  size: 26883
+  timestamp: 1705868512099
+- kind: conda
+  name: mumps-include
+  version: 5.6.2
+  build: h8af1aa0_4
+  build_number: 4
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/mumps-include-5.6.2-h8af1aa0_4.conda
+  sha256: af30dac3907f64968c2e82e8a40e9fa4ae646d476cc357d4aaa9186df79e57a0
+  md5: 72800868cafcc23cf736229bd60648d7
+  license: CECILL-C
+  size: 26708
+  timestamp: 1705868478968
+- kind: conda
+  name: mumps-include
+  version: 5.6.2
+  build: ha770c72_4
+  build_number: 4
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/mumps-include-5.6.2-ha770c72_4.conda
+  sha256: 7fe56f8c2cfbb3d3074e8f6b0db1ee61d61af4d9ec93cba50d60cfc5d7406989
+  md5: 254bd79da732863782b5d9d53b9881ea
+  license: CECILL-C
+  size: 26642
+  timestamp: 1705868386041
+- kind: conda
+  name: mumps-include
+  version: 5.6.2
+  build: hce30654_4
+  build_number: 4
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/mumps-include-5.6.2-hce30654_4.conda
+  sha256: ea072f0657d96842627b836fb265b28ac0acad6cca8dfa7e30822443638c9d8a
+  md5: 1e40cbb966ca2d707d7143ff978eb543
+  license: CECILL-C
+  size: 26903
+  timestamp: 1705868560071
+- kind: conda
+  name: mumps-seq
+  version: 5.6.2
+  build: h1f49738_4
+  build_number: 4
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/mumps-seq-5.6.2-h1f49738_4.conda
+  sha256: b7b3928a5ca5bf369205b5d5ab3740c61748a48782ada62bf565e740098040bb
+  md5: 1e1b07df56800ec678333303390da9c3
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libflang >=5.0.0,<6.0.0.a0
+  - liblapack >=3.9.0,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: CECILL-C
+  size: 3350137
+  timestamp: 1705869313801
+- kind: conda
+  name: mumps-seq
+  version: 5.6.2
+  build: hae18a20_4
+  build_number: 4
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/mumps-seq-5.6.2-hae18a20_4.conda
+  sha256: a774fdfcbdb942aeb3393d54cf55da915ba4fefa32c1e8d07cb03a8bf232fcff
+  md5: 322dfa7d9e1e1a890b334238c09233cd
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libgcc-ng >=12
+  - libgfortran-ng
+  - libgfortran5 >=12.3.0
+  - liblapack >=3.9.0,<4.0a0
+  - libscotch
+  - metis >=5.1.0,<5.1.1.0a0
+  - mumps-include >=5.6.2,<5.6.3.0a0
+  - scotch >=7.0.4,<7.0.5.0a0
+  license: CECILL-C
+  size: 1722199
+  timestamp: 1705868719507
+- kind: conda
+  name: mumps-seq
+  version: 5.6.2
+  build: hbbab245_4
+  build_number: 4
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/mumps-seq-5.6.2-hbbab245_4.conda
+  sha256: 33318f81594893644b02821cee7dc8f7c54d98645ce265cd5355b95713b58746
+  md5: 30f960e2ecf9040c54261c2592fb3e6a
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libgfortran 5.*
+  - libgfortran5 >=12.3.0
+  - libgfortran5 >=13.2.0
+  - liblapack >=3.9.0,<4.0a0
+  - libscotch
+  - metis >=5.1.0,<5.1.1.0a0
+  - mumps-include >=5.6.2,<5.6.3.0a0
+  - scotch >=7.0.4,<7.0.5.0a0
+  license: CECILL-C
+  size: 1701696
+  timestamp: 1705868911584
+- kind: conda
+  name: mumps-seq
+  version: 5.6.2
+  build: he3629b0_4
+  build_number: 4
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/mumps-seq-5.6.2-he3629b0_4.conda
+  sha256: 73107b41dc48a3ddd0dfce6d1e5f7819f6f99b869925c4a5ef3cb21a41a43296
+  md5: 192e16838874d6171a32cb93f90acde2
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libgfortran 5.*
+  - libgfortran5 >=12.3.0
+  - libgfortran5 >=13.2.0
+  - liblapack >=3.9.0,<4.0a0
+  - libscotch
+  - metis >=5.1.0,<5.1.1.0a0
+  - mumps-include >=5.6.2,<5.6.3.0a0
+  - scotch >=7.0.4,<7.0.5.0a0
+  license: CECILL-C
+  size: 1860366
+  timestamp: 1705868832832
+- kind: conda
+  name: mumps-seq
+  version: 5.6.2
+  build: hfef103a_4
+  build_number: 4
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/mumps-seq-5.6.2-hfef103a_4.conda
+  sha256: 311d01882fe43677ddb8f0eb7382ac5b072c51fb1b64b69e3ec54c2a3ca2f61c
+  md5: 04a7b59399685952f5af225bf3d9c131
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libgcc-ng >=12
+  - libgfortran-ng
+  - libgfortran5 >=12.3.0
+  - liblapack >=3.9.0,<4.0a0
+  - libscotch
+  - metis >=5.1.0,<5.1.1.0a0
+  - mumps-include >=5.6.2,<5.6.3.0a0
+  - scotch >=7.0.4,<7.0.5.0a0
+  license: CECILL-C
+  size: 1956627
+  timestamp: 1705868645516
+- kind: conda
+  name: mysql-common
+  version: 8.0.33
+  build: h1d20c9b_6
+  build_number: 6
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/mysql-common-8.0.33-h1d20c9b_6.conda
+  sha256: b6b18aeed435d4075b4aac3559a070a6caa5a174a339e8de87785fca2f8f57a6
+  md5: ad07fbd8dc7992e5e004f7bdfdee246d
+  depends:
+  - __osx >=10.9
+  - libcxx >=16.0.6
+  - openssl >=3.1.4,<4.0a0
+  size: 763190
+  timestamp: 1698938422063
+- kind: conda
+  name: mysql-common
+  version: 8.0.33
+  build: hb6794ad_6
+  build_number: 6
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/mysql-common-8.0.33-hb6794ad_6.conda
+  sha256: 58399b2cabdff285909315da99efc761d11abb18156ff642146ebaf2058163e9
+  md5: 358520a1f6cdd2314bc0c27e0d152ecd
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - openssl >=3.1.4,<4.0a0
+  size: 761797
+  timestamp: 1698937751674
+- kind: conda
+  name: mysql-common
+  version: 8.0.33
+  build: hf1915f5_6
+  build_number: 6
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/mysql-common-8.0.33-hf1915f5_6.conda
+  sha256: c8b2c5c9d0d013a4f6ef96cb4b339bfdc53a74232d8c61ed08178e5b1ec4eb63
+  md5: 80bf3b277c120dd294b51d404b931a75
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - openssl >=3.1.4,<4.0a0
+  size: 753467
+  timestamp: 1698937026421
+- kind: conda
+  name: mysql-common
+  version: 8.0.33
+  build: hf9e6398_6
+  build_number: 6
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/mysql-common-8.0.33-hf9e6398_6.conda
+  sha256: 9d60d7779c9c2e6c783521922ab715964fc966d827493877c3b6844dacf2b140
+  md5: 5c969a77f976c028192f8120483e2f4d
+  depends:
+  - __osx >=10.9
+  - libcxx >=16.0.6
+  - openssl >=3.1.4,<4.0a0
+  size: 751501
+  timestamp: 1698939564933
+- kind: conda
+  name: mysql-libs
+  version: 8.0.33
+  build: hca2cd23_6
+  build_number: 6
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/mysql-libs-8.0.33-hca2cd23_6.conda
+  sha256: 78c905637dac79b197395065c169d452b8ca2a39773b58e45e23114f1cb6dcdb
+  md5: e87530d1b12dd7f4e0f856dc07358d60
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
+  - mysql-common 8.0.33 hf1915f5_6
+  - openssl >=3.1.4,<4.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  size: 1530126
+  timestamp: 1698937116126
+- kind: conda
+  name: mysql-libs
+  version: 8.0.33
+  build: he3dca8b_6
+  build_number: 6
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/mysql-libs-8.0.33-he3dca8b_6.conda
+  sha256: 1544f64334c1d87a83df21b93d5b61429db4a9317ddb8b5e09ad3384adf88ad1
+  md5: 98bbd77933bb5d947dce7ca552744871
+  depends:
+  - __osx >=10.9
+  - libcxx >=16.0.6
+  - libzlib >=1.2.13,<1.3.0a0
+  - mysql-common 8.0.33 hf9e6398_6
+  - openssl >=3.1.4,<4.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  size: 1510603
+  timestamp: 1698939692982
+- kind: conda
+  name: mysql-libs
+  version: 8.0.33
+  build: hed35180_6
+  build_number: 6
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/mysql-libs-8.0.33-hed35180_6.conda
+  sha256: 87d754167fddf342b894e377fdcaac096c93c941773267ad9c89bb7b64924a33
+  md5: c27fddc4d3c2d471d1d706b243570f37
+  depends:
+  - __osx >=10.9
+  - libcxx >=16.0.6
+  - libzlib >=1.2.13,<1.3.0a0
+  - mysql-common 8.0.33 h1d20c9b_6
+  - openssl >=3.1.4,<4.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  size: 1493906
+  timestamp: 1698938538673
+- kind: conda
+  name: mysql-libs
+  version: 8.0.33
+  build: hf629957_6
+  build_number: 6
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/mysql-libs-8.0.33-hf629957_6.conda
+  sha256: 2b444a4577482882664617bac615948d5fa838d17356707f7c7fa57a57742dc3
+  md5: 7d88d13742ad621e0cf8f0158a03bfd6
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
+  - mysql-common 8.0.33 hb6794ad_6
+  - openssl >=3.1.4,<4.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  size: 1567046
+  timestamp: 1698937846157
+- kind: conda
+  name: ncurses
+  version: '6.4'
+  build: h0425590_2
+  build_number: 2
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/ncurses-6.4-h0425590_2.conda
+  sha256: d71cf2f2b1a9fae7ee2455a35a890423838e9594294beb4a002fe7c7b10bc086
+  md5: 4ff0a396150dedad4269e16e5810f769
+  depends:
+  - libgcc-ng >=12
+  license: X11 AND BSD-3-Clause
+  size: 920540
+  timestamp: 1698751239554
+- kind: conda
+  name: ncurses
+  version: '6.4'
+  build: h463b476_2
+  build_number: 2
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.4-h463b476_2.conda
+  sha256: f6890634f815e8408d08f36503353f8dfd7b055e4c3b9ea2ee52180255cf4b0a
+  md5: 52b6f254a7b9663e854f44b6570ed982
+  depends:
+  - __osx >=10.9
+  license: X11 AND BSD-3-Clause
+  size: 794741
+  timestamp: 1698751574074
+- kind: conda
+  name: ncurses
+  version: '6.4'
+  build: h59595ed_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.4-h59595ed_2.conda
+  sha256: 91cc03f14caf96243cead96c76fe91ab5925a695d892e83285461fb927dece5e
+  md5: 7dbaa197d7ba6032caf7ae7f32c1efa0
+  depends:
+  - libgcc-ng >=12
+  license: X11 AND BSD-3-Clause
+  size: 884434
+  timestamp: 1698751260967
+- kind: conda
+  name: ncurses
+  version: '6.4'
+  build: h93d8f39_2
+  build_number: 2
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.4-h93d8f39_2.conda
+  sha256: ea0fca66bbb52a1ef0687d466518fe120b5f279684effd6fd336a7b0dddc423a
+  md5: e58f366bd4d767e9ab97ab8b272e7670
+  depends:
+  - __osx >=10.9
+  license: X11 AND BSD-3-Clause
+  size: 822031
+  timestamp: 1698751567986
+- kind: conda
+  name: nettle
+  version: 3.9.1
+  build: h40ed0f5_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/nettle-3.9.1-h40ed0f5_0.conda
+  sha256: 5de149b6e35adac11e22ae02516a7466412348690da52049f80ea07fe544896d
+  md5: b157977e1ec1dde3ba7ebc6e0dde363f
+  license: GPL 2 and LGPL3
+  license_family: GPL
+  size: 510164
+  timestamp: 1686310071126
+- kind: conda
+  name: nettle
+  version: 3.9.1
+  build: h7ab15ed_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/nettle-3.9.1-h7ab15ed_0.conda
+  sha256: 1ef1b7efa69c7fb4e2a36a88316f307c115713698d1c12e19f55ae57c0482995
+  md5: 2bf1915cc107738811368afcb0993a59
+  depends:
+  - libgcc-ng >=12
+  license: GPL 2 and LGPL3
+  license_family: GPL
+  size: 1011638
+  timestamp: 1686309814836
+- kind: conda
+  name: nettle
+  version: 3.9.1
+  build: h8e11ae5_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/nettle-3.9.1-h8e11ae5_0.conda
+  sha256: 62de51fc44f1595a06c5b24bb717b949b4b9fb4c4acaf127b92ce99ddb546ca7
+  md5: 400dffe5d2fbb9813b51948d3e9e9ab1
+  license: GPL 2 and LGPL3
+  license_family: GPL
+  size: 509519
+  timestamp: 1686310097670
+- kind: conda
+  name: nettle
+  version: 3.9.1
+  build: h9d1147b_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/nettle-3.9.1-h9d1147b_0.conda
+  sha256: 27d70a4292515e948d6a16d03d7e5f2ec64396ccf2dd81aa9725667794fd71d8
+  md5: bf4b290d849247be4a5b89cfbd30b4d7
+  depends:
+  - libgcc-ng >=12
+  license: GPL 2 and LGPL3
+  license_family: GPL
+  size: 1123356
+  timestamp: 1686311968059
+- kind: conda
+  name: ninja
+  version: 1.11.1
+  build: h91493d7_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/ninja-1.11.1-h91493d7_0.conda
+  sha256: 0ffb1912768af8354a930f482368ef170bf3d8217db328dfea1c8b09772c8c71
+  md5: 44a99ef26178ea98626ff8e027702795
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 279200
+  timestamp: 1676838681615
+- kind: conda
+  name: ninja
+  version: 1.11.1
+  build: h924138e_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/ninja-1.11.1-h924138e_0.conda
+  sha256: b555247ac8859b4ff311e3d708a0640f1bfe9fae7125c485b444072474a84c41
+  md5: 73a4953a2d9c115bdc10ff30a52f675f
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: Apache-2.0
+  license_family: Apache
+  size: 2251263
+  timestamp: 1676837602636
+- kind: conda
+  name: ninja
+  version: 1.11.1
+  build: hb8565cd_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/ninja-1.11.1-hb8565cd_0.conda
+  sha256: 6f738d9a26fa275317b95b2b96832daab9059ef64af9a338f904a3cb684ae426
+  md5: 49ad513efe39447aa51affd47e3aa68f
+  depends:
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 121284
+  timestamp: 1676837793132
+- kind: conda
+  name: ninja
+  version: 1.11.1
+  build: hdd96247_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/ninja-1.11.1-hdd96247_0.conda
+  sha256: 2ba2e59f619c58d748f4b1b858502587691a7ed0fa9ac2c26ac04091908d95ae
+  md5: 58f4c67113cda9171e3c03d3e62731e1
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: Apache-2.0
+  license_family: Apache
+  size: 2398482
+  timestamp: 1676839419214
+- kind: conda
+  name: ninja
+  version: 1.11.1
+  build: hffc8910_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ninja-1.11.1-hffc8910_0.conda
+  sha256: a594e90b0ed8202c280fff4a008f6a355d0db54a62b17067dc4a950370ddffc0
+  md5: fdecec4002f41cf6ea1eea5b52947ee0
+  depends:
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 107047
+  timestamp: 1676837935565
+- kind: conda
+  name: nspr
+  version: '4.35'
+  build: h27087fc_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/nspr-4.35-h27087fc_0.conda
+  sha256: 8fadeebb2b7369a4f3b2c039a980d419f65c7b18267ba0c62588f9f894396d0c
+  md5: da0ec11a6454ae19bff5b02ed881a2b1
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 226848
+  timestamp: 1669784948267
+- kind: conda
+  name: nspr
+  version: '4.35'
+  build: h4de3ea5_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/nspr-4.35-h4de3ea5_0.conda
+  sha256: 23ff7274a021dd87966277b271e5d0944fcc8b893f4920cb46dd4224604218cc
+  md5: 7a392f26f76fc55354c8ed60c2b99162
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 232844
+  timestamp: 1669784904844
+- kind: conda
+  name: nspr
+  version: '4.35'
+  build: hb7217d7_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/nspr-4.35-hb7217d7_0.conda
+  sha256: 35959d36ea9e8a2c422db9f113ee0ac91a9b0c19c51b05f75d0793c3827cfa3a
+  md5: f81b5ec944dbbcff3dd08375eb036efa
+  depends:
+  - libcxx >=14.0.6
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 220745
+  timestamp: 1669785182058
+- kind: conda
+  name: nspr
+  version: '4.35'
+  build: hea0b92c_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/nspr-4.35-hea0b92c_0.conda
+  sha256: da6e19bd0ff31e219760e647cfe1cc499a8cdfaff305f06c56d495ca062b86de
+  md5: a9e56c98d13d8b7ce72bf4357317c29b
+  depends:
+  - libcxx >=14.0.6
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 230071
+  timestamp: 1669785313586
+- kind: conda
+  name: nss
+  version: '3.97'
+  build: h1d7d5a4_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/nss-3.97-h1d7d5a4_0.conda
+  sha256: a1a62d415e5b5ddbd799ad6d92b2c4a4351fda00b54d96cac2ce7afa04b2d698
+  md5: b916d71a3032416e3f9136090d814472
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  - libsqlite >=3.44.2,<4.0a0
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
+  - nspr >=4.35,<5.0a0
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 2014022
+  timestamp: 1705921777003
+- kind: conda
+  name: nss
+  version: '3.97'
+  build: h5ce2875_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/nss-3.97-h5ce2875_0.conda
+  sha256: 27786510a52aeb1115c31d8127fcc57fdec38bcef22882dd3bd05d04ca5c393d
+  md5: 5d2d69c2cce2c58171648a1fd34d6732
+  depends:
+  - libcxx >=15
+  - libsqlite >=3.44.2,<4.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - nspr >=4.35,<5.0a0
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 1803657
+  timestamp: 1705922174903
+- kind: conda
+  name: nss
+  version: '3.97'
+  build: ha05da47_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/nss-3.97-ha05da47_0.conda
+  sha256: fe26704cb733d412fafbeaf0cc4c402f9623757bc2241381d7480a22cdeb64e4
+  md5: 6408f35df2c8ba0642b13d32915a789b
+  depends:
+  - libcxx >=15
+  - libsqlite >=3.44.2,<4.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - nspr >=4.35,<5.0a0
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 1902273
+  timestamp: 1705922096082
+- kind: conda
+  name: nss
+  version: '3.97'
+  build: hc5a5cc2_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/nss-3.97-hc5a5cc2_0.conda
+  sha256: 0f8c2fc6e1b1c49db58a236150b638e990db8c8dcff592b08187ed46bba11995
+  md5: 69d61fcfcd726888d5c2add225461a35
+  depends:
+  - libgcc-ng >=12
+  - libsqlite >=3.44.2,<4.0a0
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
+  - nspr >=4.35,<5.0a0
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 2001907
+  timestamp: 1705921667319
+- kind: conda
+  name: numpy
+  version: 1.26.4
+  build: py311h0b4df5a_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/numpy-1.26.4-py311h0b4df5a_0.conda
+  sha256: 14116e72107de3089cc58119a5ce5905c22abf9a715c9fe41f8ac14db0992326
+  md5: 7b240edd44fd7a0991aa409b07cee776
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7104093
+  timestamp: 1707226459646
+- kind: conda
+  name: numpy
+  version: 1.26.4
+  build: py311h64a7726_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.26.4-py311h64a7726_0.conda
+  sha256: 3f4365e11b28e244c95ba8579942b0802761ba7bb31c026f50d1a9ea9c728149
+  md5: a502d7aad449a1206efb366d6a12c52d
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgcc-ng >=12
+  - liblapack >=3.9.0,<4.0a0
+  - libstdcxx-ng >=12
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8065890
+  timestamp: 1707225944355
+- kind: conda
+  name: numpy
+  version: 1.26.4
+  build: py311h69ead2a_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/numpy-1.26.4-py311h69ead2a_0.conda
+  sha256: 88800a1d9d11c2fccab09d40d36f7001616f5119eaf0ec86186562f33564e651
+  md5: 3fd00dd400c8d3f9da12bf33061dd28d
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgcc-ng >=12
+  - liblapack >=3.9.0,<4.0a0
+  - libstdcxx-ng >=12
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7234391
+  timestamp: 1707225781489
+- kind: conda
+  name: numpy
+  version: 1.26.4
+  build: py311h7125741_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-1.26.4-py311h7125741_0.conda
+  sha256: 160a52a01fea44fe9753a2ed22cf13d7b55c8a89ea0b8738546fdbf4795d6514
+  md5: 3160b93669a0def35a7a8158ebb33816
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=16
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6652352
+  timestamp: 1707226297967
+- kind: conda
+  name: numpy
+  version: 1.26.4
+  build: py311hc43a94b_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/numpy-1.26.4-py311hc43a94b_0.conda
+  sha256: dc9628197125ee1d02b2e7a859a769d26291d747ed79337309b8a9e67a8b8e00
+  md5: bb02b8801d17265160e466cf8bbf28da
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=16
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7504319
+  timestamp: 1707226235372
+- kind: conda
+  name: ocl-icd
+  version: 2.3.2
+  build: hd590300_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/ocl-icd-2.3.2-hd590300_0.conda
+  sha256: d413c0b42ba13532943118458caab795454f5a73d70f5d2ed2daa6118df15876
+  md5: 92e93490ee7f98bfadb389e3129b955c
+  depends:
+  - libgcc-ng >=12
+  license: BSD-2-Clause
+  size: 136327
+  timestamp: 1707866764671
+- kind: conda
+  name: ocl-icd-system
+  version: 1.0.0
+  build: '1'
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/ocl-icd-system-1.0.0-1.tar.bz2
+  sha256: cb0ce5ce5ede1be2fd9edf88abd3ce3e6c2b7397c0283d623e4d8ccf96a1ed09
+  md5: 577a4bd049737b11a24524e39a16a1f3
+  depends:
+  - ocl-icd
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 4253
+  timestamp: 1575483836797
+- kind: conda
+  name: openh264
+  version: 2.4.1
+  build: h2f0025b_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/openh264-2.4.1-h2f0025b_0.conda
+  sha256: fbd43d4ab82fd6dfd1502a55ccade4aabae4a85fa2353396078da8d5c10941db
+  md5: 97fc3bbca08e95e1d7af8366d5a4ece6
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 770201
+  timestamp: 1706873872574
+- kind: conda
+  name: openh264
+  version: 2.4.1
+  build: h59595ed_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/openh264-2.4.1-h59595ed_0.conda
+  sha256: 0d4eaf15fb771f25c924aef831d76eea11d90c824778fc1e7666346e93475f42
+  md5: 3dfcf61b8e78af08110f5229f79580af
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 735244
+  timestamp: 1706873814072
+- kind: conda
+  name: openh264
+  version: 2.4.1
+  build: h63175ca_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/openh264-2.4.1-h63175ca_0.conda
+  sha256: 37c954a1235531499c45439c602dda6f788e3683795e12fb6e1e4c86074386c7
+  md5: 01d1a98fd9ac45d49040ad8cdd62083a
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 409185
+  timestamp: 1706874444698
+- kind: conda
+  name: openh264
+  version: 2.4.1
+  build: h73e2aa4_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/openh264-2.4.1-h73e2aa4_0.conda
+  sha256: 4e660e62225815dd996788ed08dc50870e387c159f31d65cd8b677988dfb387b
+  md5: 877f116d9a4f8b826b0e1d427ac00871
+  depends:
+  - libcxx >=16
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 660428
+  timestamp: 1706874091051
+- kind: conda
+  name: openh264
+  version: 2.4.1
+  build: hebf3989_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/openh264-2.4.1-hebf3989_0.conda
+  sha256: ecadea5985082105b102f86ff8289128fb247c183b36355d867eb6fc6996df29
+  md5: 25a7835e284a4d947fe9a70efa97e019
+  depends:
+  - libcxx >=16
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 598764
+  timestamp: 1706874342701
+- kind: conda
+  name: openmp
+  version: 5.0.0
+  build: vc14_1
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/openmp-5.0.0-vc14_1.tar.bz2
+  sha256: 05c19170938b589f59049679d4e0679c98160fecc6fd1bf721b0f4980bd235dd
+  md5: 8284c925330fa53668ade00db3c9e787
+  depends:
+  - llvm-meta 5.0.0|5.0.0.*
+  - vc 14.*
+  arch: x86_64
+  platform: win
+  license: NCSA
+  size: 590466
+- kind: conda
+  name: openssl
+  version: 3.2.1
+  build: h0d3ecfb_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.2.1-h0d3ecfb_0.conda
+  sha256: 13663fcd4abc8681b31ccbad39800fee2127cb6159b51a989ed48a816af36cf5
+  md5: 421cc6e8715447b73c2c57dcf78cb9d2
+  depends:
+  - ca-certificates
+  constrains:
+  - pyopenssl >=22.1
+  license: Apache-2.0
+  license_family: Apache
+  size: 2862719
+  timestamp: 1706635779319
+- kind: conda
+  name: openssl
+  version: 3.2.1
+  build: h31becfc_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.2.1-h31becfc_0.conda
+  sha256: 952ef5de4e3913621a89ca2eb8186683bb73832527219c6443c260a6b46cd149
+  md5: b7e7c53240214ae96f52a440c0b0126a
+  depends:
+  - ca-certificates
+  - libgcc-ng >=12
+  constrains:
+  - pyopenssl >=22.1
+  license: Apache-2.0
+  license_family: Apache
+  size: 3382700
+  timestamp: 1706635800272
+- kind: conda
+  name: openssl
+  version: 3.2.1
+  build: hcfcfb64_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/openssl-3.2.1-hcfcfb64_0.conda
+  sha256: 1df1c43136f863d5e9ba20b703001caf9a4d0ea56bdc3eeb948c977e3d4f91d3
+  md5: 158df8eead8092cf0e27167c8761a8dd
+  depends:
+  - ca-certificates
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - pyopenssl >=22.1
+  license: Apache-2.0
+  license_family: Apache
+  size: 8229619
+  timestamp: 1706638014697
+- kind: conda
+  name: openssl
+  version: 3.2.1
+  build: hd590300_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.2.1-hd590300_0.conda
+  sha256: c02c12bdb898daacf7eb3d09859f93ea8f285fd1a6132ff6ff0493ab52c7fe57
+  md5: 51a753e64a3027bd7e23a189b1f6e91e
+  depends:
+  - ca-certificates
+  - libgcc-ng >=12
+  constrains:
+  - pyopenssl >=22.1
+  license: Apache-2.0
+  license_family: Apache
+  size: 2863069
+  timestamp: 1706635653339
+- kind: conda
+  name: openssl
+  version: 3.2.1
+  build: hd75f5a5_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.2.1-hd75f5a5_0.conda
+  sha256: 20c1b1a34a1831c24d37ed1500ca07300171184af0c66598f3c5ca901634d713
+  md5: 3033be9a59fd744172b03971b9ccd081
+  depends:
+  - ca-certificates
+  constrains:
+  - pyopenssl >=22.1
+  license: Apache-2.0
+  license_family: Apache
+  size: 2509168
+  timestamp: 1706636810736
+- kind: conda
+  name: osqp-eigen
+  version: 0.8.1
+  build: h63a7d18_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/osqp-eigen-0.8.1-h63a7d18_0.conda
+  sha256: 825faa6ea24ad95e18319b543cb006f6437a4cdeeacadb970700b0ee884b9392
+  md5: 0f8c9195f47fb752b7e85d33086f211c
+  depends:
+  - eigen
+  - libgcc-ng >=12
+  - libosqp >=0.6.3,<0.6.4.0a0
+  - libstdcxx-ng >=12
+  license: LGPL-3.0-or-later
+  license_family: LGPL
+  size: 34843
+  timestamp: 1690887627026
+- kind: conda
+  name: osqp-eigen
+  version: 0.8.1
+  build: h6d7489e_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/osqp-eigen-0.8.1-h6d7489e_0.conda
+  sha256: 47b51a36e1d54011005d77e48d2ad98319abaec483025f6067585db803726e39
+  md5: db2ae068a7eab79e4e986bb72bd50794
+  depends:
+  - eigen
+  - libosqp >=0.6.3,<0.6.4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: LGPL-3.0-or-later
+  license_family: LGPL
+  size: 63036
+  timestamp: 1690888036565
+- kind: conda
+  name: osqp-eigen
+  version: 0.8.1
+  build: hdd734ac_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/osqp-eigen-0.8.1-hdd734ac_0.conda
+  sha256: 356fa62bcc752fcda14876339ed749515a9f43ac5f596bd607d17bd893cf508e
+  md5: eecff09d2a294502aad440fbfaf9d218
+  depends:
+  - eigen
+  - libgcc-ng >=12
+  - libosqp >=0.6.3,<0.6.4.0a0
+  - libstdcxx-ng >=12
+  license: LGPL-3.0-or-later
+  license_family: LGPL
+  size: 35747
+  timestamp: 1690887716943
+- kind: conda
+  name: osqp-eigen
+  version: 0.8.1
+  build: hede6739_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/osqp-eigen-0.8.1-hede6739_0.conda
+  sha256: e0883d288621e2bec3a7487c874db3a5c53e883342bd3b6b160bad699823f90e
+  md5: 3b7527f4250645372a2b138493a29632
+  depends:
+  - eigen
+  - libcxx >=15.0.7
+  - libosqp >=0.6.3,<0.6.4.0a0
+  license: LGPL-3.0-or-later
+  license_family: LGPL
+  size: 35607
+  timestamp: 1690887825800
+- kind: conda
+  name: osqp-eigen
+  version: 0.8.1
+  build: hfae311c_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/osqp-eigen-0.8.1-hfae311c_0.conda
+  sha256: 7cebc990afa753bc928250020438f628dfe5c5e03f9736cc636c34d510fd173b
+  md5: d58891e7ede6d21972ab86081a30383e
+  depends:
+  - eigen
+  - libcxx >=15.0.7
+  - libosqp >=0.6.3,<0.6.4.0a0
+  license: LGPL-3.0-or-later
+  license_family: LGPL
+  size: 34698
+  timestamp: 1690888118944
+- kind: conda
+  name: p11-kit
+  version: 0.24.1
+  build: h29577a5_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/p11-kit-0.24.1-h29577a5_0.tar.bz2
+  sha256: 3e124859307956f9f390f39c74b9700be4843eaaf56891c4b09da75b1bd5b57f
+  md5: 8f111d56c8c7c1895bde91a942c43d93
+  depends:
+  - libffi >=3.4.2,<3.5.0a0
+  - libtasn1 >=4.18.0,<5.0a0
+  license: MIT
+  license_family: MIT
+  size: 890711
+  timestamp: 1654869118646
+- kind: conda
+  name: p11-kit
+  version: 0.24.1
+  build: h65f8906_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/p11-kit-0.24.1-h65f8906_0.tar.bz2
+  sha256: e16fbaadb2714c0965cb76de32fe7d13a21874cec02c97efef8ac51f4fda86fc
+  md5: e936a0ee28be948846108582f00e2d61
+  depends:
+  - libffi >=3.4.2,<3.5.0a0
+  - libtasn1 >=4.18.0,<5.0a0
+  license: MIT
+  license_family: MIT
+  size: 834487
+  timestamp: 1654869241699
+- kind: conda
+  name: p11-kit
+  version: 0.24.1
+  build: h9f2702f_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/p11-kit-0.24.1-h9f2702f_0.tar.bz2
+  sha256: 24c37c8d131e3e72350a398060ec163eb48db75f19339b09bcf2d860ad0367fe
+  md5: a27524877b697f8e18d38ad30ba022f5
+  depends:
+  - libffi >=3.4.2,<3.5.0a0
+  - libgcc-ng >=12
+  - libtasn1 >=4.18.0,<5.0a0
+  license: MIT
+  license_family: MIT
+  size: 4947687
+  timestamp: 1654869375890
+- kind: conda
+  name: p11-kit
+  version: 0.24.1
+  build: hc5aa10d_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/p11-kit-0.24.1-hc5aa10d_0.tar.bz2
+  sha256: aa8d3887b36557ad0c839e4876c0496e0d670afe843bf5bba4a87764b868196d
+  md5: 56ee94e34b71742bbdfa832c974e47a8
+  depends:
+  - libffi >=3.4.2,<3.5.0a0
+  - libgcc-ng >=12
+  - libtasn1 >=4.18.0,<5.0a0
+  license: MIT
+  license_family: MIT
+  size: 4702497
+  timestamp: 1654868759643
+- kind: conda
+  name: pcre2
+  version: '10.42'
+  build: h0ad2156_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/pcre2-10.42-h0ad2156_0.conda
+  sha256: 689559d94b64914e503d2ced53b78afc19562ed1ccfb284040797a6d41bb564c
+  md5: 41de8bab2d5e5cd6daaba1896e81d366
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 899794
+  timestamp: 1698610978148
+- kind: conda
+  name: pcre2
+  version: '10.42'
+  build: h17e33f8_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/pcre2-10.42-h17e33f8_0.conda
+  sha256: 25e33b148478de58842ccc018fbabb414665de59270476e92c951203d4485bb1
+  md5: 59610c61da3af020289a806ec9c6a7fd
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 880802
+  timestamp: 1698611415241
+- kind: conda
+  name: pcre2
+  version: '10.42'
+  build: h26f9a81_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pcre2-10.42-h26f9a81_0.conda
+  sha256: 0335a08349ecd8dce0b81699fcd61b58415e658fe953feb27316fbb994df0685
+  md5: 3e12888ecc8ee1ebee2eef9b7856357a
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 619848
+  timestamp: 1698610997157
+- kind: conda
+  name: pcre2
+  version: '10.42'
+  build: hcad00b1_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.42-hcad00b1_0.conda
+  sha256: 3ca54ff0abcda964af7d4724d389ae20d931159ae1881cfe57ad4b0ab9e6a380
+  md5: 679c8961826aa4b50653bce17ee52abe
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1017235
+  timestamp: 1698610864983
+- kind: conda
+  name: pcre2
+  version: '10.42'
+  build: hd0f9c67_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/pcre2-10.42-hd0f9c67_0.conda
+  sha256: 7ef11cc37800dcc4693c6f827e3cb58bc8a8cefe92b4307c6826845b3f198364
+  md5: 683162253dd3b6c4d21bf037e59455f4
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 944649
+  timestamp: 1698610795381
+- kind: conda
+  name: pip
+  version: '24.0'
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pip-24.0-pyhd8ed1ab_0.conda
+  sha256: b7c1c5d8f13e8cb491c4bd1d0d1896a4cf80fc47de01059ad77509112b664a4a
+  md5: f586ac1e56c8638b64f9c8122a7b8a67
+  depends:
+  - python >=3.7
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 1398245
+  timestamp: 1706960660581
+- kind: conda
+  name: pixman
+  version: 0.43.2
+  build: h2f0025b_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/pixman-0.43.2-h2f0025b_0.conda
+  sha256: 5afb7399abf43abbe8430da48be1452027ff26d949038f33e0a2adde100174aa
+  md5: 896686714eea591ad0c0891800c571fd
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 295200
+  timestamp: 1706552057640
+- kind: conda
+  name: pixman
+  version: 0.43.2
+  build: h59595ed_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.43.2-h59595ed_0.conda
+  sha256: 366d28e2a0a191d6c535e234741e0cd1d94d713f76073d8af4a5ccb2a266121e
+  md5: 71004cbf7924e19c02746ccde9fd7123
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 386826
+  timestamp: 1706549500138
+- kind: conda
+  name: pixman
+  version: 0.43.2
+  build: h63175ca_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/pixman-0.43.2-h63175ca_0.conda
+  sha256: 659db230ba8121395b23fa6fce5f16532f54e4e7397ff9e7c19d9c7e436d29f8
+  md5: 1060b0e26af2192e80b1d04cae0b029f
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 460196
+  timestamp: 1706549794397
+- kind: conda
+  name: pixman
+  version: 0.43.2
+  build: h73e2aa4_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/pixman-0.43.2-h73e2aa4_0.conda
+  sha256: 26b16d9a6aed8f3d96a7dbad5d63b6ab1bcce13d77c050bcbaf7378bada2d225
+  md5: 26cf3be47886ded561d3d2cd8654893f
+  depends:
+  - libcxx >=15
+  license: MIT
+  license_family: MIT
+  size: 324294
+  timestamp: 1706549556213
+- kind: conda
+  name: pixman
+  version: 0.43.2
+  build: hebf3989_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pixman-0.43.2-hebf3989_0.conda
+  sha256: dc3ec60e769f80c1d5124ba2788e3c9122443743989ad5f92addf416c7a4e58b
+  md5: aaf3f4397959b8900c7c2f90304ccb29
+  depends:
+  - libcxx >=15
+  license: MIT
+  license_family: MIT
+  size: 198606
+  timestamp: 1706549867392
+- kind: conda
+  name: portaudio
+  version: 19.6.0
+  build: h13dd4ca_9
+  build_number: 9
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/portaudio-19.6.0-h13dd4ca_9.conda
+  sha256: 5ff2b55d685c29dfe632ef856796a4b862305088543d4982f0b807e8d9bb756e
+  md5: d325d46394b6c46d15718c855fb20b4a
+  depends:
+  - libcxx >=15.0.7
+  license: MIT
+  license_family: MIT
+  size: 78863
+  timestamp: 1693868663440
+- kind: conda
+  name: portaudio
+  version: 19.6.0
+  build: h5c6c0ed_9
+  build_number: 9
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/portaudio-19.6.0-h5c6c0ed_9.conda
+  sha256: a73e31c5fe9d717cd42470b394018f4e48eed4a439b9371d2c6d380c86aed591
+  md5: ab049f8223bccc6f621975beaa75c624
+  depends:
+  - alsa-lib >=1.2.10,<1.2.11.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 118203
+  timestamp: 1693868376750
+- kind: conda
+  name: portaudio
+  version: 19.6.0
+  build: h63175ca_9
+  build_number: 9
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/portaudio-19.6.0-h63175ca_9.conda
+  sha256: 5f5cf0c24075e9006c96537c885342f24a8c4f4408e994bfe1a63a2ae2528f13
+  md5: 62046084688064857ae9152cefd10abf
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 152179
+  timestamp: 1693868652380
+- kind: conda
+  name: portaudio
+  version: 19.6.0
+  build: h7c63dc7_9
+  build_number: 9
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/portaudio-19.6.0-h7c63dc7_9.conda
+  sha256: c09ae032d0303abfea34c0957834538b48133b0431283852741ed3e0f66fdb36
+  md5: 893f2c33af6b03cfd04820a8c31f5798
+  depends:
+  - alsa-lib >=1.2.10,<1.2.11.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 115512
+  timestamp: 1693868383
+- kind: conda
+  name: portaudio
+  version: 19.6.0
+  build: he965462_9
+  build_number: 9
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/portaudio-19.6.0-he965462_9.conda
+  sha256: fa568ca8f85dc081f8ef5d84b44ca42b9886327d9c2090d46a4aabaf5a29ccb3
+  md5: 433d8393c9d8aa95f38f520416c4eb27
+  depends:
+  - libcxx >=15.0.7
+  license: MIT
+  license_family: MIT
+  size: 77178
+  timestamp: 1693868569418
+- kind: conda
+  name: pthread-stubs
+  version: '0.4'
+  build: h27ca646_1001
+  build_number: 1001
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-h27ca646_1001.tar.bz2
+  sha256: 9da9e6f5d51dff6ad2e4ee0874791437ba952e0a6249942273f0fedfd07ea826
+  md5: d3f26c6494d4105d4ecb85203d687102
+  license: MIT
+  license_family: MIT
+  size: 5696
+  timestamp: 1606147608402
+- kind: conda
+  name: pthread-stubs
+  version: '0.4'
+  build: h36c2ea0_1001
+  build_number: 1001
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-h36c2ea0_1001.tar.bz2
+  sha256: 67c84822f87b641d89df09758da498b2d4558d47b920fd1d3fe6d3a871e000ff
+  md5: 22dad4df6e8630e8dff2428f6f6a7036
+  depends:
+  - libgcc-ng >=7.5.0
+  license: MIT
+  license_family: MIT
+  size: 5625
+  timestamp: 1606147468727
+- kind: conda
+  name: pthread-stubs
+  version: '0.4'
+  build: hb9de7d4_1001
+  build_number: 1001
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/pthread-stubs-0.4-hb9de7d4_1001.tar.bz2
+  sha256: f1d7ff5e06cc515ec82010537813c796369f8e9dde46ce3f4fa1a9f70bc7db7d
+  md5: d0183ec6ce0b5aaa3486df25fa5f0ded
+  depends:
+  - libgcc-ng >=7.5.0
+  license: MIT
+  license_family: MIT
+  size: 5657
+  timestamp: 1606147738742
+- kind: conda
+  name: pthread-stubs
+  version: '0.4'
+  build: hc929b4f_1001
+  build_number: 1001
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/pthread-stubs-0.4-hc929b4f_1001.tar.bz2
+  sha256: 6e3900bb241bcdec513d4e7180fe9a19186c1a38f0b4080ed619d26014222c53
+  md5: addd19059de62181cd11ae8f4ef26084
+  license: MIT
+  license_family: MIT
+  size: 5653
+  timestamp: 1606147699844
+- kind: conda
+  name: pthreads-win32
+  version: 2.9.1
+  build: hfa6e2cd_3
+  build_number: 3
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/pthreads-win32-2.9.1-hfa6e2cd_3.tar.bz2
+  sha256: 576a228630a72f25d255a5e345e5f10878e153221a96560f2498040cd6f54005
+  md5: e2da8758d7d51ff6aa78a14dfb9dbed4
+  depends:
+  - vc 14.*
+  license: LGPL 2
+  size: 144301
+  timestamp: 1537755684331
+- kind: conda
+  name: pugixml
+  version: '1.14'
+  build: h13dd4ca_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pugixml-1.14-h13dd4ca_0.conda
+  sha256: 0bfeac4f1a374da9ff0a322344cdab577d397d6a0a0e5591f08cb7b491926825
+  md5: 4de774bb04e03af9704ec1a2618c636c
+  depends:
+  - libcxx >=15.0.7
+  license: MIT
+  license_family: MIT
+  size: 92472
+  timestamp: 1696182843052
+- kind: conda
+  name: pugixml
+  version: '1.14'
+  build: h2f0025b_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/pugixml-1.14-h2f0025b_0.conda
+  sha256: 4f37f0a94bb465157e66f1a38ac1843f223db72b80c5e6a87ff354219ee86037
+  md5: 9af93a191056b12e841b7d32f1b01b1c
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 110831
+  timestamp: 1696182637281
+- kind: conda
+  name: pugixml
+  version: '1.14'
+  build: h59595ed_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/pugixml-1.14-h59595ed_0.conda
+  sha256: ea5f2d593177318f6b19af05018c953f41124cbb3bf21f9fdedfdb6ac42913ae
+  md5: 2c97dd90633508b422c11bd3018206ab
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 114871
+  timestamp: 1696182708943
+- kind: conda
+  name: pugixml
+  version: '1.14'
+  build: h63175ca_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/pugixml-1.14-h63175ca_0.conda
+  sha256: 68a5cb9a7560b2ce0d72ccebc7f6623e13ca66a67f80feb1094a75199bd1a50c
+  md5: 6794ab7a1f26ebfe0452297eba029d4f
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 111324
+  timestamp: 1696182979614
+- kind: conda
+  name: pugixml
+  version: '1.14'
+  build: he965462_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/pugixml-1.14-he965462_0.conda
+  sha256: 8ba30eb9ead058a19a472bb8e795ab408c629b0b84fc5bb7b6899e7429d5e625
+  md5: 92f9416f48c010bf04c34c9841c84b09
+  depends:
+  - libcxx >=15.0.7
+  license: MIT
+  license_family: MIT
+  size: 94175
+  timestamp: 1696182807580
+- kind: conda
+  name: pulseaudio-client
+  version: '16.1'
+  build: h729494f_5
+  build_number: 5
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/pulseaudio-client-16.1-h729494f_5.conda
+  sha256: da519980beffcda9e6f469f3b6a7eb5ee79178c1b0c13b9ce836e8cadb1eb1a0
+  md5: 2a7db85ea4e74dcc7677b2c76e244a9a
+  depends:
+  - dbus >=1.13.6,<2.0a0
+  - libgcc-ng >=12
+  - libglib >=2.76.4,<3.0a0
+  - libsndfile >=1.2.2,<1.3.0a0
+  - libsystemd0 >=254
+  constrains:
+  - pulseaudio 16.1 *_5
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 758313
+  timestamp: 1693928930444
+- kind: conda
+  name: pulseaudio-client
+  version: '16.1'
+  build: hb77b528_5
+  build_number: 5
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/pulseaudio-client-16.1-hb77b528_5.conda
+  sha256: 9981c70893d95c8cac02e7edd1a9af87f2c8745b772d529f08b7f9dafbe98606
+  md5: ac902ff3c1c6d750dd0dfc93a974ab74
+  depends:
+  - dbus >=1.13.6,<2.0a0
+  - libgcc-ng >=12
+  - libglib >=2.76.4,<3.0a0
+  - libsndfile >=1.2.2,<1.3.0a0
+  - libsystemd0 >=254
+  constrains:
+  - pulseaudio 16.1 *_5
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 754844
+  timestamp: 1693928953742
+- kind: conda
+  name: pyparsing
+  version: 3.1.1
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.1-pyhd8ed1ab_0.conda
+  sha256: 4a1332d634b6c2501a973655d68f08c9c42c0bd509c349239127b10572b8354b
+  md5: 176f7d56f0cfe9008bdf1bccd7de02fb
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 89521
+  timestamp: 1690737983548
+- kind: conda
+  name: python
+  version: 3.11.7
+  build: h2628c8c_1_cpython
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/python-3.11.7-h2628c8c_1_cpython.conda
+  sha256: 668e9fd58e627c823e6e9d791e1fb8b372c76b5704a0c3b0cc94b3a34f5be582
+  md5: c2f9a938fca6aa621b44afc8f5db79ab
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.5.0,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libsqlite >=3.44.2,<4.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.2.0,<4.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - python_abi 3.11.* *_cp311
+  license: Python-2.0
+  size: 18191531
+  timestamp: 1703342117253
+- kind: conda
+  name: python
+  version: 3.11.7
+  build: h43d1f9e_1_cpython
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/python-3.11.7-h43d1f9e_1_cpython.conda
+  sha256: d1d98331d7593d30fba6fdb03873e2e20b81963b596ed53804423e8d14e3306c
+  md5: f14f508a1135462ecb00d28967d9612b
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - ld_impl_linux-aarch64 >=2.36.1
+  - libexpat >=2.5.0,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=12
+  - libnsl >=2.0.1,<2.1.0a0
+  - libsqlite >=3.44.2,<4.0a0
+  - libuuid >=2.38.1,<3.0a0
+  - libxcrypt >=4.4.36
+  - libzlib >=1.2.13,<1.3.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.2.0,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - python_abi 3.11.* *_cp311
+  license: Python-2.0
+  size: 15302406
+  timestamp: 1703341709968
+- kind: conda
+  name: python
+  version: 3.11.7
+  build: h9f0c242_1_cpython
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/python-3.11.7-h9f0c242_1_cpython.conda
+  sha256: d234064dffa64715cf0a3f6c6a3665ead193f5a898614691b08d9c5afcdf11cc
+  md5: 686f211dcfbb8d27c6fe1ca905870189
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.5.0,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libsqlite >=3.44.2,<4.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.2.0,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - python_abi 3.11.* *_cp311
+  license: Python-2.0
+  size: 15452269
+  timestamp: 1703343492323
+- kind: conda
+  name: python
+  version: 3.11.7
+  build: hab00c5b_1_cpython
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.11.7-hab00c5b_1_cpython.conda
+  sha256: 8266801d3f21ae3018b997dcd05503b034016a3335aa3ab5b8c3f482af1e6580
+  md5: 27cf681282c11dba7b0b1fd266e8f289
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - ld_impl_linux-64 >=2.36.1
+  - libexpat >=2.5.0,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=12
+  - libnsl >=2.0.1,<2.1.0a0
+  - libsqlite >=3.44.2,<4.0a0
+  - libuuid >=2.38.1,<3.0a0
+  - libxcrypt >=4.4.36
+  - libzlib >=1.2.13,<1.3.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.2.0,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - python_abi 3.11.* *_cp311
+  license: Python-2.0
+  size: 30830615
+  timestamp: 1703344491543
+- kind: conda
+  name: python
+  version: 3.11.7
+  build: hdf0ec26_1_cpython
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.11.7-hdf0ec26_1_cpython.conda
+  sha256: 92ac26592b53ddb646237c0dd83fd073d2f181dd1553e7ac8428b4475ff5560b
+  md5: f0f1fcde592e067a5ca2187d6f232bd3
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.5.0,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libsqlite >=3.44.2,<4.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.2.0,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - python_abi 3.11.* *_cp311
+  license: Python-2.0
+  size: 14567667
+  timestamp: 1703342625860
+- kind: conda
+  name: python-dateutil
+  version: 2.8.2
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.8.2-pyhd8ed1ab_0.tar.bz2
+  sha256: 54d7785c7678166aa45adeaccfc1d2b8c3c799ca2dc05d4a82bb39b1968bd7da
+  md5: dd999d1cc9f79e67dbb855c8924c7984
+  depends:
+  - python >=3.6
+  - six >=1.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 245987
+  timestamp: 1626286448716
+- kind: conda
+  name: python_abi
+  version: '3.11'
+  build: 4_cp311
+  build_number: 4
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.11-4_cp311.conda
+  sha256: 0be3ac1bf852d64f553220c7e6457e9c047dfb7412da9d22fbaa67e60858b3cf
+  md5: d786502c97404c94d7d58d258a445a65
+  constrains:
+  - python 3.11.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6385
+  timestamp: 1695147338551
+- kind: conda
+  name: python_abi
+  version: '3.11'
+  build: 4_cp311
+  build_number: 4
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/python_abi-3.11-4_cp311.conda
+  sha256: 135a21de5721a2667613529b4ac50a9454979bf969fa99d74b6e5ad9a4ff284d
+  md5: 89983f987dfee288f94ddb2ee550ea60
+  constrains:
+  - python 3.11.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6384
+  timestamp: 1695147390555
+- kind: conda
+  name: python_abi
+  version: '3.11'
+  build: 4_cp311
+  build_number: 4
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.11-4_cp311.conda
+  sha256: f56dfe2a57b3b27bad3f9527f943548e8b2526e949d9d6fc0a383020d9359afe
+  md5: fef7a52f0eca6bae9e8e2e255bc86394
+  constrains:
+  - python 3.11.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6478
+  timestamp: 1695147518012
+- kind: conda
+  name: python_abi
+  version: '3.11'
+  build: 4_cp311
+  build_number: 4
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.11-4_cp311.conda
+  sha256: 4837089c477b9b84fa38a17f453e6634e68237267211b27a8a2f5ccd847f4e55
+  md5: 8d3751bc73d3bbb66f216fa2331d5649
+  constrains:
+  - python 3.11.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6492
+  timestamp: 1695147509940
+- kind: conda
+  name: python_abi
+  version: '3.11'
+  build: 4_cp311
+  build_number: 4
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.11-4_cp311.conda
+  sha256: 67c2aade3e2160642eec0742384e766b20c766055e3d99335681e3e05d88ed7b
+  md5: 70513332c71b56eace4ee6441e66c012
+  constrains:
+  - python 3.11.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6755
+  timestamp: 1695147711935
+- kind: conda
+  name: pyyaml
+  version: 5.4.1
+  build: py311h5547dcb_4
+  build_number: 4
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/pyyaml-5.4.1-py311h5547dcb_4.tar.bz2
+  sha256: 6af5ce72933856ce2e7bb373d56b81b8b6c9765c5062fa866b1b02da45d83216
+  md5: 262c823ba0fcc726282f867ec33401c0
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 204030
+  timestamp: 1668001919172
+- kind: conda
+  name: pyyaml
+  version: 5.4.1
+  build: py311ha68e1ae_4
+  build_number: 4
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/pyyaml-5.4.1-py311ha68e1ae_4.tar.bz2
+  sha256: ae4b648bb53d03539838ab2db8d19c71d8c49b5981d061ddbb45e92720b2d8ef
+  md5: fbaa1fc5ae77f904e3e8baac493f32bc
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 186122
+  timestamp: 1668002022566
+- kind: conda
+  name: pyyaml
+  version: 5.4.1
+  build: py311hd4cff14_4
+  build_number: 4
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-5.4.1-py311hd4cff14_4.tar.bz2
+  sha256: 5d40d1ed0fad520244e05ea97bf6d2271823a0ded865ae77f16a1b32947474af
+  md5: 13234c1dc70ea098bc4ab77993f6b299
+  depends:
+  - libgcc-ng >=12
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 212460
+  timestamp: 1668001623550
+- kind: conda
+  name: pyyaml
+  version: 5.4.1
+  build: py311hdfa8b44_4
+  build_number: 4
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/pyyaml-5.4.1-py311hdfa8b44_4.tar.bz2
+  sha256: 22dde2ba51105a94115453d6a4a6581f7ad855ec00f4a18cdeecd35467df7ba6
+  md5: d261063b9c7570e1899867eea5cbc47e
+  depends:
+  - libgcc-ng >=12
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 205441
+  timestamp: 1668001721673
+- kind: conda
+  name: pyyaml
+  version: 5.4.1
+  build: py311he2be06e_4
+  build_number: 4
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-5.4.1-py311he2be06e_4.tar.bz2
+  sha256: bf62a818bbf0407de0cb2b1c4fc1b0eb4ee0dd76943ffb32fc6f61fd4ebd80ca
+  md5: 1b6cfb6cb92e157279ef57706562bbde
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 199136
+  timestamp: 1668001956147
+- kind: conda
+  name: qt-main
+  version: 5.15.8
+  build: h4385fff_19
+  build_number: 19
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/qt-main-5.15.8-h4385fff_19.conda
+  sha256: f1ab73268198fe66c0b438b58b34bc56b987d0c411c4d60882c9474186a7d7f0
+  md5: e9e7fc8f8b31e436472e6c2697dfa9fa
+  depends:
+  - gst-plugins-base >=1.22.9,<1.23.0a0
+  - gstreamer >=1.22.9,<1.23.0a0
+  - icu >=73.2,<74.0a0
+  - krb5 >=1.21.2,<1.22.0a0
+  - libclang >=15.0.7,<16.0a0
+  - libclang13 >=15.0.7
+  - libcxx >=14
+  - libglib >=2.78.3,<3.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libpng >=1.6.42,<1.7.0a0
+  - libpq >=16.2,<17.0a0
+  - libsqlite >=3.45.1,<4.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - mysql-libs >=8.0.33,<8.1.0a0
+  - nspr >=4.35,<5.0a0
+  - nss >=3.97,<4.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  constrains:
+  - qt 5.15.8
+  - __osx >=10.13
+  license: LGPL-3.0-only
+  size: 46210935
+  timestamp: 1707961847477
+- kind: conda
+  name: qt-main
+  version: 5.15.8
+  build: h5810be5_19
+  build_number: 19
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/qt-main-5.15.8-h5810be5_19.conda
+  sha256: 41228ec12346d640ef1f549885d8438e98b1be0fdeb68cd1dd3938f255cbd719
+  md5: 54866f708d43002a514d0b9b0f84bc11
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - alsa-lib >=1.2.10,<1.2.11.0a0
+  - dbus >=1.13.6,<2.0a0
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - gst-plugins-base >=1.22.9,<1.23.0a0
+  - gstreamer >=1.22.9,<1.23.0a0
+  - harfbuzz >=8.3.0,<9.0a0
+  - icu >=73.2,<74.0a0
+  - krb5 >=1.21.2,<1.22.0a0
+  - libclang >=15.0.7,<16.0a0
+  - libclang13 >=15.0.7
+  - libcups >=2.3.3,<2.4.0a0
+  - libevent >=2.1.12,<2.1.13.0a0
+  - libexpat >=2.5.0,<3.0a0
+  - libgcc-ng >=12
+  - libglib >=2.78.3,<3.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libpng >=1.6.42,<1.7.0a0
+  - libpq >=16.2,<17.0a0
+  - libsqlite >=3.45.1,<4.0a0
+  - libstdcxx-ng >=12
+  - libxcb >=1.15,<1.16.0a0
+  - libxkbcommon >=1.6.0,<2.0a0
+  - libxml2 >=2.12.5,<3.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - mysql-libs >=8.0.33,<8.1.0a0
+  - nspr >=4.35,<5.0a0
+  - nss >=3.97,<4.0a0
+  - openssl >=3.2.1,<4.0a0
+  - pulseaudio-client >=16.1,<16.2.0a0
+  - xcb-util >=0.4.0,<0.5.0a0
+  - xcb-util-image >=0.4.0,<0.5.0a0
+  - xcb-util-keysyms >=0.4.0,<0.5.0a0
+  - xcb-util-renderutil >=0.3.9,<0.4.0a0
+  - xcb-util-wm >=0.4.1,<0.5.0a0
+  - xorg-libice >=1.1.1,<2.0a0
+  - xorg-libsm >=1.2.4,<2.0a0
+  - xorg-libx11 >=1.8.7,<2.0a0
+  - xorg-libxext >=1.3.4,<2.0a0
+  - xorg-xf86vidmodeproto
+  - zstd >=1.5.5,<1.6.0a0
+  constrains:
+  - qt 5.15.8
+  license: LGPL-3.0-only
+  size: 61337596
+  timestamp: 1707958161584
+- kind: conda
+  name: qt-main
+  version: 5.15.8
+  build: h5992497_18
+  build_number: 18
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/qt-main-5.15.8-h5992497_18.conda
+  sha256: bc72f2472b1cfc418c99ba8719138c0d3eee4ca51d6d97ae0fea474735bbde40
+  md5: 4d287ec80c254043afc54cecaaf84ad5
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - alsa-lib >=1.2.10,<1.2.11.0a0
+  - dbus >=1.13.6,<2.0a0
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - gst-plugins-base >=1.22.7,<1.23.0a0
+  - gstreamer >=1.22.7,<1.23.0a0
+  - harfbuzz >=8.3.0,<9.0a0
+  - icu >=73.2,<74.0a0
+  - krb5 >=1.21.2,<1.22.0a0
+  - libclang >=15.0.7,<16.0a0
+  - libclang13 >=15.0.7
+  - libcups >=2.3.3,<2.4.0a0
+  - libevent >=2.1.12,<2.1.13.0a0
+  - libexpat >=2.5.0,<3.0a0
+  - libgcc-ng >=12
+  - libglib >=2.78.3,<3.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libpq >=16.1,<17.0a0
+  - libsqlite >=3.44.2,<4.0a0
+  - libstdcxx-ng >=12
+  - libxcb >=1.15,<1.16.0a0
+  - libxkbcommon >=1.6.0,<2.0a0
+  - libxml2 >=2.12.2,<3.0.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - mysql-libs >=8.0.33,<8.1.0a0
+  - nspr >=4.35,<5.0a0
+  - nss >=3.95,<4.0a0
+  - openssl >=3.2.0,<4.0a0
+  - pulseaudio-client >=16.1,<16.2.0a0
+  - xcb-util >=0.4.0,<0.5.0a0
+  - xcb-util-image >=0.4.0,<0.5.0a0
+  - xcb-util-keysyms >=0.4.0,<0.5.0a0
+  - xcb-util-renderutil >=0.3.9,<0.4.0a0
+  - xcb-util-wm >=0.4.1,<0.5.0a0
+  - xorg-libice >=1.1.1,<2.0a0
+  - xorg-libsm >=1.2.4,<2.0a0
+  - xorg-libx11 >=1.8.7,<2.0a0
+  - xorg-libxext >=1.3.4,<2.0a0
+  - xorg-xf86vidmodeproto
+  - zstd >=1.5.5,<1.6.0a0
+  constrains:
+  - qt 5.15.8
+  license: LGPL-3.0-only
+  license_family: LGPL
+  size: 60341847
+  timestamp: 1702216026937
+- kind: conda
+  name: qt-main
+  version: 5.15.8
+  build: h6bf1bb6_19
+  build_number: 19
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/qt-main-5.15.8-h6bf1bb6_19.conda
+  sha256: 11774126630e5816bb0725231f0915f3b303bc2fe54844190f5b4d7f5a02a265
+  md5: 9abd8726afab7f8e7709f45a444c4844
+  depends:
+  - gst-plugins-base >=1.22.9,<1.23.0a0
+  - gstreamer >=1.22.9,<1.23.0a0
+  - icu >=73.2,<74.0a0
+  - krb5 >=1.21.2,<1.22.0a0
+  - libclang >=15.0.7,<16.0a0
+  - libclang13 >=15.0.7
+  - libcxx >=14
+  - libglib >=2.78.3,<3.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libpng >=1.6.42,<1.7.0a0
+  - libpq >=16.2,<17.0a0
+  - libsqlite >=3.45.1,<4.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - mysql-libs >=8.0.33,<8.1.0a0
+  - nspr >=4.35,<5.0a0
+  - nss >=3.97,<4.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  constrains:
+  - qt 5.15.8
+  license: LGPL-3.0-only
+  size: 51329823
+  timestamp: 1707961383220
+- kind: conda
+  name: qt-main
+  version: 5.15.8
+  build: h9e85ed6_19
+  build_number: 19
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/qt-main-5.15.8-h9e85ed6_19.conda
+  sha256: a132554a24f0617f54668479a29d9af80a2235653b08a4ebd200dcd30da971a8
+  md5: 1e5fa5b05768a8eed9d8bb0bf5585b1f
+  depends:
+  - gst-plugins-base >=1.22.9,<1.23.0a0
+  - gstreamer >=1.22.9,<1.23.0a0
+  - icu >=73.2,<74.0a0
+  - krb5 >=1.21.2,<1.22.0a0
+  - libclang >=15.0.7,<16.0a0
+  - libclang13 >=15.0.7
+  - libglib >=2.78.3,<3.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libpng >=1.6.42,<1.7.0a0
+  - libsqlite >=3.45.1,<4.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.2.1,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zstd >=1.5.5,<1.6.0a0
+  constrains:
+  - qt 5.15.8
+  license: LGPL-3.0-only
+  size: 60081554
+  timestamp: 1707957968211
+- kind: conda
+  name: readline
+  version: '8.2'
+  build: h8228510_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
+  sha256: 5435cf39d039387fbdc977b0a762357ea909a7694d9528ab40f005e9208744d7
+  md5: 47d31b792659ce70f470b5c82fdfb7a4
+  depends:
+  - libgcc-ng >=12
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 281456
+  timestamp: 1679532220005
+- kind: conda
+  name: readline
+  version: '8.2'
+  build: h8fc344f_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/readline-8.2-h8fc344f_1.conda
+  sha256: 4c99f7417419734e3797d45bc355e61c26520e111893b0d7087a01a7fbfbe3dd
+  md5: 105eb1e16bf83bfb2eb380a48032b655
+  depends:
+  - libgcc-ng >=12
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 294092
+  timestamp: 1679532238805
+- kind: conda
+  name: readline
+  version: '8.2'
+  build: h92ec313_1
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h92ec313_1.conda
+  sha256: a1dfa679ac3f6007362386576a704ad2d0d7a02e98f5d0b115f207a2da63e884
+  md5: 8cbb776a2f641b943d413b3e19df71f4
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 250351
+  timestamp: 1679532511311
+- kind: conda
+  name: readline
+  version: '8.2'
+  build: h9e318b2_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/readline-8.2-h9e318b2_1.conda
+  sha256: 41e7d30a097d9b060037f0c6a2b1d4c4ae7e942c06c943d23f9d481548478568
+  md5: f17f77f2acf4d344734bda76829ce14e
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 255870
+  timestamp: 1679532707590
+- kind: conda
+  name: robot-testing-framework
+  version: 2.0.1
+  build: h63175ca_1
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/robot-testing-framework-2.0.1-h63175ca_1.conda
+  sha256: 5552242dd9b16126fb19bbece630d1a7184e44ab5a9b40f2fb6d11472006ccce
+  md5: fc8684b4e2e739e6dc3d33b5863c64a5
+  depends:
+  - tinyxml
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: LGPL-2.1-or-later
+  size: 229485
+  timestamp: 1674117166712
+- kind: conda
+  name: robot-testing-framework
+  version: 2.0.1
+  build: hb7217d7_1
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/robot-testing-framework-2.0.1-hb7217d7_1.conda
+  sha256: b9e1e7c27b0c3559691921d07a6cdb1b57d2bea575cce2939401f3c643a2a1cc
+  md5: f94db447c6bd18a0a22087dd897e400c
+  depends:
+  - libcxx >=14.0.6
+  - tinyxml
+  license: LGPL-2.1-or-later
+  size: 181170
+  timestamp: 1674117151771
+- kind: conda
+  name: robot-testing-framework
+  version: 2.0.1
+  build: hcb278e6_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/robot-testing-framework-2.0.1-hcb278e6_1.conda
+  sha256: 242a98d006cb6056ada72553b856d89c3965f1f76ee96aaeac1020922ae5fffb
+  md5: 3e26d7c5a6e543cd83264ac70df92b6b
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - tinyxml
+  license: LGPL-2.1-or-later
+  size: 185412
+  timestamp: 1674116888665
+- kind: conda
+  name: robot-testing-framework
+  version: 2.0.1
+  build: hd600fc2_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/robot-testing-framework-2.0.1-hd600fc2_1.conda
+  sha256: 326bdaab98b2f68f0b5b83e5b022fff50fa49ded1e959a1c9b00e378aa6ff2e2
+  md5: d186a8ab75c012d89f274cc903b17182
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - tinyxml
+  license: LGPL-2.1-or-later
+  size: 181367
+  timestamp: 1674116967037
+- kind: conda
+  name: robot-testing-framework
+  version: 2.0.1
+  build: hf0c8a7f_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/robot-testing-framework-2.0.1-hf0c8a7f_1.conda
+  sha256: abf91531f35526083b3d3656f56b38084be5069eb53a2431be70632c915b4b29
+  md5: 4b729ac0107d659584848764ab16ad2b
+  depends:
+  - libcxx >=14.0.6
+  - tinyxml
+  license: LGPL-2.1-or-later
+  size: 186609
+  timestamp: 1674117260864
+- kind: conda
+  name: ruby
+  version: 3.2.2
+  build: h20ad4f3_1
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/ruby-3.2.2-h20ad4f3_1.conda
+  sha256: b1a149dfa4eb2a4560d8b9317e3d18958a4232417506cb0e88f50663062c9a82
+  md5: e4b00fff2518ccf9b1c47111ad35af6c
+  depends:
+  - libffi >=3.4,<4.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.2.0,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - yaml >=0.2.5,<0.3.0a0
+  track_features:
+  - rb32
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 15322685
+  timestamp: 1703349839755
+- kind: conda
+  name: ruby
+  version: 3.2.2
+  build: h4b2e751_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/ruby-3.2.2-h4b2e751_1.conda
+  sha256: b94233ff796b76e8208a176735a15385f1cc47b478c5045e6d2f9e5111475cd1
+  md5: b6807bf9876d9861dc6dd285d9c0dca5
+  depends:
+  - gdbm >=1.18,<1.19.0a0
+  - gettext >=0.21.1,<1.0a0
+  - gmp >=6.3.0,<7.0a0
+  - libcxx >=15
+  - libffi >=3.4,<4.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.2.0,<4.0a0
+  - readline >=8.2,<9.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  track_features:
+  - rb32
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 8063051
+  timestamp: 1703349335846
+- kind: conda
+  name: ruby
+  version: 3.2.2
+  build: h983345b_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/ruby-3.2.2-h983345b_1.conda
+  sha256: be733598e379edab3b573d094c731d48ee6e773bb0427092c31fcf948b114673
+  md5: c54d030ba62fe04a4545b6a18a65216b
+  depends:
+  - gdbm >=1.18,<1.19.0a0
+  - gmp >=6.3.0,<7.0a0
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=12
+  - libxcrypt >=4.4.36
+  - libzlib >=1.2.13,<1.3.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.2.0,<4.0a0
+  - readline >=8.2,<9.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  track_features:
+  - rb32
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 8092624
+  timestamp: 1703348802899
+- kind: conda
+  name: ruby
+  version: 3.2.2
+  build: ha6ee62f_1
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ruby-3.2.2-ha6ee62f_1.conda
+  sha256: 54a15794144c12e4d99280d7840862ac521dda4889f314a57605eed225595513
+  md5: c66c31af371555d6447109e9842eb905
+  depends:
+  - gettext >=0.21.1,<1.0a0
+  - gmp >=6.3.0,<7.0a0
+  - libcxx >=15
+  - libffi >=3.4,<4.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.2.0,<4.0a0
+  - readline >=8.2,<9.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  track_features:
+  - rb32
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 9321405
+  timestamp: 1703349858995
+- kind: conda
+  name: ruby
+  version: 3.2.2
+  build: hcdc5f17_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/ruby-3.2.2-hcdc5f17_1.conda
+  sha256: 178f133baeb05d1440165139a671169660950d5e7ffed270c45f79a4728ba446
+  md5: 39290be94d6960c2e9a46c11ebe1ed3d
+  depends:
+  - gmp >=6.3.0,<7.0a0
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=12
+  - libxcrypt >=4.4.36
+  - libzlib >=1.2.13,<1.3.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.2.0,<4.0a0
+  - readline >=8.2,<9.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  track_features:
+  - rb32
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 8236895
+  timestamp: 1703349359919
+- kind: conda
+  name: scotch
+  version: 7.0.4
+  build: h23d43cc_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/scotch-7.0.4-h23d43cc_1.conda
+  sha256: 63bed3999eb07598cb249b670fb36f8f3278cf4abebdafd3b9d908fba904e8bf
+  md5: 29663db7f60e56db7a2576ddf5a7fdc2
+  depends:
+  - libscotch 7.0.4 h91e35bf_1
+  license: CECILL-C
+  size: 92023
+  timestamp: 1702323154062
+- kind: conda
+  name: scotch
+  version: 7.0.4
+  build: h52a132a_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/scotch-7.0.4-h52a132a_1.conda
+  sha256: e9d98aeb38ddde3c3ea537a24818b4bce19fe331ec1ab0390aab03ef6a82ea6a
+  md5: 20861af41e8b87c54ae231a00d801df9
+  depends:
+  - libscotch 7.0.4 hc2ac6e5_1
+  license: CECILL-C
+  size: 78475
+  timestamp: 1702323468906
+- kind: conda
+  name: scotch
+  version: 7.0.4
+  build: habe6132_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/scotch-7.0.4-habe6132_1.conda
+  sha256: 66cd82be2e4989a76be489b453d97b9fb18b16976ebd13684f5c6c8e2de31bad
+  md5: 8e201be4922a66725150d863544926b7
+  depends:
+  - libscotch 7.0.4 h16908e7_1
+  license: CECILL-C
+  size: 99530
+  timestamp: 1702326258817
+- kind: conda
+  name: scotch
+  version: 7.0.4
+  build: heaa5b5c_1
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/scotch-7.0.4-heaa5b5c_1.conda
+  sha256: 912b497b2adde2647d9ed31325abfff0944a02e6e2819d87315bfef1081b4b70
+  md5: a30162091e3e0c0940f459ac73813192
+  depends:
+  - libscotch 7.0.4 hc938e73_1
+  license: CECILL-C
+  size: 81912
+  timestamp: 1702323453484
+- kind: conda
+  name: sdl
+  version: 1.2.68
+  build: h21dd15a_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/sdl-1.2.68-h21dd15a_0.conda
+  sha256: 6db7e8853bf7b2ed45c987c927ee4190d0255f914c9cd135693a169416bef727
+  md5: 695be37cf7e9d14a14ec5f79ef1ffc6b
+  depends:
+  - sdl2 >=2.28.3,<3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 151281
+  timestamp: 1695760016129
+- kind: conda
+  name: sdl
+  version: 1.2.68
+  build: h293081c_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/sdl-1.2.68-h293081c_0.conda
+  sha256: 794978a95605128144fc14c193eae1abf79524dafe34d9ef36aa5d6ba40ff7bb
+  md5: 53326ff6864578787913ba15616ad2f9
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - sdl2 >=2.28.3,<3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 156115
+  timestamp: 1695759535287
+- kind: conda
+  name: sdl
+  version: 1.2.68
+  build: h32cd00b_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/sdl-1.2.68-h32cd00b_0.conda
+  sha256: 7c6efceabfb742aa84cd745dd5e3cf24d9ee7167ee3851c99b29425faf21fd1c
+  md5: 2beaa8269df50204969ed14432cec69e
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - sdl2 >=2.28.3,<3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 159244
+  timestamp: 1695759461200
+- kind: conda
+  name: sdl
+  version: 1.2.68
+  build: hce1cd6f_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/sdl-1.2.68-hce1cd6f_0.conda
+  sha256: ae5d633048e1f8e77a3e57153f7a97982045cf6961e03e301d324797aefeb6d3
+  md5: 4c5c936fe91d3302ff62f99fee1057f3
+  depends:
+  - libcxx >=15.0.7
+  - sdl2 >=2.28.3,<3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 157071
+  timestamp: 1695759772225
+- kind: conda
+  name: sdl
+  version: 1.2.68
+  build: hfc12253_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/sdl-1.2.68-hfc12253_0.conda
+  sha256: 7f1e0d3e765a629852f00aef8a66a23ac98d2251efdb18073239d8e76493e14a
+  md5: 3f2b68e7acdffc200fea7b801be0ed36
+  depends:
+  - libcxx >=15.0.7
+  - sdl2 >=2.28.3,<3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 156067
+  timestamp: 1695759902673
+- kind: conda
+  name: sdl2
+  version: 2.28.5
+  build: h4e7748e_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/sdl2-2.28.5-h4e7748e_0.conda
+  sha256: 47aba875abfee18ab9be58b887a36a8f592e5cf6b31f4df1af194b2b161d4f34
+  md5: e6acdb75b2a0b729f21aedb5dec913b0
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - pulseaudio-client >=16.1,<16.2.0a0
+  - xorg-libx11 >=1.8.7,<2.0a0
+  - xorg-libxext >=1.3.4,<2.0a0
+  license: Zlib
+  size: 1294716
+  timestamp: 1701816779695
+- kind: conda
+  name: sdl2
+  version: 2.28.5
+  build: h63175ca_1
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/sdl2-2.28.5-h63175ca_1.conda
+  sha256: 76803888df269be087e39943c2e6ad924026c1b11441c2c58cc4a8b11b9ffbfd
+  md5: 94ae01bbeb7aaeb532ecc9737831990c
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Zlib
+  size: 2123088
+  timestamp: 1706359408484
+- kind: conda
+  name: sdl2
+  version: 2.28.5
+  build: h73e2aa4_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/sdl2-2.28.5-h73e2aa4_1.conda
+  sha256: 07fbb6fc2c5511992a4726202a22d047d813b8b7a891fd0ddb49f1fe5c11b75a
+  md5: 5220f48503862fa9fbc7bcfd46c88df8
+  depends:
+  - libcxx >=15
+  license: Zlib
+  size: 1174285
+  timestamp: 1706359178469
+- kind: conda
+  name: sdl2
+  version: 2.28.5
+  build: h77f46ba_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/sdl2-2.28.5-h77f46ba_0.conda
+  sha256: f1380a83bbb8968a4dfafb1b51f86fd76e2c57c75b76a2249faa02d77ec38a8c
+  md5: 8e8d854355eb56c55682f5c0df8b575d
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - pulseaudio-client >=16.1,<16.2.0a0
+  - xorg-libx11 >=1.8.7,<2.0a0
+  - xorg-libxext >=1.3.4,<2.0a0
+  license: Zlib
+  size: 1369406
+  timestamp: 1701816620021
+- kind: conda
+  name: sdl2
+  version: 2.28.5
+  build: hebf3989_1
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/sdl2-2.28.5-hebf3989_1.conda
+  sha256: bcc2f386718e23298245b381a835bda755b1d7c462eb49ffdc60c0eebc83328b
+  md5: 442ba740a1ad5b03ddc673c44c74c5c5
+  depends:
+  - libcxx >=15
+  license: Zlib
+  size: 1234766
+  timestamp: 1706359239217
+- kind: conda
+  name: setuptools
+  version: 69.0.3
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-69.0.3-pyhd8ed1ab_0.conda
+  sha256: 0fe2a0473ad03dac6c7f5c42ef36a8e90673c88a0350dfefdea4b08d43803db2
+  md5: 40695fdfd15a92121ed2922900d0308b
+  depends:
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  size: 470548
+  timestamp: 1704224855187
+- kind: conda
+  name: sigtool
+  version: 0.1.3
+  build: h44b9a77_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/sigtool-0.1.3-h44b9a77_0.tar.bz2
+  sha256: 70791ae00a3756830cb50451db55f63e2a42a2fa2a8f1bab1ebd36bbb7d55bff
+  md5: 4a2cac04f86a4540b8c9b8d8f597848f
+  depends:
+  - openssl >=3.0.0,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 210264
+  timestamp: 1643442231687
+- kind: conda
+  name: sigtool
+  version: 0.1.3
+  build: h88f4db0_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/sigtool-0.1.3-h88f4db0_0.tar.bz2
+  sha256: 46fdeadf8f8d725819c4306838cdfd1099cd8fe3e17bd78862a5dfdcd6de61cf
+  md5: fbfb84b9de9a6939cb165c02c69b1865
+  depends:
+  - openssl >=3.0.0,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 213817
+  timestamp: 1643442169866
+- kind: conda
+  name: six
+  version: 1.16.0
+  build: pyh6c4a22f_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
+  sha256: a85c38227b446f42c5b90d9b642f2c0567880c15d72492d8da074a59c8f91dd6
+  md5: e5f25f8dbc060e9a8d912e432202afc2
+  depends:
+  - python
+  license: MIT
+  license_family: MIT
+  size: 14259
+  timestamp: 1620240338595
+- kind: conda
+  name: snappy
+  version: 1.1.10
+  build: h17c5cce_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/snappy-1.1.10-h17c5cce_0.conda
+  sha256: dfae03cd2339587871e53b42833657faa4c9e42e3e2c56ee9e32bc60797c7f62
+  md5: ac82a611d1a67a598096ebaa857198e3
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 33879
+  timestamp: 1678534968831
+- kind: conda
+  name: snappy
+  version: 1.1.10
+  build: h225ccf5_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/snappy-1.1.10-h225ccf5_0.conda
+  sha256: 575915dc13152e446a84e2f88de70a14f8b6af1a870e708f9370bd4be105583b
+  md5: 4320a8781f14cd959689b86e349f3b73
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 34657
+  timestamp: 1678534768395
+- kind: conda
+  name: snappy
+  version: 1.1.10
+  build: h9fff704_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.1.10-h9fff704_0.conda
+  sha256: 02219f2382b4fe39250627dade087a4412d811936a5a445636b7260477164eac
+  md5: e6d228cd0bb74a51dd18f5bfce0b4115
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 38865
+  timestamp: 1678534590321
+- kind: conda
+  name: snappy
+  version: 1.1.10
+  build: he8610fa_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/snappy-1.1.10-he8610fa_0.conda
+  sha256: 5a7d6cf781cbaaea4effce4d8f2677cd6173af5e8b744912e1283a704eb91946
+  md5: 11c25e55894bb8207a81a87e6a32b6e7
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 38265
+  timestamp: 1678534683114
+- kind: conda
+  name: snappy
+  version: 1.1.10
+  build: hfb803bf_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/snappy-1.1.10-hfb803bf_0.conda
+  sha256: 2a195b38cb63f03ad9f73a82db52434ebefe216fb70f7ea3defe4ddf263d408a
+  md5: cff1df79c9cff719460eb2dd172568de
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 57065
+  timestamp: 1678534804734
+- kind: conda
+  name: soxr
+  version: 0.1.3
+  build: h0b41bf4_3
+  build_number: 3
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/soxr-0.1.3-h0b41bf4_3.conda
+  sha256: 141e3364d26f162bfeae8491787c0d8796ada6c29a8cd567c1cd17c3c6b418f9
+  md5: e8d261785be19b1575d23ccbbeae4ddd
+  depends:
+  - _openmp_mutex >=4.5
+  - libgcc-ng >=12
+  license: LGPL-2.1-or-later
+  size: 131370
+  timestamp: 1674059502792
+- kind: conda
+  name: soxr
+  version: 0.1.3
+  build: h5008568_3
+  build_number: 3
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/soxr-0.1.3-h5008568_3.conda
+  sha256: b3028eab2df50ebfbfbf7e21074d4862a8aa12867272ae363c0b415c6119ebe7
+  md5: 02fbc2cdd53ed18f8a4dbf36125d8b7d
+  depends:
+  - llvm-openmp >=14.0.6
+  license: LGPL-2.1-or-later
+  size: 90088
+  timestamp: 1674122598089
+- kind: conda
+  name: soxr
+  version: 0.1.3
+  build: hb4cce97_3
+  build_number: 3
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/soxr-0.1.3-hb4cce97_3.conda
+  sha256: 58b006195863f200efdb5785a4a954f8d0284b5984703d4d74ec4c09343e58e2
+  md5: 13e1d5bd316dec4077351f4246b9b2a8
+  depends:
+  - _openmp_mutex >=4.5
+  - libgcc-ng >=12
+  license: LGPL-2.1-or-later
+  size: 111209
+  timestamp: 1674059588618
+- kind: conda
+  name: soxr
+  version: 0.1.3
+  build: hbf74d83_3
+  build_number: 3
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/soxr-0.1.3-hbf74d83_3.conda
+  sha256: d274add245e2f9f1b8963533d08ce0761baa78c7923d0c8450ad54d7b2885e77
+  md5: 27b06405f0b654997e5bda2b33e5e2e7
+  depends:
+  - llvm-openmp >=14.0.6
+  license: LGPL-2.1-or-later
+  size: 127934
+  timestamp: 1674059732818
+- kind: conda
+  name: soxr
+  version: 0.1.3
+  build: hcfcfb64_3
+  build_number: 3
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/soxr-0.1.3-hcfcfb64_3.conda
+  sha256: 167201931c6be6355fa79e22fe5b8993f67a2efd0fc94acbb15393918d9a7578
+  md5: 8112bd0d3eb530551b2adebda0ea4c0c
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: LGPL-2.1-or-later
+  size: 112328
+  timestamp: 1674059996047
+- kind: conda
+  name: svt-av1
+  version: 1.8.0
+  build: h2f0025b_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/svt-av1-1.8.0-h2f0025b_0.conda
+  sha256: bcf42cef4cf08e0b79a71f4978e16ba92bd70624b25eb32a324a0be3edc79f4c
+  md5: 64801dba0cb1972e64a568b7234331e1
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1798999
+  timestamp: 1702362756845
+- kind: conda
+  name: svt-av1
+  version: 1.8.0
+  build: h463b476_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/svt-av1-1.8.0-h463b476_0.conda
+  sha256: 176ddc0f0b579038b028d03cf51cf5c70740e16f451ee60e6eb0567560331568
+  md5: bdc78f014823b0fe7be5bed84909e8c3
+  depends:
+  - __osx >=10.9
+  - libcxx >=16.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1388702
+  timestamp: 1702359462579
+- kind: conda
+  name: svt-av1
+  version: 1.8.0
+  build: h59595ed_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/svt-av1-1.8.0-h59595ed_0.conda
+  sha256: 6d64facdcdaadc5a3e5e4382ee195b4fde3c84ae3d4156fdd9b78ba7de358ba7
+  md5: a9fb862e9d3beb0ebc61c10806056a7d
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2644060
+  timestamp: 1702359203835
+- kind: conda
+  name: svt-av1
+  version: 1.8.0
+  build: h63175ca_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/svt-av1-1.8.0-h63175ca_0.conda
+  sha256: fe24efc86bf0dab4eeed3fa88f8a2592a729c1bc835f9975aff763cb91d3075e
+  md5: 89b2c7d39a898b83e71152beafd6e312
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2358109
+  timestamp: 1702359801424
+- kind: conda
+  name: svt-av1
+  version: 1.8.0
+  build: h93d8f39_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/svt-av1-1.8.0-h93d8f39_0.conda
+  sha256: ce33415f2ffd1643e26a3e464c416a96b68e409f985021f5314efe4f402a8c09
+  md5: 5cfb5476c2e9308c77afe3427da3b3b3
+  depends:
+  - __osx >=10.9
+  - libcxx >=16.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2376471
+  timestamp: 1702362435425
+- kind: conda
+  name: sysroot_linux-64
+  version: '2.12'
+  build: he073ed8_16
+  build_number: 16
+  subdir: noarch
+  noarch: generic
+  url: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.12-he073ed8_16.conda
+  sha256: 4c024b2eee24c6da7d3e08723111ec02665c578844c5b3e9e6b38f89000bec41
+  md5: 071ea8dceff4d30ac511f4a2f8437cd1
+  depends:
+  - kernel-headers_linux-64 2.6.32 he073ed8_16
+  license: LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0
+  license_family: GPL
+  size: 15277813
+  timestamp: 1689214980563
+- kind: conda
+  name: sysroot_linux-aarch64
+  version: '2.17'
+  build: h5b4a56d_13
+  build_number: 13
+  subdir: noarch
+  noarch: generic
+  url: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-aarch64-2.17-h5b4a56d_13.conda
+  sha256: 16c9c99b04952456c344fd786d5933b5b851778b96b655d339b2f81ff8d53043
+  md5: 5493598eda29002426b4d04dcee88361
+  depends:
+  - _sysroot_linux-aarch64_curr_repodata_hack 4.*
+  - kernel-headers_linux-aarch64 4.18.0 h5b4a56d_13
+  license: LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0
+  license_family: GPL
+  size: 16291428
+  timestamp: 1682995534198
+- kind: conda
+  name: tapi
+  version: 1100.0.11
+  build: h9ce4665_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/tapi-1100.0.11-h9ce4665_0.tar.bz2
+  sha256: 34b18ce8d1518b67e333ca1d3af733c3976ecbdf3a36b727f9b4dedddcc588fa
+  md5: f9ff42ccf809a21ba6f8607f8de36108
+  depends:
+  - libcxx >=10.0.0.a0
+  license: NCSA
+  license_family: MIT
+  size: 201044
+  timestamp: 1602664232074
+- kind: conda
+  name: tapi
+  version: 1100.0.11
+  build: he4954df_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/tapi-1100.0.11-he4954df_0.tar.bz2
+  sha256: 1709265fbee693a9e8b4126b0a3e68a6c4718b05821c659279c1af051f2d40f3
+  md5: d83362e7d0513f35f454bc50b0ca591d
+  depends:
+  - libcxx >=11.0.0.a0
+  license: NCSA
+  license_family: MIT
+  size: 191416
+  timestamp: 1602687595316
+- kind: conda
+  name: tbb
+  version: 2021.11.0
+  build: h00ab1b0_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/tbb-2021.11.0-h00ab1b0_1.conda
+  sha256: ded4de0d5a3eb7b47ed829f0ed0e3c61ccd428308bde52d8d22ced228038223b
+  md5: 4531d2927578e7e254ff3bcf6457518c
+  depends:
+  - libgcc-ng >=12
+  - libhwloc >=2.9.3,<2.9.4.0a0
+  - libstdcxx-ng >=12
+  license: Apache-2.0
+  license_family: APACHE
+  size: 195540
+  timestamp: 1706163436794
+- kind: conda
+  name: tbb
+  version: 2021.11.0
+  build: h2a328a1_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/tbb-2021.11.0-h2a328a1_1.conda
+  sha256: eb8a3fb326828c2ff7ba8e2879bf11b3bd52f34c317d0faebe59772533d7d1de
+  md5: 4e385c984b98c7cbf28af64041d21cc4
+  depends:
+  - libgcc-ng >=12
+  - libhwloc >=2.9.3,<2.9.4.0a0
+  - libstdcxx-ng >=12
+  license: Apache-2.0
+  license_family: APACHE
+  size: 161613
+  timestamp: 1706166156098
+- kind: conda
+  name: tbb
+  version: 2021.11.0
+  build: h2ffa867_1
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/tbb-2021.11.0-h2ffa867_1.conda
+  sha256: 35aa1918c901fb784c74f3d322f21a87d5bf57fbf02e5586778152b5c4cd82da
+  md5: e5584996979b373d50560a28321547e9
+  depends:
+  - libcxx >=15
+  - libhwloc >=2.9.3,<2.9.4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 128174
+  timestamp: 1706163796739
+- kind: conda
+  name: tbb
+  version: 2021.11.0
+  build: h7728843_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/tbb-2021.11.0-h7728843_1.conda
+  sha256: 6d531daba5ccf150b58d434fa72b1da0da04e8f14ab71bdad289a90d355f47e8
+  md5: 29e29beba9deb0ef66bee015c5bf3c14
+  depends:
+  - libcxx >=15
+  - libhwloc >=2.9.3,<2.9.4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 173117
+  timestamp: 1706163682083
+- kind: conda
+  name: tbb
+  version: 2021.11.0
+  build: h91493d7_1
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.11.0-h91493d7_1.conda
+  sha256: aa30c089fdd6f66c7808592362e29963586e094159964a5fb61fb8efa9e349bc
+  md5: 21069f3ed16812f9f4f2700667b6ec86
+  depends:
+  - libhwloc >=2.9.3,<2.9.4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: APACHE
+  size: 161382
+  timestamp: 1706164225098
+- kind: conda
+  name: tinyxml
+  version: 2.6.2
+  build: h260d524_2
+  build_number: 2
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/tinyxml-2.6.2-h260d524_2.tar.bz2
+  sha256: ffed96f7167394be9007c1b4e2b28cf690388f9aaef0b57f0d44ad44bb247f94
+  md5: 514f487df6232e8dd819faf3c5915e58
+  depends:
+  - libcxx >=11.0.1
+  license: Zlib
+  size: 52319
+  timestamp: 1613627858183
+- kind: conda
+  name: tinyxml
+  version: 2.6.2
+  build: h2d74725_2
+  build_number: 2
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/tinyxml-2.6.2-h2d74725_2.tar.bz2
+  sha256: 92b01cf22522c6da6e56825692c2ae2c0dd1a1bc7251a86cdf47d5ab451cb31c
+  md5: a5c2010323ceaa8faec6697921b23928
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
+  license: Zlib
+  size: 71271
+  timestamp: 1611562303689
+- kind: conda
+  name: tinyxml
+  version: 2.6.2
+  build: h4bd325d_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/tinyxml-2.6.2-h4bd325d_2.tar.bz2
+  sha256: d9e3c192c535c06ec139ada7bcd1f12313ebd377208fc8149348e8534229f39e
+  md5: 39dd0757ee71ccd5b120440dce126c37
+  depends:
+  - libgcc-ng >=9.3.0
+  - libstdcxx-ng >=9.3.0
+  license: Zlib
+  size: 56535
+  timestamp: 1611562094388
+- kind: conda
+  name: tinyxml
+  version: 2.6.2
+  build: h65a07b1_2
+  build_number: 2
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/tinyxml-2.6.2-h65a07b1_2.tar.bz2
+  sha256: 46ab86c00bd3da363965ed7ce70568c034161bcff00b60c7b214bfc5863598c7
+  md5: f68a89c60bb5823762f1b15a2cd6ff0b
+  depends:
+  - libcxx >=11.0.1
+  license: Zlib
+  size: 52047
+  timestamp: 1613627913149
+- kind: conda
+  name: tinyxml
+  version: 2.6.2
+  build: hd62202e_2
+  build_number: 2
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/tinyxml-2.6.2-hd62202e_2.tar.bz2
+  sha256: d7f66bd0ddfbe1b8f2638678d962140e8ab8a63d779b9366247e1f7daabeb575
+  md5: 454eb4b31a1f4313c72ef7f536cae5d9
+  depends:
+  - libgcc-ng >=9.3.0
+  - libstdcxx-ng >=9.3.0
+  license: Zlib
+  size: 56283
+  timestamp: 1611562275383
+- kind: conda
+  name: tk
+  version: 8.6.13
+  build: h194ca79_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/tk-8.6.13-h194ca79_0.conda
+  sha256: 7fa27cc512d3a783f38bd16bbbffc008807372499d5b65d089a8e43bde9db267
+  md5: f75105e0585851f818e0009dd1dde4dc
+  depends:
+  - libgcc-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
+  license: TCL
+  license_family: BSD
+  size: 3351802
+  timestamp: 1695506242997
+- kind: conda
+  name: tk
+  version: 8.6.13
+  build: h1abcd95_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h1abcd95_1.conda
+  sha256: 30412b2e9de4ff82d8c2a7e5d06a15f4f4fef1809a72138b6ccb53a33b26faf5
+  md5: bf830ba5afc507c6232d4ef0fb1a882d
+  depends:
+  - libzlib >=1.2.13,<1.3.0a0
+  license: TCL
+  license_family: BSD
+  size: 3270220
+  timestamp: 1699202389792
+- kind: conda
+  name: tk
+  version: 8.6.13
+  build: h5083fa2_1
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h5083fa2_1.conda
+  sha256: 72457ad031b4c048e5891f3f6cb27a53cb479db68a52d965f796910e71a403a8
+  md5: b50a57ba89c32b62428b71a875291c9b
+  depends:
+  - libzlib >=1.2.13,<1.3.0a0
+  license: TCL
+  license_family: BSD
+  size: 3145523
+  timestamp: 1699202432999
+- kind: conda
+  name: tk
+  version: 8.6.13
+  build: h5226925_1
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h5226925_1.conda
+  sha256: 2c4e914f521ccb2718946645108c9bd3fc3216ba69aea20c2c3cedbd8db32bb1
+  md5: fc048363eb8f03cd1737600a5d08aafe
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: TCL
+  license_family: BSD
+  size: 3503410
+  timestamp: 1699202577803
+- kind: conda
+  name: tk
+  version: 8.6.13
+  build: noxft_h4845f30_101
+  build_number: 101
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
+  sha256: e0569c9caa68bf476bead1bed3d79650bb080b532c64a4af7d8ca286c08dea4e
+  md5: d453b98d9c83e71da0741bb0ff4d76bc
+  depends:
+  - libgcc-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
+  license: TCL
+  license_family: BSD
+  size: 3318875
+  timestamp: 1699202167581
+- kind: conda
+  name: tzdata
+  version: 2024a
+  build: h0c530f3_0
+  subdir: noarch
+  noarch: generic
+  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
+  sha256: 7b2b69c54ec62a243eb6fba2391b5e443421608c3ae5dbff938ad33ca8db5122
+  md5: 161081fc7cec0bfda0d86d7cb595f8d8
+  license: LicenseRef-Public-Domain
+  size: 119815
+  timestamp: 1706886945727
+- kind: conda
+  name: ucrt
+  version: 10.0.22621.0
+  build: h57928b3_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_0.tar.bz2
+  sha256: f29cdaf8712008f6b419b8b1a403923b00ab2504bfe0fb2ba8eb60e72d4f14c6
+  md5: 72608f6cd3e5898229c3ea16deb1ac43
+  constrains:
+  - vs2015_runtime >=14.29.30037
+  license: LicenseRef-Proprietary
+  license_family: PROPRIETARY
+  size: 1283972
+  timestamp: 1666630199266
+- kind: conda
+  name: unixodbc
+  version: 2.3.12
+  build: h0e2417a_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/unixodbc-2.3.12-h0e2417a_0.conda
+  sha256: c23df29cd90c80f1bd599909cb8fb0281058d372324afde481687f240a7e77c7
+  md5: 466dfbfb384f10c790f48c9b4316ffb1
+  depends:
+  - libcxx >=15.0.7
+  - libedit >=3.1.20191231,<3.2.0a0
+  - libiconv >=1.17,<2.0a0
+  license: LGPL-2.1
+  size: 253937
+  timestamp: 1691504579753
+- kind: conda
+  name: unixodbc
+  version: 2.3.12
+  build: h661eb56_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/unixodbc-2.3.12-h661eb56_0.conda
+  sha256: 718eb807a5e6e6993ee06745cb2a25a6b353427485a6e50df01db99c6016a53f
+  md5: a737e5c549c13fbb5590c581848b0446
+  depends:
+  - libedit >=3.1.20191231,<3.2.0a0
+  - libgcc-ng >=12
+  - libiconv >=1.17,<2.0a0
+  - libstdcxx-ng >=12
+  license: LGPL-2.1
+  size: 281830
+  timestamp: 1691504075258
+- kind: conda
+  name: unixodbc
+  version: 2.3.12
+  build: h7b6a552_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/unixodbc-2.3.12-h7b6a552_0.conda
+  sha256: 09156b060dbfba9480bbd782ee57e4e6b324365385fb75e1ddaffb25cb79e218
+  md5: 7da048d2fb224953a804da9e8026197f
+  depends:
+  - libedit >=3.1.20191231,<3.2.0a0
+  - libgcc-ng >=12
+  - libiconv >=1.17,<2.0a0
+  - libstdcxx-ng >=12
+  license: LGPL-2.1
+  size: 319756
+  timestamp: 1691504019265
+- kind: conda
+  name: unixodbc
+  version: 2.3.12
+  build: he8a5cf4_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/unixodbc-2.3.12-he8a5cf4_0.conda
+  sha256: 048b6e6911905c413176601c6ea8ca519f57f5c12eeff297623dfcadd4012c68
+  md5: ab0e676e1de2d40a2816aeda4d4edcab
+  depends:
+  - libcxx >=15.0.7
+  - libedit >=3.1.20191231,<3.2.0a0
+  - libiconv >=1.17,<2.0a0
+  license: LGPL-2.1
+  size: 259234
+  timestamp: 1691504490810
+- kind: conda
+  name: vc
+  version: '14.3'
+  build: hcf57466_18
+  build_number: 18
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-hcf57466_18.conda
+  sha256: 447a8d8292a7b2107dcc18afb67f046824711a652725fc0f522c368e7a7b8318
+  md5: 20e1e652a4c740fa719002a8449994a2
+  depends:
+  - vc14_runtime >=14.38.33130
+  track_features:
+  - vc14
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16977
+  timestamp: 1702511255313
+- kind: conda
+  name: vc14_runtime
+  version: 14.38.33130
+  build: h82b7239_18
+  build_number: 18
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.38.33130-h82b7239_18.conda
+  sha256: bf94c9af4b2e9cba88207001197e695934eadc96a5c5e4cd7597e950aae3d8ff
+  md5: 8be79fdd2725ddf7bbf8a27a4c1f79ba
+  depends:
+  - ucrt >=10.0.20348.0
+  constrains:
+  - vs2015_runtime 14.38.33130.* *_18
+  license: LicenseRef-ProprietaryMicrosoft
+  license_family: Proprietary
+  size: 749868
+  timestamp: 1702511239004
+- kind: conda
+  name: vs2015_runtime
+  version: 14.38.33130
+  build: hcb4865c_18
+  build_number: 18
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.38.33130-hcb4865c_18.conda
+  sha256: a2fec221f361d6263c117f4ea6d772b21c90a2f8edc6f3eb0eadec6bfe8843db
+  md5: 10d42885e3ed84e575b454db30f1aa93
+  depends:
+  - vc14_runtime >=14.38.33130
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16988
+  timestamp: 1702511261442
+- kind: conda
+  name: vs2019_win-64
+  version: 19.29.30139
+  build: he1865b1_18
+  build_number: 18
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/vs2019_win-64-19.29.30139-he1865b1_18.conda
+  sha256: b8f5128fc767fc04b48ec10df7ac6eea5d07df0efa2d91fff6d872e3dcde9029
+  md5: 6d9d317010ece223fc46a69360d0eb84
+  depends:
+  - vswhere
+  track_features:
+  - vc14
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19488
+  timestamp: 1702511289992
+- kind: conda
+  name: vswhere
+  version: 3.1.4
+  build: h57928b3_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/vswhere-3.1.4-h57928b3_0.conda
+  sha256: 553c41fc1a883415a39444313f8d99236685529776fdd04e8d97288b73496002
+  md5: b1d1d6a1f874d8c93a57b5efece52f03
+  license: MIT
+  license_family: MIT
+  size: 218421
+  timestamp: 1682376911339
+- kind: conda
+  name: wheel
+  version: 0.42.0
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/wheel-0.42.0-pyhd8ed1ab_0.conda
+  sha256: 80be0ccc815ce22f80c141013302839b0ed938a2edb50b846cf48d8a8c1cfa01
+  md5: 1cdea58981c5cbc17b51973bcaddcea7
+  depends:
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  size: 57553
+  timestamp: 1701013309664
+- kind: conda
+  name: x264
+  version: 1!164.3095
+  build: h166bdaf_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/x264-1!164.3095-h166bdaf_2.tar.bz2
+  sha256: 175315eb3d6ea1f64a6ce470be00fa2ee59980108f246d3072ab8b977cb048a5
+  md5: 6c99772d483f566d59e25037fea2c4b1
+  depends:
+  - libgcc-ng >=12
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 897548
+  timestamp: 1660323080555
+- kind: conda
+  name: x264
+  version: 1!164.3095
+  build: h4e544f5_2
+  build_number: 2
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/x264-1!164.3095-h4e544f5_2.tar.bz2
+  sha256: b48f150db8c052c197691c9d76f59e252d3a7f01de123753d51ebf2eed1cf057
+  md5: 0efaf807a0b5844ce5f605bd9b668281
+  depends:
+  - libgcc-ng >=12
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 1000661
+  timestamp: 1660324722559
+- kind: conda
+  name: x264
+  version: 1!164.3095
+  build: h57fd34a_2
+  build_number: 2
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/x264-1!164.3095-h57fd34a_2.tar.bz2
+  sha256: debdf60bbcfa6a60201b12a1d53f36736821db281a28223a09e0685edcce105a
+  md5: b1f6dccde5d3a1f911960b6e567113ff
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 717038
+  timestamp: 1660323292329
+- kind: conda
+  name: x264
+  version: 1!164.3095
+  build: h775f41a_2
+  build_number: 2
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/x264-1!164.3095-h775f41a_2.tar.bz2
+  sha256: de611da29f4ed0733a330402e163f9260218e6ba6eae593a5f945827d0ee1069
+  md5: 23e9c3180e2c0f9449bb042914ec2200
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 937077
+  timestamp: 1660323305349
+- kind: conda
+  name: x264
+  version: 1!164.3095
+  build: h8ffe710_2
+  build_number: 2
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/x264-1!164.3095-h8ffe710_2.tar.bz2
+  sha256: 97166b318f8c68ffe4d50b2f4bd36e415219eeaef233e7d41c54244dc6108249
+  md5: 19e39905184459760ccb8cf5c75f148b
+  depends:
+  - vc >=14.1,<15
+  - vs2015_runtime >=14.16.27033
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 1041889
+  timestamp: 1660323726084
+- kind: conda
+  name: x265
+  version: '3.5'
+  build: h2d74725_3
+  build_number: 3
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/x265-3.5-h2d74725_3.tar.bz2
+  sha256: 02b9874049112f2b7335c9a3e880ac05d99a08d9a98160c5a98898b2b3ac42b2
+  md5: ca7129a334198f08347fb19ac98a2de9
+  depends:
+  - vc >=14.1,<15
+  - vs2015_runtime >=14.16.27033
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 5517425
+  timestamp: 1646611941216
+- kind: conda
+  name: x265
+  version: '3.5'
+  build: h924138e_3
+  build_number: 3
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/x265-3.5-h924138e_3.tar.bz2
+  sha256: 76c7405bcf2af639971150f342550484efac18219c0203c5ee2e38b8956fe2a0
+  md5: e7f6ed84d4623d52ee581325c1587a6b
+  depends:
+  - libgcc-ng >=10.3.0
+  - libstdcxx-ng >=10.3.0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 3357188
+  timestamp: 1646609687141
+- kind: conda
+  name: x265
+  version: '3.5'
+  build: hbb4e6a2_3
+  build_number: 3
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/x265-3.5-hbb4e6a2_3.tar.bz2
+  sha256: 6b6a57710192764d0538f72ea1ccecf2c6174a092e0bc76d790f8ca36bbe90e4
+  md5: a3bf3e95b7795871a6734a784400fcea
+  depends:
+  - libcxx >=12.0.1
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 3433205
+  timestamp: 1646610148268
+- kind: conda
+  name: x265
+  version: '3.5'
+  build: hbc6ce65_3
+  build_number: 3
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/x265-3.5-hbc6ce65_3.tar.bz2
+  sha256: 2fed6987dba7dee07bd9adc1a6f8e6c699efb851431bcb6ebad7de196e87841d
+  md5: b1f7f2780feffe310b068c021e8ff9b2
+  depends:
+  - libcxx >=12.0.1
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 1832744
+  timestamp: 1646609481185
+- kind: conda
+  name: x265
+  version: '3.5'
+  build: hdd96247_3
+  build_number: 3
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/x265-3.5-hdd96247_3.tar.bz2
+  sha256: cb2227f2441499900bdc0168eb423d7b2056c8fd5a3541df4e2d05509a88c668
+  md5: 786853760099c74a1d4f0da98dd67aea
+  depends:
+  - libgcc-ng >=10.3.0
+  - libstdcxx-ng >=10.3.0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 1018181
+  timestamp: 1646610147365
+- kind: conda
+  name: xcb-util
+  version: 0.4.0
+  build: h31becfc_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-0.4.0-h31becfc_1.conda
+  sha256: 28d5d383128cf869ac7db173c3ae5d37fa15953bf8f836942b59f6f4e3951a94
+  md5: cd63fffc384ebf7ef90c3e03640089d9
+  depends:
+  - libgcc-ng >=12
+  - libxcb >=1.13
+  - libxcb >=1.15,<1.16.0a0
+  license: MIT
+  license_family: MIT
+  size: 21121
+  timestamp: 1684640370585
+- kind: conda
+  name: xcb-util
+  version: 0.4.0
+  build: hd590300_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-0.4.0-hd590300_1.conda
+  sha256: 0c91d87f0efdaadd4e56a5f024f8aab20ec30f90aa2ce9e4ebea05fbc20f71ad
+  md5: 9bfac7ccd94d54fd21a0501296d60424
+  depends:
+  - libgcc-ng >=12
+  - libxcb >=1.13
+  - libxcb >=1.15,<1.16.0a0
+  license: MIT
+  license_family: MIT
+  size: 19728
+  timestamp: 1684639166048
+- kind: conda
+  name: xcb-util-image
+  version: 0.4.0
+  build: h8ee46fc_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-image-0.4.0-h8ee46fc_1.conda
+  sha256: 92ffd68d2801dbc27afe223e04ae7e78ef605fc8575f107113c93c7bafbd15b0
+  md5: 9d7bcddf49cbf727730af10e71022c73
+  depends:
+  - libgcc-ng >=12
+  - libxcb >=1.15,<1.16.0a0
+  - xcb-util >=0.4.0,<0.5.0a0
+  license: MIT
+  license_family: MIT
+  size: 24474
+  timestamp: 1684679894554
+- kind: conda
+  name: xcb-util-image
+  version: 0.4.0
+  build: hcb25cf1_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-image-0.4.0-hcb25cf1_1.conda
+  sha256: 94f546f2d8f5053bd21ccc656be364cfa5b1b8736f95befecadda4343a55b871
+  md5: 395256583f9ba09af83bd2875e2dd43e
+  depends:
+  - libgcc-ng >=12
+  - libxcb >=1.15,<1.16.0a0
+  - xcb-util >=0.4.0,<0.5.0a0
+  license: MIT
+  license_family: MIT
+  size: 24820
+  timestamp: 1684680024607
+- kind: conda
+  name: xcb-util-keysyms
+  version: 0.4.0
+  build: h8ee46fc_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-keysyms-0.4.0-h8ee46fc_1.conda
+  sha256: 8451d92f25d6054a941b962179180728c48c62aab5bf20ac10fef713d5da6a9a
+  md5: 632413adcd8bc16b515cab87a2932913
+  depends:
+  - libgcc-ng >=12
+  - libxcb >=1.15,<1.16.0a0
+  license: MIT
+  license_family: MIT
+  size: 14186
+  timestamp: 1684680497805
+- kind: conda
+  name: xcb-util-keysyms
+  version: 0.4.0
+  build: hcb25cf1_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-keysyms-0.4.0-hcb25cf1_1.conda
+  sha256: a6d14beea8c0fca033a375a3ac3059d909bdf3e19d9e0c683358b34247b7f6f7
+  md5: befa651eadbd51987c8ebc462497a8ff
+  depends:
+  - libgcc-ng >=12
+  - libxcb >=1.15,<1.16.0a0
+  license: MIT
+  license_family: MIT
+  size: 14261
+  timestamp: 1684680602585
+- kind: conda
+  name: xcb-util-renderutil
+  version: 0.3.9
+  build: h31becfc_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-renderutil-0.3.9-h31becfc_1.conda
+  sha256: 037a9be6da2afed4fdbfcfb0ea13a60c1d80a025b023e879c89f3fe572571b4c
+  md5: 15c02e09b3441d567b83199173abc1f9
+  depends:
+  - libgcc-ng >=12
+  - libxcb >=1.13
+  - libxcb >=1.15,<1.16.0a0
+  license: MIT
+  license_family: MIT
+  size: 18016
+  timestamp: 1684640014593
+- kind: conda
+  name: xcb-util-renderutil
+  version: 0.3.9
+  build: hd590300_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-renderutil-0.3.9-hd590300_1.conda
+  sha256: 6987588e6fff5892056021c2ea52f7a0deefb2c7348e70d24750e2d60dabf009
+  md5: e995b155d938b6779da6ace6c6b13816
+  depends:
+  - libgcc-ng >=12
+  - libxcb >=1.13
+  - libxcb >=1.15,<1.16.0a0
+  license: MIT
+  license_family: MIT
+  size: 16955
+  timestamp: 1684639112393
+- kind: conda
+  name: xcb-util-wm
+  version: 0.4.1
+  build: h8ee46fc_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-wm-0.4.1-h8ee46fc_1.conda
+  sha256: 08ba7147c7579249b6efd33397dc1a8c2404278053165aaecd39280fee705724
+  md5: 90108a432fb5c6150ccfee3f03388656
+  depends:
+  - libgcc-ng >=12
+  - libxcb >=1.15,<1.16.0a0
+  license: MIT
+  license_family: MIT
+  size: 52114
+  timestamp: 1684679248466
+- kind: conda
+  name: xcb-util-wm
+  version: 0.4.1
+  build: hcb25cf1_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-wm-0.4.1-hcb25cf1_1.conda
+  sha256: 19e4883076c87f998cf3bef532d6e731208f0ef4d65414cde32d7454eb2d1890
+  md5: 615e8be7baf44b5205f8a4f5908f57f7
+  depends:
+  - libgcc-ng >=12
+  - libxcb >=1.15,<1.16.0a0
+  license: MIT
+  license_family: MIT
+  size: 49952
+  timestamp: 1684680157286
+- kind: conda
+  name: xkeyboard-config
+  version: '2.41'
+  build: h31becfc_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xkeyboard-config-2.41-h31becfc_0.conda
+  sha256: 95cedc415f7b056e5ccb76ba21c6f48644a5585617b953ad44b0d0088a1622b7
+  md5: 1df80651a2a70e3004cfc72e03fe55bd
+  depends:
+  - libgcc-ng >=12
+  - xorg-libx11 >=1.8.7,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 896792
+  timestamp: 1707104436982
+- kind: conda
+  name: xkeyboard-config
+  version: '2.41'
+  build: hd590300_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.41-hd590300_0.conda
+  sha256: 56955610c0747ea7cb026bb8aa9ef165ff41d616e89894538173b8b7dd2ee49a
+  md5: 81f740407b45e3f9047b3174fa94eb9e
+  depends:
+  - libgcc-ng >=12
+  - xorg-libx11 >=1.8.7,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 898045
+  timestamp: 1707104384997
+- kind: conda
+  name: xorg-fixesproto
+  version: '5.0'
+  build: h3557bc0_1002
+  build_number: 1002
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-fixesproto-5.0-h3557bc0_1002.tar.bz2
+  sha256: f22351d3ca1bc6130b474c52d35b02078941ba65e3c3621b630d853ed7ffe946
+  md5: d83ed0a123097ef38c744f8aa8a814f4
+  depends:
+  - libgcc-ng >=9.3.0
+  - xorg-xextproto
+  license: MIT
+  license_family: MIT
+  size: 9135
+  timestamp: 1617480316800
+- kind: conda
+  name: xorg-fixesproto
+  version: '5.0'
+  build: h7f98852_1002
+  build_number: 1002
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-fixesproto-5.0-h7f98852_1002.tar.bz2
+  sha256: 5d2af1b40f82128221bace9466565eca87c97726bb80bbfcd03871813f3e1876
+  md5: 65ad6e1eb4aed2b0611855aff05e04f6
+  depends:
+  - libgcc-ng >=9.3.0
+  - xorg-xextproto
+  license: MIT
+  license_family: MIT
+  size: 9122
+  timestamp: 1617479697350
+- kind: conda
+  name: xorg-inputproto
+  version: 2.3.2
+  build: h3557bc0_1002
+  build_number: 1002
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-inputproto-2.3.2-h3557bc0_1002.tar.bz2
+  sha256: d75eaa12b1e57c8e4fc6548006da94ee15175c3efe483069b77c2cc82ba846a1
+  md5: 4930bec8521a4673b69db6e60cc3da08
+  depends:
+  - libgcc-ng >=9.3.0
+  license: MIT
+  license_family: MIT
+  size: 19680
+  timestamp: 1610028138894
+- kind: conda
+  name: xorg-inputproto
+  version: 2.3.2
+  build: h7f98852_1002
+  build_number: 1002
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-inputproto-2.3.2-h7f98852_1002.tar.bz2
+  sha256: 6c8c2803de0f643f8bad16ece3f9a7259e4a49247543239c182d66d5e3a129a7
+  md5: bcd1b3396ec6960cbc1d2855a9e60b2b
+  depends:
+  - libgcc-ng >=9.3.0
+  license: MIT
+  license_family: MIT
+  size: 19602
+  timestamp: 1610027678228
+- kind: conda
+  name: xorg-kbproto
+  version: 1.0.7
+  build: h27ca646_1002
+  build_number: 1002
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-kbproto-1.0.7-h27ca646_1002.tar.bz2
+  sha256: 265d5ba719fe05d227a6ccd897b1f53bacf6bc9c9c728dcbf917b2d47e9dfac6
+  md5: 7fb248f07fec67488000ebd466a5b73d
+  license: MIT
+  license_family: MIT
+  size: 27417
+  timestamp: 1610027770456
+- kind: conda
+  name: xorg-kbproto
+  version: 1.0.7
+  build: h3557bc0_1002
+  build_number: 1002
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-kbproto-1.0.7-h3557bc0_1002.tar.bz2
+  sha256: 421c0a115b31f02082f95c8f06dbba48b2274718f66a72d64d5102141e5a8731
+  md5: ec8ce6b3dac3945a4010559a6284b755
+  depends:
+  - libgcc-ng >=9.3.0
+  license: MIT
+  license_family: MIT
+  size: 27369
+  timestamp: 1610028170368
+- kind: conda
+  name: xorg-kbproto
+  version: 1.0.7
+  build: h35c211d_1002
+  build_number: 1002
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/xorg-kbproto-1.0.7-h35c211d_1002.tar.bz2
+  sha256: ea4e792e48f28023668ce3e716ebee9b7d04e2d397d678f8f3aef4c7a66f4449
+  md5: 41302c2bc60a15ca4a018775fd20b442
+  license: MIT
+  license_family: MIT
+  size: 27396
+  timestamp: 1610027854580
+- kind: conda
+  name: xorg-kbproto
+  version: 1.0.7
+  build: h7f98852_1002
+  build_number: 1002
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-kbproto-1.0.7-h7f98852_1002.tar.bz2
+  sha256: e90b0a6a5d41776f11add74aa030f789faf4efd3875c31964d6f9cfa63a10dd1
+  md5: 4b230e8381279d76131116660f5a241a
+  depends:
+  - libgcc-ng >=9.3.0
+  license: MIT
+  license_family: MIT
+  size: 27338
+  timestamp: 1610027759842
+- kind: conda
+  name: xorg-libice
+  version: 1.1.1
+  build: h7935292_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libice-1.1.1-h7935292_0.conda
+  sha256: c889673c9313798372bea7c93640e853561bda5ba361b265ad4b14d7d1295235
+  md5: 025968e2637bca910b9b3e7f6743beff
+  depends:
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 60321
+  timestamp: 1685308489806
+- kind: conda
+  name: xorg-libice
+  version: 1.1.1
+  build: hd590300_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.1-hd590300_0.conda
+  sha256: 5aa9b3682285bb2bf1a8adc064cb63aff76ef9178769740d855abb42b0d24236
+  md5: b462a33c0be1421532f28bfe8f4a7514
+  depends:
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 58469
+  timestamp: 1685307573114
+- kind: conda
+  name: xorg-libsm
+  version: 1.2.4
+  build: h5a01bc2_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libsm-1.2.4-h5a01bc2_0.conda
+  sha256: 2678975d4001f1123752ceabf9e2810cab51f740624320077de1ab12b537b498
+  md5: d788eca20ecd63bad8eea7219e5c5fb7
+  depends:
+  - libgcc-ng >=12
+  - libuuid >=2.38.1,<3.0a0
+  - xorg-libice >=1.1.1,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 28634
+  timestamp: 1685454576261
+- kind: conda
+  name: xorg-libsm
+  version: 1.2.4
+  build: h7391055_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.4-h7391055_0.conda
+  sha256: 089ad5f0453c604e18985480218a84b27009e9e6de9a0fa5f4a20b8778ede1f1
+  md5: 93ee23f12bc2e684548181256edd2cf6
+  depends:
+  - libgcc-ng >=12
+  - libuuid >=2.38.1,<3.0a0
+  - xorg-libice >=1.1.1,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 27433
+  timestamp: 1685453649160
+- kind: conda
+  name: xorg-libx11
+  version: 1.8.7
+  build: h055a233_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libx11-1.8.7-h055a233_0.conda
+  sha256: dc688480f6afa3b5880b9d4e11e25e6c8dd10e961a07cfa30b2dc5e529e250bb
+  md5: b3ff774afbb2cd7678044e1fed24f59e
+  depends:
+  - libgcc-ng >=12
+  - libxcb >=1.15,<1.16.0a0
+  - xorg-kbproto
+  - xorg-xextproto >=7.3.0,<8.0a0
+  - xorg-xproto
+  license: MIT
+  license_family: MIT
+  size: 854309
+  timestamp: 1697056918786
+- kind: conda
+  name: xorg-libx11
+  version: 1.8.7
+  build: h8ee46fc_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.7-h8ee46fc_0.conda
+  sha256: 7a02a7beac472ae2759498550b5fc5261bf5be7a9a2b4648a3f67818a7bfefcf
+  md5: 49e482d882669206653b095f5206c05b
+  depends:
+  - libgcc-ng >=12
+  - libxcb >=1.15,<1.16.0a0
+  - xorg-kbproto
+  - xorg-xextproto >=7.3.0,<8.0a0
+  - xorg-xproto
+  license: MIT
+  license_family: MIT
+  size: 828692
+  timestamp: 1697056910935
+- kind: conda
+  name: xorg-libx11
+  version: 1.8.7
+  build: hbd0b022_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/xorg-libx11-1.8.7-hbd0b022_0.conda
+  sha256: 696c8e8dd7bf76a2075373640b3fa171c20e2b9a706a48b0e57bea3ec74d83e6
+  md5: 1861bf782a55f2cc66478a46b053159a
+  depends:
+  - libxcb >=1.15,<1.16.0a0
+  - xorg-kbproto
+  - xorg-xextproto >=7.3.0,<8.0a0
+  - xorg-xproto
+  license: MIT
+  license_family: MIT
+  size: 777870
+  timestamp: 1697057121760
+- kind: conda
+  name: xorg-libx11
+  version: 1.8.7
+  build: hfd9643e_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libx11-1.8.7-hfd9643e_0.conda
+  sha256: d89b74e67c6bf6bec4ad732d9c1cfa843ac7ee604afeccb496a0833db399598b
+  md5: 62362b81bf9d497d283ae2b8fd5e6a99
+  depends:
+  - libxcb >=1.15,<1.16.0a0
+  - xorg-kbproto
+  - xorg-xextproto >=7.3.0,<8.0a0
+  - xorg-xproto
+  license: MIT
+  license_family: MIT
+  size: 767300
+  timestamp: 1697057150709
+- kind: conda
+  name: xorg-libxau
+  version: 1.0.11
+  build: h0dc2134_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxau-1.0.11-h0dc2134_0.conda
+  sha256: 8a2e398c4f06f10c64e69f56bcf3ddfa30b432201446a0893505e735b346619a
+  md5: 9566b4c29274125b0266d0177b5eb97b
+  license: MIT
+  license_family: MIT
+  size: 13071
+  timestamp: 1684638167647
+- kind: conda
+  name: xorg-libxau
+  version: 1.0.11
+  build: h31becfc_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxau-1.0.11-h31becfc_0.conda
+  sha256: c00a8909e783ba7f4ada7256f0385ae46fc21322f4090fa396c80b4481abd5f4
+  md5: 13de34f69cb73165dbe08c1e9148bedb
+  depends:
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 15380
+  timestamp: 1684638889756
+- kind: conda
+  name: xorg-libxau
+  version: 1.0.11
+  build: hb547adb_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.11-hb547adb_0.conda
+  sha256: 02c313a1cada46912e5b9bdb355cfb4534bfe22143b4ea4ecc419690e793023b
+  md5: ca73dc4f01ea91e44e3ed76602c5ea61
+  license: MIT
+  license_family: MIT
+  size: 13667
+  timestamp: 1684638272445
+- kind: conda
+  name: xorg-libxau
+  version: 1.0.11
+  build: hd590300_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.11-hd590300_0.conda
+  sha256: 309751371d525ce50af7c87811b435c176915239fc9e132b99a25d5e1703f2d4
+  md5: 2c80dc38fface310c9bd81b17037fee5
+  depends:
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 14468
+  timestamp: 1684637984591
+- kind: conda
+  name: xorg-libxcursor
+  version: 1.2.0
+  build: h0b41bf4_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxcursor-1.2.0-h0b41bf4_1.conda
+  sha256: 109cffb4c07cec101fad55b3f8f8d1e83bb7acef00798a7d2fd6992f14218189
+  md5: b58859de3b5972860c36f638c8c0ebb6
+  depends:
+  - libgcc-ng >=12
+  - xorg-libx11 >=1.7.2,<2.0a0
+  - xorg-libxfixes 5.0.*
+  - xorg-libxrender 0.9.*
+  license: MIT
+  license_family: MIT
+  size: 31383
+  timestamp: 1677037230603
+- kind: conda
+  name: xorg-libxcursor
+  version: 1.2.0
+  build: hb4cce97_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxcursor-1.2.0-hb4cce97_1.conda
+  sha256: b95a567ea83a2bd0aa41bb7bcbe17af7e48cc7190832ab6f7699e95aed9f8dc4
+  md5: fb221f8966e4ca8d22b14011a7b35aa2
+  depends:
+  - libgcc-ng >=12
+  - xorg-libx11 >=1.7.2,<2.0a0
+  - xorg-libxfixes 5.0.*
+  - xorg-libxrender 0.9.*
+  license: MIT
+  license_family: MIT
+  size: 33356
+  timestamp: 1677037219636
+- kind: conda
+  name: xorg-libxdmcp
+  version: 1.1.3
+  build: h27ca646_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.3-h27ca646_0.tar.bz2
+  sha256: d9a2fb4762779994718832f05a7d62ab2dcf6103a312235267628b5187ce88f7
+  md5: 6738b13f7fadc18725965abdd4129c36
+  license: MIT
+  license_family: MIT
+  size: 18164
+  timestamp: 1610071737668
+- kind: conda
+  name: xorg-libxdmcp
+  version: 1.1.3
+  build: h3557bc0_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxdmcp-1.1.3-h3557bc0_0.tar.bz2
+  sha256: 2aad9a0b57796170b8fb40317598fd79cfc7ae27fa7fb68c417d815e44499d59
+  md5: a6c9016ae1ca5c47a3603ed4cd65fedd
+  depends:
+  - libgcc-ng >=9.3.0
+  license: MIT
+  license_family: MIT
+  size: 19916
+  timestamp: 1610072242320
+- kind: conda
+  name: xorg-libxdmcp
+  version: 1.1.3
+  build: h35c211d_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxdmcp-1.1.3-h35c211d_0.tar.bz2
+  sha256: 485421c16f03a01b8ed09984e0b2ababdbb3527e1abf354ff7646f8329be905f
+  md5: 86ac76d6bf1cbb9621943eb3bd9ae36e
+  license: MIT
+  license_family: MIT
+  size: 17225
+  timestamp: 1610071995461
+- kind: conda
+  name: xorg-libxdmcp
+  version: 1.1.3
+  build: h7f98852_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.3-h7f98852_0.tar.bz2
+  sha256: 4df7c5ee11b8686d3453e7f3f4aa20ceef441262b49860733066c52cfd0e4a77
+  md5: be93aabceefa2fac576e971aef407908
+  depends:
+  - libgcc-ng >=9.3.0
+  license: MIT
+  license_family: MIT
+  size: 19126
+  timestamp: 1610071769228
+- kind: conda
+  name: xorg-libxext
+  version: 1.3.4
+  build: h0b41bf4_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.4-h0b41bf4_2.conda
+  sha256: 73e5cfbdff41ef8a844441f884412aa5a585a0f0632ec901da035a03e1fe1249
+  md5: 82b6df12252e6f32402b96dacc656fec
+  depends:
+  - libgcc-ng >=12
+  - xorg-libx11 >=1.7.2,<2.0a0
+  - xorg-xextproto
+  license: MIT
+  license_family: MIT
+  size: 50143
+  timestamp: 1677036907815
+- kind: conda
+  name: xorg-libxext
+  version: 1.3.4
+  build: h1a8c8d9_2
+  build_number: 2
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxext-1.3.4-h1a8c8d9_2.conda
+  sha256: 073e673a9b4ef748c256d655d1ab5f368e5e3972ad3332c96c1d4c2cf0c7b9af
+  md5: 0ea792d9a253b64752e9fcfaafe8d529
+  depends:
+  - xorg-libx11 >=1.7.2,<2.0a0
+  - xorg-xextproto
+  license: MIT
+  license_family: MIT
+  size: 41541
+  timestamp: 1677037316516
+- kind: conda
+  name: xorg-libxext
+  version: 1.3.4
+  build: h2a766a3_2
+  build_number: 2
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxext-1.3.4-h2a766a3_2.conda
+  sha256: 16eff29fb70b2f89b9120d112d2d5df1bf7bd4e95d1e5baafabc61dac4977fa8
+  md5: 0cea7d840c8eeaa4e349e0b4775c826d
+  depends:
+  - libgcc-ng >=12
+  - xorg-libx11 >=1.7.2,<2.0a0
+  - xorg-xextproto
+  license: MIT
+  license_family: MIT
+  size: 50856
+  timestamp: 1677037784530
+- kind: conda
+  name: xorg-libxext
+  version: 1.3.4
+  build: hb7f2c08_2
+  build_number: 2
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxext-1.3.4-hb7f2c08_2.conda
+  sha256: 56ca81c5e6d493e7a991f2beac1c38dec36d732c83495ef08f57a34c260a5aaa
+  md5: 0f98aff18e0455f0bdc4326c04f98883
+  depends:
+  - xorg-libx11 >=1.7.2,<2.0a0
+  - xorg-xextproto
+  license: MIT
+  license_family: MIT
+  size: 43076
+  timestamp: 1677037100444
+- kind: conda
+  name: xorg-libxfixes
+  version: 5.0.3
+  build: h3557bc0_1004
+  build_number: 1004
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxfixes-5.0.3-h3557bc0_1004.tar.bz2
+  sha256: c6d38bfb9d9a9ab4c1331700a29970d6fa4894bb1e2585300a21d75ac3c0ee8d
+  md5: 8c639389f12135ddc2bb23497d6d1918
+  depends:
+  - libgcc-ng >=9.3.0
+  - xorg-fixesproto
+  - xorg-libx11 >=1.7.0,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 18684
+  timestamp: 1617718455442
+- kind: conda
+  name: xorg-libxfixes
+  version: 5.0.3
+  build: h7f98852_1004
+  build_number: 1004
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxfixes-5.0.3-h7f98852_1004.tar.bz2
+  sha256: 1e426a1abb774ef1dcf741945ed5c42ad12ea2dc7aeed7682d293879c3e1e4c3
+  md5: e9a21aa4d5e3e5f1aed71e8cefd46b6a
+  depends:
+  - libgcc-ng >=9.3.0
+  - xorg-fixesproto
+  - xorg-libx11 >=1.7.0,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 18145
+  timestamp: 1617717802636
+- kind: conda
+  name: xorg-libxi
+  version: 1.7.10
+  build: h3557bc0_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxi-1.7.10-h3557bc0_0.tar.bz2
+  sha256: cc750f04be99affd279ed11741d4921a56ae45d85472dbf1c84c0503a95c0020
+  md5: 02eaabe40f65695705a288757f1d56b5
+  depends:
+  - libgcc-ng >=9.3.0
+  - xorg-inputproto
+  - xorg-libx11 >=1.7.0,<2.0a0
+  - xorg-libxext 1.3.*
+  - xorg-libxfixes 5.0.*
+  license: MIT
+  license_family: MIT
+  size: 48543
+  timestamp: 1620071478169
+- kind: conda
+  name: xorg-libxi
+  version: 1.7.10
+  build: h7f98852_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxi-1.7.10-h7f98852_0.tar.bz2
+  sha256: 745c1284a96b4282fe6fe122b2643e1e8c26a7ff40b733a8f4b61357238c4e68
+  md5: e77615e5141cad5a2acaa043d1cf0ca5
+  depends:
+  - libgcc-ng >=9.3.0
+  - xorg-inputproto
+  - xorg-libx11 >=1.7.0,<2.0a0
+  - xorg-libxext 1.3.*
+  - xorg-libxfixes 5.0.*
+  license: MIT
+  license_family: MIT
+  size: 47287
+  timestamp: 1620070911951
+- kind: conda
+  name: xorg-libxinerama
+  version: 1.1.5
+  build: h27087fc_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxinerama-1.1.5-h27087fc_0.tar.bz2
+  sha256: 0dc50f019ab9871bd9a8be0b00a1e0fa98172ef9c775a13e2dac2924844bb75e
+  md5: 2e1c65825c586444df23784f68bef90e
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - xorg-libxext
+  license: MIT
+  license_family: MIT
+  size: 13350
+  timestamp: 1667399989190
+- kind: conda
+  name: xorg-libxinerama
+  version: 1.1.5
+  build: h4de3ea5_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxinerama-1.1.5-h4de3ea5_0.tar.bz2
+  sha256: 3ad05b332c87f6486de67571dc4450a5d077215789e1820f6e278345aec45746
+  md5: dde29991cafb378facde5dfe371989d9
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - xorg-libxext
+  license: MIT
+  license_family: MIT
+  size: 13876
+  timestamp: 1667399792390
+- kind: conda
+  name: xorg-libxrandr
+  version: 1.5.2
+  build: h7f98852_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrandr-1.5.2-h7f98852_1.tar.bz2
+  sha256: ffd075a463896ed86d9519e26dc36f754b695b9c1e1b6115d34fe138b36d8200
+  md5: 5b0f7da25a4556c9619c3e4b4a98ab07
+  depends:
+  - libgcc-ng >=9.3.0
+  - xorg-libx11 >=1.7.1,<2.0a0
+  - xorg-libxext
+  - xorg-libxrender
+  - xorg-randrproto
+  - xorg-renderproto
+  - xorg-xextproto
+  license: MIT
+  license_family: MIT
+  size: 29688
+  timestamp: 1621515728586
+- kind: conda
+  name: xorg-libxrandr
+  version: 1.5.2
+  build: hf897c2e_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxrandr-1.5.2-hf897c2e_1.tar.bz2
+  sha256: 6d25ba7b97c1522ea084de1bec11bfd828afd8b62a09d67e89d22302456666c0
+  md5: 858f6db334e0e2b0011e25e033e6eb4c
+  depends:
+  - libgcc-ng >=9.3.0
+  - xorg-libx11 >=1.7.1,<2.0a0
+  - xorg-libxext
+  - xorg-libxrender
+  - xorg-randrproto
+  - xorg-renderproto
+  - xorg-xextproto
+  license: MIT
+  license_family: MIT
+  size: 30119
+  timestamp: 1621515659529
+- kind: conda
+  name: xorg-libxrender
+  version: 0.9.11
+  build: h7935292_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxrender-0.9.11-h7935292_0.conda
+  sha256: 15ab433c3b565d92bbd9dc83e469bb4ff1076f9002f7cd142b8a39e1b6cbcfab
+  md5: 8c96b84f7fb97a3cd533a14dbdcd6626
+  depends:
+  - libgcc-ng >=12
+  - xorg-libx11 >=1.8.6,<2.0a0
+  - xorg-renderproto
+  license: MIT
+  license_family: MIT
+  size: 37477
+  timestamp: 1688300682978
+- kind: conda
+  name: xorg-libxrender
+  version: 0.9.11
+  build: hd590300_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.11-hd590300_0.conda
+  sha256: 26da4d1911473c965c32ce2b4ff7572349719eaacb88a066db8d968a4132c3f7
+  md5: ed67c36f215b310412b2af935bf3e530
+  depends:
+  - libgcc-ng >=12
+  - xorg-libx11 >=1.8.6,<2.0a0
+  - xorg-renderproto
+  license: MIT
+  license_family: MIT
+  size: 37770
+  timestamp: 1688300707994
+- kind: conda
+  name: xorg-randrproto
+  version: 1.5.0
+  build: h7f98852_1001
+  build_number: 1001
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-randrproto-1.5.0-h7f98852_1001.tar.bz2
+  sha256: f5c7c2de3655a95153e900118959df6a50b6c104a3d7afaee3eadbf86b85fa2e
+  md5: 68cce654461713977dac6f9ac1bce89a
+  depends:
+  - libgcc-ng >=9.3.0
+  license: MIT
+  license_family: MIT
+  size: 32984
+  timestamp: 1621340029170
+- kind: conda
+  name: xorg-randrproto
+  version: 1.5.0
+  build: hf897c2e_1001
+  build_number: 1001
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-randrproto-1.5.0-hf897c2e_1001.tar.bz2
+  sha256: cb304b318b2a335394d16acb5c8449999eaf30e010aaeb09b2d7fcc187a73edb
+  md5: b881991d65594646403c42be82f15642
+  depends:
+  - libgcc-ng >=9.3.0
+  license: MIT
+  license_family: MIT
+  size: 32963
+  timestamp: 1621339952801
+- kind: conda
+  name: xorg-renderproto
+  version: 0.11.1
+  build: h3557bc0_1002
+  build_number: 1002
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-renderproto-0.11.1-h3557bc0_1002.tar.bz2
+  sha256: e57e8b4a58f8c3b5011bf6cd66f499fca9fc5067981bb33f828750b168c3698d
+  md5: 01cbfe96ce66b78a9a270ac305791dd2
+  depends:
+  - libgcc-ng >=9.3.0
+  license: MIT
+  license_family: MIT
+  size: 9612
+  timestamp: 1614866892676
+- kind: conda
+  name: xorg-renderproto
+  version: 0.11.1
+  build: h7f98852_1002
+  build_number: 1002
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-renderproto-0.11.1-h7f98852_1002.tar.bz2
+  sha256: 38942930f233d1898594dd9edf4b0c0786f3dbc12065a0c308634c37fd936034
+  md5: 06feff3d2634e3097ce2fe681474b534
+  depends:
+  - libgcc-ng >=9.3.0
+  license: MIT
+  license_family: MIT
+  size: 9621
+  timestamp: 1614866326326
+- kind: conda
+  name: xorg-xextproto
+  version: 7.3.0
+  build: h0b41bf4_1003
+  build_number: 1003
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-xextproto-7.3.0-h0b41bf4_1003.conda
+  sha256: b8dda3b560e8a7830fe23be1c58cc41f407b2e20ae2f3b6901eb5842ba62b743
+  md5: bce9f945da8ad2ae9b1d7165a64d0f87
+  depends:
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 30270
+  timestamp: 1677036833037
+- kind: conda
+  name: xorg-xextproto
+  version: 7.3.0
+  build: h1a8c8d9_1003
+  build_number: 1003
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-xextproto-7.3.0-h1a8c8d9_1003.conda
+  sha256: 6e5500675070d5bd07ab790f81e6a768c7d1424185a10e896dd03e1ad6e37199
+  md5: e054e2dd816a8907ac9d8d67a6020b37
+  license: MIT
+  license_family: MIT
+  size: 30550
+  timestamp: 1677037030945
+- kind: conda
+  name: xorg-xextproto
+  version: 7.3.0
+  build: h2a766a3_1003
+  build_number: 1003
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-xextproto-7.3.0-h2a766a3_1003.conda
+  sha256: 62298f1c7b963f3a5921a65d9cb6aae82c3ec8b3069319c8264c5b0a3d190286
+  md5: 32de1e4422c986e3b6eff59e7edc4d04
+  depends:
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 30267
+  timestamp: 1677037618141
+- kind: conda
+  name: xorg-xextproto
+  version: 7.3.0
+  build: hb7f2c08_1003
+  build_number: 1003
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/xorg-xextproto-7.3.0-hb7f2c08_1003.conda
+  sha256: 53f1690e46c31c93f9899c6e6524bd1ddd4c8928caff5570b1d30e4ed89858f6
+  md5: e4db268e1dc61ab3dcbbb302f6519f66
+  license: MIT
+  license_family: MIT
+  size: 30477
+  timestamp: 1677037035675
+- kind: conda
+  name: xorg-xf86vidmodeproto
+  version: 2.3.1
+  build: h7f98852_1002
+  build_number: 1002
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-xf86vidmodeproto-2.3.1-h7f98852_1002.tar.bz2
+  sha256: 43398aeacad5b8753b7a1c12cb6bca36124e0c842330372635879c350c430791
+  md5: 3ceea9668625c18f19530de98b15d5b0
+  depends:
+  - libgcc-ng >=9.3.0
+  license: MIT
+  license_family: MIT
+  size: 23875
+  timestamp: 1620067286978
+- kind: conda
+  name: xorg-xf86vidmodeproto
+  version: 2.3.1
+  build: hf897c2e_1002
+  build_number: 1002
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-xf86vidmodeproto-2.3.1-hf897c2e_1002.tar.bz2
+  sha256: 097cbc95fbbc9f97571493b0ab1bdd950be8e38395631b32d87d115613abdf4f
+  md5: 8fff0d5f50da4c73f752365c85b5e922
+  depends:
+  - libgcc-ng >=9.3.0
+  license: MIT
+  license_family: MIT
+  size: 23841
+  timestamp: 1620067236301
+- kind: conda
+  name: xorg-xproto
+  version: 7.0.31
+  build: h27ca646_1007
+  build_number: 1007
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-xproto-7.0.31-h27ca646_1007.tar.bz2
+  sha256: 0ab583e40897d4f3ad414d768371839508bb2a46c5c99e2e5f504aedce5ecf84
+  md5: fca1f15eca1f9fd68a5f2433cb8e5a3f
+  license: MIT
+  license_family: MIT
+  size: 74988
+  timestamp: 1607291556181
+- kind: conda
+  name: xorg-xproto
+  version: 7.0.31
+  build: h3557bc0_1007
+  build_number: 1007
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-xproto-7.0.31-h3557bc0_1007.tar.bz2
+  sha256: 7711ca1898e6f74a8434931fe6c0593ff7201277778aa09ea012d8be8bc7a7f5
+  md5: 987e98faa0ad2c667bbea6b6aae260bc
+  depends:
+  - libgcc-ng >=9.3.0
+  license: MIT
+  license_family: MIT
+  size: 74831
+  timestamp: 1607291481791
+- kind: conda
+  name: xorg-xproto
+  version: 7.0.31
+  build: h35c211d_1007
+  build_number: 1007
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/xorg-xproto-7.0.31-h35c211d_1007.tar.bz2
+  sha256: 433fa2cf3282e0e6f13cf5e73280cd1add4d3be76f19f2674cbd127c9ec70dd4
+  md5: e1b279e3b8c03f88a90e81480a8f319a
+  license: MIT
+  license_family: MIT
+  size: 74832
+  timestamp: 1607291623383
+- kind: conda
+  name: xorg-xproto
+  version: 7.0.31
+  build: h7f98852_1007
+  build_number: 1007
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-xproto-7.0.31-h7f98852_1007.tar.bz2
+  sha256: f197bb742a17c78234c24605ad1fe2d88b1d25f332b75d73e5ba8cf8fbc2a10d
+  md5: b4a4381d54784606820704f7b5f05a15
+  depends:
+  - libgcc-ng >=9.3.0
+  license: MIT
+  license_family: MIT
+  size: 74922
+  timestamp: 1607291557628
+- kind: conda
+  name: xz
+  version: 5.2.6
+  build: h166bdaf_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2
+  sha256: 03a6d28ded42af8a347345f82f3eebdd6807a08526d47899a42d62d319609162
+  md5: 2161070d867d1b1204ea749c8eec4ef0
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.1 and GPL-2.0
+  size: 418368
+  timestamp: 1660346797927
+- kind: conda
+  name: xz
+  version: 5.2.6
+  build: h57fd34a_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.2.6-h57fd34a_0.tar.bz2
+  sha256: 59d78af0c3e071021cfe82dc40134c19dab8cdf804324b62940f5c8cd71803ec
+  md5: 39c6b54e94014701dd157f4f576ed211
+  license: LGPL-2.1 and GPL-2.0
+  size: 235693
+  timestamp: 1660346961024
+- kind: conda
+  name: xz
+  version: 5.2.6
+  build: h775f41a_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/xz-5.2.6-h775f41a_0.tar.bz2
+  sha256: eb09823f34cc2dd663c0ec4ab13f246f45dcd52e5b8c47b9864361de5204a1c8
+  md5: a72f9d4ea13d55d745ff1ed594747f10
+  license: LGPL-2.1 and GPL-2.0
+  size: 238119
+  timestamp: 1660346964847
+- kind: conda
+  name: xz
+  version: 5.2.6
+  build: h8d14728_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/xz-5.2.6-h8d14728_0.tar.bz2
+  sha256: 54d9778f75a02723784dc63aff4126ff6e6749ba21d11a6d03c1f4775f269fe0
+  md5: 515d77642eaa3639413c6b1bc3f94219
+  depends:
+  - vc >=14.1,<15
+  - vs2015_runtime >=14.16.27033
+  license: LGPL-2.1 and GPL-2.0
+  size: 217804
+  timestamp: 1660346976440
+- kind: conda
+  name: xz
+  version: 5.2.6
+  build: h9cdd2b7_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xz-5.2.6-h9cdd2b7_0.tar.bz2
+  sha256: 93f58a7b393adf41fa007ac8c55978765e957e90cd31877ece1e5a343cb98220
+  md5: 83baad393a31d59c20b63ba4da6592df
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.1 and GPL-2.0
+  size: 440555
+  timestamp: 1660348056328
+- kind: conda
+  name: yaml
+  version: 0.2.5
+  build: h0d85af4_2
+  build_number: 2
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-h0d85af4_2.tar.bz2
+  sha256: 5301417e2c8dea45b401ffee8df3957d2447d4ce80c83c5ff151fc6bfe1c4148
+  md5: d7e08fcf8259d742156188e8762b4d20
+  license: MIT
+  license_family: MIT
+  size: 84237
+  timestamp: 1641347062780
+- kind: conda
+  name: yaml
+  version: 0.2.5
+  build: h3422bc3_2
+  build_number: 2
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h3422bc3_2.tar.bz2
+  sha256: 93181a04ba8cfecfdfb162fc958436d868cc37db504c58078eab4c1a3e57fbb7
+  md5: 4bb3f014845110883a3c5ee811fd84b4
+  license: MIT
+  license_family: MIT
+  size: 88016
+  timestamp: 1641347076660
+- kind: conda
+  name: yaml
+  version: 0.2.5
+  build: h7f98852_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h7f98852_2.tar.bz2
+  sha256: a4e34c710eeb26945bdbdaba82d3d74f60a78f54a874ec10d373811a5d217535
+  md5: 4cb3ad778ec2d5a7acbdf254eb1c42ae
+  depends:
+  - libgcc-ng >=9.4.0
+  license: MIT
+  license_family: MIT
+  size: 89141
+  timestamp: 1641346969816
+- kind: conda
+  name: yaml
+  version: 0.2.5
+  build: h8ffe710_2
+  build_number: 2
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/yaml-0.2.5-h8ffe710_2.tar.bz2
+  sha256: 4e2246383003acbad9682c7c63178e2e715ad0eb84f03a8df1fbfba455dfedc5
+  md5: adbfb9f45d1004a26763652246a33764
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
+  license: MIT
+  license_family: MIT
+  size: 63274
+  timestamp: 1641347623319
+- kind: conda
+  name: yaml
+  version: 0.2.5
+  build: hf897c2e_2
+  build_number: 2
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/yaml-0.2.5-hf897c2e_2.tar.bz2
+  sha256: 8bc601d6dbe249eba44b3c456765265cd8f42ef1e778f8df9b0c9c88b8558d7e
+  md5: b853307650cb226731f653aa623936a4
+  depends:
+  - libgcc-ng >=9.4.0
+  license: MIT
+  license_family: MIT
+  size: 92927
+  timestamp: 1641347626613
+- kind: conda
+  name: yarp
+  version: 3.9.0
+  build: h57928b3_1
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/yarp-3.9.0-h57928b3_1.conda
+  sha256: 756555348c65cdb52bbd620357df0ae0319daefe001bec8778d4b21b6f499013
+  md5: 8088ba85b024eda5d4e145c5fc173840
+  depends:
+  - libyarp 3.9.0 ha0ae21b_1
+  - yarp-python >=3.9.0,<3.9.1.0a0
+  license: BSD-3-Clause AND MIT AND GPL-3.0-or-later
+  size: 23377
+  timestamp: 1706037612517
+- kind: conda
+  name: yarp
+  version: 3.9.0
+  build: h694c41f_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/yarp-3.9.0-h694c41f_1.conda
+  sha256: 2f087f49a49cf27d042e06d809e64f3cea35e411148aa69bebc34fc6a11fb6af
+  md5: 7c4ba414580270e39dc1a59e65fec1c7
+  depends:
+  - libyarp 3.9.0 h9c0c770_1
+  - yarp-python >=3.9.0,<3.9.1.0a0
+  license: BSD-3-Clause AND MIT AND GPL-3.0-or-later
+  size: 23200
+  timestamp: 1706036382744
+- kind: conda
+  name: yarp
+  version: 3.9.0
+  build: h8af1aa0_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/yarp-3.9.0-h8af1aa0_1.conda
+  sha256: f898376a55d48aa8fa3ea430cd422a1b936998785164bafea999071371e5be57
+  md5: f37afd4e91d86faecaedd77fe3eee9cd
+  depends:
+  - libyarp 3.9.0 h6d2be9b_1
+  - yarp-python >=3.9.0,<3.9.1.0a0
+  license: BSD-3-Clause AND MIT AND GPL-3.0-or-later
+  size: 23079
+  timestamp: 1706036258481
+- kind: conda
+  name: yarp
+  version: 3.9.0
+  build: ha770c72_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/yarp-3.9.0-ha770c72_1.conda
+  sha256: 52e643455da12ba1a4fcc3c5614b206b2092850e86f7fbbce1f783c06a27d7d9
+  md5: baa3f7bfb0c2382aa0e44b62809e510a
+  depends:
+  - libyarp 3.9.0 ha614a09_1
+  - yarp-python >=3.9.0,<3.9.1.0a0
+  license: BSD-3-Clause AND MIT AND GPL-3.0-or-later
+  size: 23134
+  timestamp: 1706035101138
+- kind: conda
+  name: yarp
+  version: 3.9.0
+  build: hce30654_1
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/yarp-3.9.0-hce30654_1.conda
+  sha256: c315b4bdca9ffa707b1edd1af4c12c81f64ee1bcba10438549816500fa88256b
+  md5: e0bc1b09a9baa66d905c40c5d959fc5c
+  depends:
+  - libyarp 3.9.0 hff4382b_1
+  - yarp-python >=3.9.0,<3.9.1.0a0
+  license: BSD-3-Clause AND MIT AND GPL-3.0-or-later
+  size: 23209
+  timestamp: 1706036816531
+- kind: conda
+  name: yarp-python
+  version: 3.9.0
+  build: py311h0e2f32c_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/yarp-python-3.9.0-py311h0e2f32c_1.conda
+  sha256: 07438980aa8d10cd73e77f3ce96513542c2ffa9fb6289f4c1bd7787c149b266d
+  md5: 3002b8027d3b83789e7726c5fe495b9f
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libyarp 3.9.0 ha614a09_1
+  - numpy
+  - openssl >=3.2.0,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause AND MIT AND GPL-3.0-or-later
+  size: 1156939
+  timestamp: 1706034479319
+- kind: conda
+  name: yarp-python
+  version: 3.9.0
+  build: py311h1e2cc8c_1
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/yarp-python-3.9.0-py311h1e2cc8c_1.conda
+  sha256: b5916b41a6c6d29356ba7ab3fda3c3ecde8d7d1231ecac4d0a2794bb0e8219d2
+  md5: e0746ac8badfeef9a085818cfe461af8
+  depends:
+  - libcxx >=15
+  - libyarp 3.9.0 hff4382b_1
+  - numpy
+  - openssl >=3.2.0,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause AND MIT AND GPL-3.0-or-later
+  size: 951417
+  timestamp: 1706035922618
+- kind: conda
+  name: yarp-python
+  version: 3.9.0
+  build: py311h22f05a9_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/yarp-python-3.9.0-py311h22f05a9_1.conda
+  sha256: 32765a18b2a91db0f2ba02a2bbee5609d079fcb24e9480043e5ecf143b8aab92
+  md5: ebfa497fc5e23b7b1b433067a30b06f9
+  depends:
+  - libcxx >=15
+  - libyarp 3.9.0 h9c0c770_1
+  - numpy
+  - openssl >=3.2.0,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause AND MIT AND GPL-3.0-or-later
+  size: 1027438
+  timestamp: 1706036133957
+- kind: conda
+  name: yarp-python
+  version: 3.9.0
+  build: py311h49b8dee_1
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/yarp-python-3.9.0-py311h49b8dee_1.conda
+  sha256: e8468f2546f514587e29895576f9168e1157ed23a2b55c2d09c4e5987b8e648d
+  md5: 1b8e3a3616832d1390064a293c573099
+  depends:
+  - libyarp 3.9.0 ha0ae21b_1
+  - numpy
+  - openssl >=3.2.0,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause AND MIT AND GPL-3.0-or-later
+  size: 900162
+  timestamp: 1706037595584
+- kind: conda
+  name: yarp-python
+  version: 3.9.0
+  build: py311h6b46aae_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/yarp-python-3.9.0-py311h6b46aae_1.conda
+  sha256: 0a2852ca2a3faefcd0d64e3d09e4807bd3a8f0edc8c02b63c0aacdddb9cc5d45
+  md5: 677d1b9bacedcae295470aec523e08f8
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libyarp 3.9.0 h6d2be9b_1
+  - numpy
+  - openssl >=3.2.0,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause AND MIT AND GPL-3.0-or-later
+  size: 1009213
+  timestamp: 1706036004062
+- kind: conda
+  name: ycm-cmake-modules
+  version: 0.16.2
+  build: h2f0025b_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/ycm-cmake-modules-0.16.2-h2f0025b_0.conda
+  sha256: 5e3e70bafbae59286829d60e7871f11c7bd2943e4358a554e454b1d451f4d444
+  md5: 75ca6899cc4bc94e30892dd765da4401
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 141938
+  timestamp: 1703084956263
+- kind: conda
+  name: ycm-cmake-modules
+  version: 0.16.2
+  build: h59595ed_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/ycm-cmake-modules-0.16.2-h59595ed_0.conda
+  sha256: 40cdc7a2c32531b186363359da840af525b1d394214e9158e8d10e509d581229
+  md5: 7a923f74bc92d761e6d4abedc047bdac
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 141265
+  timestamp: 1703084908727
+- kind: conda
+  name: ycm-cmake-modules
+  version: 0.16.2
+  build: h63175ca_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/ycm-cmake-modules-0.16.2-h63175ca_0.conda
+  sha256: 84284eb0e30b1c6acb8749092291f2d2bafc0bd37b6ec6cdd292314a33dc38e4
+  md5: 72023d3fa5103039e275f11f5a8882ee
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 141585
+  timestamp: 1703085171511
+- kind: conda
+  name: ycm-cmake-modules
+  version: 0.16.2
+  build: h73e2aa4_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/ycm-cmake-modules-0.16.2-h73e2aa4_0.conda
+  sha256: 964c3839758f9c2e59042c7b4514f7de3838e62ede00e26a0206a342af79406d
+  md5: 78ec16ea9b285eaa46dcc9e41d0520f8
+  depends:
+  - libcxx >=15
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 141935
+  timestamp: 1703085317380
+- kind: conda
+  name: ycm-cmake-modules
+  version: 0.16.2
+  build: hebf3989_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ycm-cmake-modules-0.16.2-hebf3989_0.conda
+  sha256: a3fe8fc080fdeccd6b676865c5de667817f4af24f195ee87f7cd5043edb41c69
+  md5: 88b9231e9d85d3cbd6b6d1f2f481d390
+  depends:
+  - libcxx >=15
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 141873
+  timestamp: 1703085124368
+- kind: conda
+  name: zlib
+  version: 1.2.13
+  build: h31becfc_5
+  build_number: 5
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/zlib-1.2.13-h31becfc_5.conda
+  sha256: aa3e9d46b13d1959faf634f03d929d7dec950dc1b84a8ff109f7f0e3f364b562
+  md5: 96866c7301479abaf8308c50958c71a4
+  depends:
+  - libgcc-ng >=12
+  - libzlib 1.2.13 h31becfc_5
+  license: Zlib
+  license_family: Other
+  size: 95842
+  timestamp: 1686575155348
+- kind: conda
+  name: zlib
+  version: 1.2.13
+  build: h53f4e23_5
+  build_number: 5
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.2.13-h53f4e23_5.conda
+  sha256: de0ee1e24aa6867058d3b852a15c8d7f49f262f5828772700c647186d4a96bbe
+  md5: a08383f223b10b71492d27566fafbf6c
+  depends:
+  - libzlib 1.2.13 h53f4e23_5
+  license: Zlib
+  license_family: Other
+  size: 79577
+  timestamp: 1686575471024
+- kind: conda
+  name: zlib
+  version: 1.2.13
+  build: h8a1eda9_5
+  build_number: 5
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/zlib-1.2.13-h8a1eda9_5.conda
+  sha256: d1f4c82fd7bd240a78ce8905e931e68dca5f523c7da237b6b63c87d5625c5b35
+  md5: 75a8a98b1c4671c5d2897975731da42d
+  depends:
+  - libzlib 1.2.13 h8a1eda9_5
+  license: Zlib
+  license_family: Other
+  size: 90764
+  timestamp: 1686575574678
+- kind: conda
+  name: zlib
+  version: 1.2.13
+  build: hcfcfb64_5
+  build_number: 5
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/zlib-1.2.13-hcfcfb64_5.conda
+  sha256: 0f91b719c7558046bcd37fdc7ae4b9eb2b7a8e335beb8b59ae7ccb285a46aa46
+  md5: a318e8622e11663f645cc7fa3260f462
+  depends:
+  - libzlib 1.2.13 hcfcfb64_5
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Zlib
+  license_family: Other
+  size: 107711
+  timestamp: 1686575474476
+- kind: conda
+  name: zlib
+  version: 1.2.13
+  build: hd590300_5
+  build_number: 5
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.2.13-hd590300_5.conda
+  sha256: 9887a04d7e7cb14bd2b52fa01858f05a6d7f002c890f618d9fcd864adbfecb1b
+  md5: 68c34ec6149623be41a1933ab996a209
+  depends:
+  - libgcc-ng >=12
+  - libzlib 1.2.13 hd590300_5
+  license: Zlib
+  license_family: Other
+  size: 92825
+  timestamp: 1686575231103
+- kind: conda
+  name: zstd
+  version: 1.5.5
+  build: h12be248_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.5-h12be248_0.conda
+  sha256: d540dd56c5ec772b60e4ce7d45f67f01c6614942225885911964ea1e70bb99e3
+  md5: 792bb5da68bf0a6cac6a6072ecb8dbeb
+  depends:
+  - libzlib >=1.2.13,<1.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 343428
+  timestamp: 1693151615801
+- kind: conda
+  name: zstd
+  version: 1.5.5
+  build: h4c53e97_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/zstd-1.5.5-h4c53e97_0.conda
+  sha256: d1e070029e9d07a3f25e6ed082d507b0f3cff1b109dd18d0b091a5c7b86dd07b
+  md5: b74eb9dbb5c3c15cb3cee7cbdf198c75
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 528989
+  timestamp: 1693151197934
+- kind: conda
+  name: zstd
+  version: 1.5.5
+  build: h4f39d0f_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.5-h4f39d0f_0.conda
+  sha256: 7e1fe6057628bbb56849a6741455bbb88705bae6d6646257e57904ac5ee5a481
+  md5: 5b212cfb7f9d71d603ad891879dc7933
+  depends:
+  - libzlib >=1.2.13,<1.3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 400508
+  timestamp: 1693151393180
+- kind: conda
+  name: zstd
+  version: 1.5.5
+  build: h829000d_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.5-h829000d_0.conda
+  sha256: d54e31d3d8de5e254c0804abd984807b8ae5cd3708d758a8bf1adff1f5df166c
+  md5: 80abc41d0c48b82fe0f04e7f42f5cb7e
+  depends:
+  - libzlib >=1.2.13,<1.3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 499383
+  timestamp: 1693151312586
+- kind: conda
+  name: zstd
+  version: 1.5.5
+  build: hfc55251_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.5-hfc55251_0.conda
+  sha256: 607cbeb1a533be98ba96cf5cdf0ddbb101c78019f1fda063261871dad6248609
+  md5: 04b88013080254850d6c01ed54810589
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 545199
+  timestamp: 1693151163452

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,0 +1,40 @@
+[project]
+name = "icub-models-generator"
+# pixi forces the use of a version, but then the version is not used anywhere,
+# so we actually just set it to 0.0.0 and never update it
+version = "0.0.0"
+description = "Resources and programs to generate models (URDF, SDF) of the iCub robot."
+authors = ["Silvio Traversaro <silvio.traversaro@iit.it>"]
+channels = ["conda-forge"]
+platforms = ["linux-64", "linux-aarch64", "win-64", "osx-arm64", "osx-64"]
+
+[tasks]
+# As of pixi 0.13.0, pixi does not support git pip packages, so we install it from source
+# Specific commit of urdfdom_py is a workaround for https://github.com/robotology/simmechanics-to-urdf/issues/36
+header_commit = { cmd = "echo Automatic build of models via icub-models-generator.  > ./deploy_commit_message" }
+header_repos = { cmd = "echo ### Dependencies information of dependencies installed manually: >> ./deploy_commit_message",  depends_on = ["header_commit"] }
+install_urdfdom_py = { cmd = "export URDF_PARSER_PY_COMMIT=31474b9baaf7c3845b40e5a9aa87d5900a2282c3 && pip install git+https://github.com/ros/urdf_parser_py.git@$URDF_PARSER_PY_COMMIT --no-deps && echo urdf_parser_py commit: ros/urdf_parser_py@$URDF_PARSER_PY_COMMIT >> ./deploy_commit_message", depends_on = ["header_repos"]}
+install_simmechanics_to_urdf = { cmd = "export SIMMECHANICS_TO_URDF_COMMIT=22caa23cfe7063299c5746304850b8afd74f4e1f && pip install git+https://github.com/robotology/simmechanics-to-urdf@$SIMMECHANICS_TO_URDF_COMMIT --no-deps && echo icub-model-generator commit: robotology/icub-models-generator@$SIMMECHANICS_TO_URDF_COMMIT >> ./deploy_commit_message", depends_on = ["install_urdfdom_py"] }
+header_pixi_list = { cmd = "echo ### Dependencies information via pixi list:  >> ./deploy_commit_message", depends_on = ["install_simmechanics_to_urdf"]}
+pixi_list = { cmd = "pixi list >> ./deploy_commit_message",  depends_on = ["header_pixi_list"]}
+configure_cmake_project = { cmd = "cmake -GNinja -S. -B.build -DICUB_MODELS_SOURCE_DIR=$ICUB_MODELS_SOURCE_DIR -DBUILD_TESTING:BOOL=ON",  depends_on = ["pixi_list"]}
+generate_models = { cmd = "cmake --build .build --target generate-models",  depends_on = ["configure_cmake_project"]}
+copy_models_to_icub_models = { cmd = "cmake --build .build --target copy-models-to-icub-models",  depends_on = ["configure_cmake_project"]}
+build_tests = { cmd = "cmake --build .build", depends_on = ["configure_cmake_project"] }
+test_generated_models = { cmd = "ctest --test-dir .build",  depends_on = ["generate_models", "build_tests"]}
+
+[dependencies]
+idyntree = ">=10.3.0,<10.4"
+yarp = ">=3.9.0,<3.10"
+lxml = "==4.9.4"
+# Not using latest pyyaml as workaround for https://github.com/robotology/simmechanics-to-urdf/issues/57
+pyyaml = ">=5.0.0,<6.0.0"
+numpy = ">=1.26.4,<1.27"
+catkin_pkg = ">=1.0.0,<1.1"
+pip = ">=24.0,<25"
+python = ">=3.11.1,<3.12"
+ninja = ">=1.11.1,<1.12"
+cxx-compiler = ">=1.7.0,<1.8"
+c-compiler = ">=1.7.0,<1.8"
+# ruby is used by the convertSTL.rb script
+ruby = ">=3.2.2,<3.3"


### PR DESCRIPTION
Fix https://github.com/robotology/icub-models-generator/issues/205 . 

While looking into https://github.com/robotology/icub-models-generator/pull/260, I found really annoying that it was basically impossible to generate the models locally, and hence do any kind of debugging. This is the problem tracked in https://github.com/robotology/icub-models-generator/issues/205 . 

The problem is particularly sensitive in this case as for historical reason this script requires a huge stack of code (CMake, Python, I just realized we are also still using ruby here) and libraries that require to use a precise old version to workaround bugs and problems. On one hand, it is highly unlike we will ever cleanup this, as all the effort for new robots is on the creo2urdf effort (see https://github.com/icub-tech-iit/creo2urdf). However, realistically we will need to be able to generate models for iCub robots for an indefinite amount of time in the future. Why not take the occasion to use this as a testbench for setting up an example of reproducible research software?

To do so, I added [pixi](https://pixi.sh) support to this repo. In a nutshell, pixi use conda packages, but it simplifies the management of so-called "lock files" (in the case of pixi, `pixi.lock`) that capture exactly the version of all the software dependencies used at some point in time. Furthermore, pixi also have a "task" system, in which manual step can be automated in a cross-platform way.

After doing this, once you have pixi installed, process of generating models in a `icub-models` folder contained in the robotology-superbuild boils down to:
~~~bash
git clone https://github.com/robotology/icub-models-generator
export ICUB_MODELS_SOURCE_DIR=/usr/local/src/robotology-superbuild/src/icub-models
cd icub-models-generator
pixi run copy_models_to_icub_models
~~~

See the README for more details. 

The main advantage w.r.t. to regular conda environment files (such as the one added in https://github.com/robotology/icub-models-generator/pull/244) is that the automatically generated `pixi.toml` file tracks the exact version of software used. So if in the future a new version of `catkin_pkg` (see https://github.com/robotology/icub-models-generator/blob/a42368e1a2ef2b7640a6c517b9b525735e852488/environment.yml#L15), or some transitive dependency of the packages listed in the environment breaks the software, the pixi workflows will continue to work as it uses the exact version saved in `pixi.lock` . Using conda, one could achieve something similar using [`conda-lock`](https://github.com/conda/conda-lock), but being an external tool its use is not straightforwardly integrated in conda/mamba.

Note that in general I am not happy to add some pixi task code on top of the CMake glue code that is used to launch the Python scripts, but that is the price we pay for reproducibility and being able to solve  https://github.com/robotology/icub-models-generator/issues/205 .


