### PR TITLE
iCubV2_*: Fix measure of arm ft sensors

### DIFF
--- a/simmechanics/data/icub2_5/ICUB_2-5_BB_simmechanics_options.yaml.in
+++ b/simmechanics/data/icub2_5/ICUB_2-5_BB_simmechanics_options.yaml.in
@@ -644,7 +644,7 @@ forceTorqueSensors:
   - jointName: l_arm_ft_sensor
     directionChildToParent: Yes
     exportFrameInURDF: Yes
-    frame: sensor
+    frame: child
     frameName: SCSYS_L_UPPER_ARM_FT45
     linkName: l_shoulder_3
     sensorName: l_arm_ft
@@ -656,7 +656,7 @@ forceTorqueSensors:
   - jointName: r_arm_ft_sensor
     directionChildToParent: Yes
     exportFrameInURDF: Yes
-    frame: sensor
+    frame: child
     frameName: SCSYS_R_UPPER_ARM_FT45
     linkName: r_shoulder_3
     sensorName: r_arm_ft


### PR DESCRIPTION
It fixes #233.

Basically the problem is that in the child link of the ft sensor joints of the arms we do not have the CSYS, then we are computing the pose wrt the parent link.
Since the frame of the ft sensor should be the joint frame (i.e. the child link frame) setting `frame` to `child` make that the `pose` is referring to the correct frame and the measure is now correct.

cc @martinaxgloria 