### PR TITLE
icub2_5: Add alljoints-inertials_wrapper/remapper

### DIFF
--- a/simmechanics/data/icub2_5/conf/icub.xml
+++ b/simmechanics/data/icub2_5/conf/icub.xml
@@ -31,6 +31,8 @@
     <xi:include href="wrappers/inertials/head-inertials_wrapper.xml" />
     <xi:include href="wrappers/inertials/left_arm-inertials_wrapper.xml" />
     <xi:include href="wrappers/inertials/right_arm-inertials_wrapper.xml" />
+    <xi:include href="wrappers/inertials/alljoints-inertials_remapper.xml" />
+    <xi:include href="wrappers/inertials/alljoints-inertials_wrapper.xml" />
     <!--  NOT USED RIGHT NOW
     <xi:include href="wrappers/inertials/waist-inertials_wrapper.xml" /> -->    
     </devices>

--- a/simmechanics/data/icub2_5/conf/wrappers/inertials/alljoints-inertials_remapper.xml
+++ b/simmechanics/data/icub2_5/conf/wrappers/inertials/alljoints-inertials_remapper.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="alljoints-inertials_remapper" type="multipleanalogsensorsremapper">
+    <param name="OrientationSensorsNames">
+        (l_arm_ft r_arm_ft head_imu_0)
+    </param>
+    <action phase="startup" level="5" type="attach">
+        <paramlist name="networks">
+            <elem name="head_imu">  head_inertial_hardware_device </elem>
+            <elem name="left_arm_imu">  left_arm_inertial_hardware_device </elem>
+            <elem name="right_arm_imu">  right_arm_inertial_hardware_device </elem>
+        </paramlist>
+    </action>
+
+    <action phase="shutdown" level="20" type="detach" />
+</device>

--- a/simmechanics/data/icub2_5/conf/wrappers/inertials/alljoints-inertials_wrapper.xml
+++ b/simmechanics/data/icub2_5/conf/wrappers/inertials/alljoints-inertials_wrapper.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="alljoints-inertials_wrapper" type="multipleanalogsensorsserver">
+    <param name="period">      10                           </param>
+    <param name="name"> ${portprefix}/alljoints/inertials   </param>
+
+    <action phase="startup" level="10" type="attach">
+        <paramlist name="networks">
+            <elem name="FirstStrain"> alljoints-inertials_remapper </elem>
+        </paramlist>
+       </action>
+
+    <action phase="shutdown" level="15" type="detach" />
+</device>


### PR DESCRIPTION
So far, if you want to use the IMU test in [icub-tests](https://github.com/robotology/icub-tests/tree/devel/src/imu) to test multiple sensors at once, the robot must expose in its yarprobotinterface configuration file a `multipleanalogsensorsserver` that publishes the orientation measurements for all of available sensors, with a `prefix` that matches exactly the [port parameter](https://github.com/robotology/icub-tests/blob/devel/suites/contexts/icub/test_imu.ini#L3) of the test (the default one is `${portprefix}/alljoints/inertials`).

For this reason, it would be nice to have those files upstream also for iCubV2_* simulated models

cc @Nicogene @pattacini 