### PR TITLE
Update pixi.lock on 2024/03/22

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -8,85 +8,95 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ace-7.1.3-h59595ed_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.10-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.11-hd590300_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ampl-mp-3.1.0-h2cc385e_1006.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aom-3.8.1-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aom-3.8.2-h59595ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/assimp-5.3.1-hfb0e8fe_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/attr-2.5.1-h166bdaf_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils-2.40-hdd6e379_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.40-hf600244_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.40-hbdbef99_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.40-hdade7a5_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hd590300_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.26.0-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.27.0-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/c-compiler-1.7.0-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.2.2-hbcca054_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.0-h3faef2a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/catkin_pkg-1.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cxx-compiler-1.7.0-h00ab1b0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/dav1d-1.2.1-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.13.6-h5008d03_3.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/docutils-0.20.1-py311h38be061_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/eigen-3.4.0-h00ab1b0_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/expat-2.5.0-hcb278e6_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ffmpeg-6.1.1-gpl_h8007c5b_104.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/expat-2.6.2-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ffmpeg-6.1.1-gpl_h38e077a_106.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.14.2-h14ed4e7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/freeglut-3.2.2-hac7e632_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.12.1-h267a509_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fribidi-1.0.10-h36c2ea0_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc-12.3.0-h8d2909c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc-12.3.0-h95e488c_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-12.3.0-he2b93b0_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-12.3.0-h76fc315_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-12.3.0-h6477408_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gdbm-1.18-h0a1914f_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gettext-0.21.1-h27087fc_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/glfw-3.3.9-hd590300_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/glib-2.78.3-hfc55251_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.78.3-hfc55251_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.3.0-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/glfw-3.4-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/glib-2.80.0-hf2295e7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.80.0-hde27a5a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.3.0-h59595ed_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gnutls-3.7.9-hb077bed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.13-h58526e2_1001.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gst-plugins-base-1.22.9-h8e1006c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gstreamer-1.22.9-h98fc4e7_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx-12.3.0-h8d2909c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx-12.3.0-h95e488c_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-12.3.0-he2b93b0_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-12.3.0-h8a814eb_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-12.3.0-h4a1b8e8_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-8.3.0-h3d44ed6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.3-nompi_h4f84152_100.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-73.2-h59595ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/idyntree-10.3.0-py311ha885c8a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/imath-3.1.11-hfc55251_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ipopt-3.14.14-h04b96a2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/irrlicht-1.8.5-h2a6caf8_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/jasper-4.2.0-he6dfbbe_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/jasper-4.2.2-he6dfbbe_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-2.6.32-he073ed8_17.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.1-h166bdaf_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.2-h659d440_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lame-3.100-h166bdaf_1003.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.40-h41732ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h27087fc_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20230802.1-cxx17_h59595ed_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libaec-1.1.2-h59595ed_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20240116.1-cxx17_h59595ed_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libaec-1.1.3-h59595ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libass-0.17.1-h8fe9dca_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-21_linux64_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-1.82.0-h6fcfa73_6.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcap-2.69-h0f662aa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-21_linux64_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-15.0.7-default_hb11cfb5_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang13-15.0.7-default_ha2b6cf4_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-15.0.7-default_h127d8a8_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang13-15.0.7-default_h5d6823c_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-h4637d8d_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.5.0-hca28451_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.6.0-hca28451_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.19-hd590300_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.114-h166bdaf_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.120-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.12-hf998b51_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.5.0-hcb278e6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.6.2-h59595ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libflac-1.4.3-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-12.3.0-h8bca6fd_105.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-13.2.0-h807b86a_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcrypt-1.10.3-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-13.2.0-h69a702a_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-13.2.0-ha4646dd_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.78.3-h783c2da_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.80.0-hf2295e7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libglu-9.0.0-hac7e632_1003.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-13.2.0-h807b86a_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgpg-error-1.47-h71f35ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgpg-error-1.48-h71f35ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.9.3-default_h554bfaf_1009.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libi2c-4.3-hcb278e6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.17-hd590300_2.conda
@@ -99,48 +109,49 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libogg-1.3.4-h7f98852_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.26-pthreads_h413a1c8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopencv-4.9.0-py311haea74c2_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-2023.3.0-h2e90f83_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-batch-plugin-2023.3.0-hd5fc58b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-plugin-2023.3.0-hd5fc58b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-hetero-plugin-2023.3.0-h3ecfda7_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-cpu-plugin-2023.3.0-h2e90f83_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-gpu-plugin-2023.3.0-h2e90f83_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-ir-frontend-2023.3.0-h3ecfda7_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-onnx-frontend-2023.3.0-hfbc7f12_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-paddle-frontend-2023.3.0-hfbc7f12_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-pytorch-frontend-2023.3.0-h59595ed_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-frontend-2023.3.0-h0bff32c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-lite-frontend-2023.3.0-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopencv-4.9.0-qt5_py38h03d32d8_512.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-2024.0.0-h2e90f83_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-batch-plugin-2024.0.0-hd5fc58b_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-plugin-2024.0.0-hd5fc58b_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-hetero-plugin-2024.0.0-h3ecfda7_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-cpu-plugin-2024.0.0-h2e90f83_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-gpu-plugin-2024.0.0-h2e90f83_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-ir-frontend-2024.0.0-h3ecfda7_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-onnx-frontend-2024.0.0-h757c851_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-paddle-frontend-2024.0.0-h757c851_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-pytorch-frontend-2024.0.0-h59595ed_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-frontend-2024.0.0-hca94c1a_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-lite-frontend-2024.0.0-h59595ed_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopus-1.3.1-h7f98852_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libosqp-0.6.3-h59595ed_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.17-h166bdaf_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.42-h2797004_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-16.2-h33b98f1_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-4.25.1-hf27288f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.18-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.43-h2797004_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-16.2-h33b98f1_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-4.25.3-h08a7969_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libqdldl-0.1.5-h27087fc_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-12.3.0-h0f45ef3_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libscotch-7.0.4-h91e35bf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsndfile-1.2.2-hc60ed4a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libspral-2023.09.07-h6aa6db2_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.45.1-h2797004_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.45.2-h2797004_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.0-h0841786_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-12.3.0-h8bca6fd_105.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-13.2.0-h7e041cc_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-255-h3516f8a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-255-h3516f8a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libtasn1-4.19.0-h166bdaf_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.6.0-ha9c0a0a_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libunistring-0.9.10-h7f98852_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libva-2.20.0-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libva-2.21.0-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libvorbis-1.3.7-h9c3ff4c_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libvpx-1.13.1-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libvpx-1.14.0-h59595ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.3.2-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.15-h0b41bf4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxkbcommon-1.6.0-hd429924_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.12.5-h232c23b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.12.6-h232c23b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxslt-1.1.39-h76b75d6_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libyarp-3.9.0-ha614a09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libyarp-3.9.0-ha614a09_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.2.13-hd590300_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lxml-4.9.4-py311h9691dec_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.9.4-hcb278e6_0.conda
@@ -150,25 +161,28 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mumps-seq-5.6.2-hfef103a_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mysql-common-8.0.33-hf1915f5_6.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mysql-libs-8.0.33-hca2cd23_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.4-h59595ed_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.4.20240210-h59595ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/nettle-3.9.1-h7ab15ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ninja-1.11.1-h924138e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/nspr-4.35-h27087fc_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/nss-3.97-h1d7d5a4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/nss-3.98-h1d7d5a4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.26.4-py311h64a7726_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ocl-icd-2.3.2-hd590300_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ocl-icd-system-1.0.0-1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ocl-icd-2.3.2-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openexr-3.2.2-haf962dd_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openh264-2.4.1-h59595ed_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.2.1-hd590300_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/osqp-eigen-0.8.1-hdd734ac_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.2.1-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/osqp-eigen-0.8.1-hdd734ac_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/p11-kit-0.24.1-hc5aa10d_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.42-hcad00b1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.43-hcad00b1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.43.2-h59595ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/portaudio-19.6.0-h7c63dc7_9.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-h36c2ea0_1001.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pugixml-1.14-h59595ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pulseaudio-client-16.1-hb77b528_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.11.7-hab00c5b_1_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.11.8-hab00c5b_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.11-4_cp311.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-5.4.1-py311hd4cff14_4.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qt-main-5.15.8-h5810be5_19.conda
@@ -178,13 +192,19 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/scotch-7.0.4-h23d43cc_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sdl-1.2.68-h293081c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sdl2-2.28.5-h77f46ba_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-69.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.1.10-h9fff704_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/soxr-0.1.3-h0b41bf4_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/svt-av1-1.8.0-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.12-he073ed8_17.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2021.11.0-h00ab1b0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tinyxml-2.6.2-h4bd325d_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/unixodbc-2.3.12-h661eb56_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/wayland-1.22.0-h8c25dac_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.43.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/x264-1!164.3095-h166bdaf_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/x265-3.5-h924138e_3.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-0.4.0-hd590300_1.conda
@@ -200,124 +220,114 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.4-h7391055_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.7-h8ee46fc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.11-hd590300_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxcursor-1.2.0-h0b41bf4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.3-h7f98852_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.4-h0b41bf4_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxfixes-5.0.3-h7f98852_1004.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxi-1.7.10-h7f98852_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxinerama-1.1.5-h27087fc_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrandr-1.5.2-h7f98852_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.11-hd590300_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-randrproto-1.5.0-h7f98852_1001.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-renderproto-0.11.1-h7f98852_1002.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xextproto-7.3.0-h0b41bf4_1003.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xf86vidmodeproto-2.3.1-h7f98852_1002.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xproto-7.0.31-h7f98852_1007.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h7f98852_2.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/yarp-3.9.0-ha770c72_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/yarp-python-3.9.0-py311h0e2f32c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/yarp-3.9.0-ha770c72_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/yarp-python-3.9.0-py311h0e2f32c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ycm-cmake-modules-0.16.2-h59595ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.2.13-hd590300_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.5-hfc55251_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/catkin_pkg-1.0.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-2.6.32-he073ed8_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-12.3.0-h8bca6fd_105.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-12.3.0-h8bca6fd_105.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.8.2-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-69.0.3-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.12-he073ed8_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.42.0-pyhd8ed1ab_0.conda
       linux-aarch64:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-2_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/_sysroot_linux-aarch64_curr_repodata_hack-4-h57d6b7b_14.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ace-7.1.3-h787c7f5_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/alsa-lib-1.2.10-h31becfc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/alsa-lib-1.2.11-h31becfc_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ampl-mp-3.1.0-h05efe27_1006.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aom-3.8.1-h0425590_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aom-3.8.2-h0425590_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/assimp-5.3.1-h28f1edd_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/attr-2.5.1-h4e544f5_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils-2.40-h64c2a2e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_impl_linux-aarch64-2.40-h870a726_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_linux-aarch64-2.40-h94bbfa1_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_linux-aarch64-2.40-h95d2017_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bzip2-1.0.8-h31becfc_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/c-ares-1.26.0-h31becfc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/c-ares-1.27.0-h31becfc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/c-compiler-1.7.0-h31becfc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ca-certificates-2024.2.2-hcefe29a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cairo-1.18.0-ha13f110_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/catkin_pkg-1.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cxx-compiler-1.7.0-h2a328a1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/dav1d-1.2.1-h31becfc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/dbus-1.13.6-h12b9eeb_3.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/docutils-0.20.1-py311hfecb2dc_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/eigen-3.4.0-h2a328a1_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/expat-2.5.0-hd600fc2_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ffmpeg-6.1.1-gpl_hd8c5532_104.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/expat-2.6.2-h2f0025b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ffmpeg-6.1.1-gpl_h991a198_106.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fontconfig-2.14.2-ha9a116f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freeglut-3.2.2-hf4b6fbe_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freetype-2.12.1-hf0a5ef3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fribidi-1.0.10-hb9de7d4_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc-12.3.0-hc1b51f9_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc-12.3.0-he80d746_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_impl_linux-aarch64-12.3.0-hcde2664_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_linux-aarch64-12.3.0-h464a8f7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_linux-aarch64-12.3.0-h9622932_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gettext-0.21.1-ha18d298_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glfw-3.3.9-h31becfc_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glib-2.78.3-hd84c7bf_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glib-tools-2.78.3-hd84c7bf_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gmp-6.3.0-h2f0025b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glfw-3.4-h31becfc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glib-2.80.0-h9d8fbc1_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glib-tools-2.80.0-hfbcf09e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gmp-6.3.0-h2f0025b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gnutls-3.7.9-hb309da9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/graphite2-1.3.13-h7fd3ca4_1001.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gst-plugins-base-1.22.9-h6d82d15_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gstreamer-1.22.9-hed71854_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx-12.3.0-hc1b51f9_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx-12.3.0-he80d746_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_impl_linux-aarch64-12.3.0-hcde2664_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_linux-aarch64-12.3.0-h21accf6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_linux-aarch64-12.3.0-h3d1e521_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/harfbuzz-8.3.0-hebeb849_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/hdf5-1.14.3-nompi_ha486f32_100.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-73.2-h787c7f5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/idyntree-10.3.0-py311h5498c2b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/imath-3.1.11-hd84c7bf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ipopt-3.14.14-h64a9e3f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/irrlicht-1.8.5-h962fdfd_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/jasper-4.2.0-h381c573_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/jasper-4.2.2-h381c573_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-aarch64-4.18.0-h5b4a56d_14.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/keyutils-1.6.1-h4e544f5_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/krb5-1.21.2-hc419048_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lame-3.100-h4e544f5_1003.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.40-h2d8c526_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lerc-4.0.0-h4de3ea5_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libabseil-20230802.1-cxx17_h2f0025b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libaec-1.1.2-h2f0025b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libabseil-20240116.1-cxx17_h2f0025b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libaec-1.1.3-h2f0025b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libass-0.17.1-h36b5d3b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libblas-3.9.0-21_linuxaarch64_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libboost-1.82.0-h133f18d_6.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcap-2.69-h883460d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcblas-3.9.0-21_linuxaarch64_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang-15.0.7-default_h65c9d4d_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang13-15.0.7-default_hf5d3afd_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang-15.0.7-default_hb368394_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang13-15.0.7-default_hf9b4efe_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcups-2.3.3-h405e4a8_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurl-8.5.0-h4e8248e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurl-8.6.0-h4e8248e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libdeflate-1.19-h31becfc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libev-4.33-h31becfc_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libevent-2.1.12-h4ba1bb4_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libexpat-2.5.0-hd600fc2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libexpat-2.6.2-h2f0025b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libffi-3.4.2-h3557bc0_5.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libflac-1.4.3-h2f0025b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-aarch64-12.3.0-h8b5ab12_105.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-13.2.0-hf8544c7_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcrypt-1.10.3-h31becfc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-ng-13.2.0-he9431aa_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-13.2.0-h582850c_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglib-2.78.3-h311d5f7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglib-2.80.0-h9d8fbc1_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglu-9.0.0-hf4b6fbe_1003.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-13.2.0-hf8544c7_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgpg-error-1.47-h5ce24db_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgpg-error-1.48-h5ce24db_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libhwloc-2.9.3-default_hda148da_1009.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libi2c-4.3-hd600fc2_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libiconv-1.17-h31becfc_2.conda
@@ -330,45 +340,46 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnsl-2.0.1-h31becfc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libogg-1.3.4-h3557bc0_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenblas-0.3.26-pthreads_h5a5ec62_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopencv-4.9.0-py311h5435783_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-2023.3.0-h3e0449b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-arm-cpu-plugin-2023.3.0-h3e0449b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-auto-batch-plugin-2023.3.0-hd429f41_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-auto-plugin-2023.3.0-hd429f41_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-hetero-plugin-2023.3.0-hc6dd956_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-ir-frontend-2023.3.0-hc6dd956_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-onnx-frontend-2023.3.0-hb0b24c1_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-paddle-frontend-2023.3.0-hb0b24c1_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-pytorch-frontend-2023.3.0-h2f0025b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-tensorflow-frontend-2023.3.0-h5dc61ae_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-tensorflow-lite-frontend-2023.3.0-h2f0025b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopencv-4.9.0-headless_py311h773aa8a_12.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-2024.0.0-h3e0449b_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-arm-cpu-plugin-2024.0.0-h3e0449b_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-auto-batch-plugin-2024.0.0-hd429f41_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-auto-plugin-2024.0.0-hd429f41_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-hetero-plugin-2024.0.0-hc6dd956_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-ir-frontend-2024.0.0-hc6dd956_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-onnx-frontend-2024.0.0-h81208d3_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-paddle-frontend-2024.0.0-h81208d3_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-pytorch-frontend-2024.0.0-h2f0025b_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-tensorflow-frontend-2024.0.0-h5177828_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-tensorflow-lite-frontend-2024.0.0-h2f0025b_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopus-1.3.1-hf897c2e_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libosqp-0.6.3-h2f0025b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpng-1.6.42-h194ca79_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpq-16.2-h58720eb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libprotobuf-4.25.1-h87e877f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpng-1.6.43-h194ca79_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpq-16.2-h58720eb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libprotobuf-4.25.3-h648ac29_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libqdldl-0.1.5-h4de3ea5_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsanitizer-12.3.0-h8ebda82_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libscotch-7.0.4-h16908e7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsndfile-1.2.2-h79657aa_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libspral-2023.09.07-h98a5362_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsqlite-3.45.1-h194ca79_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsqlite-3.45.2-h194ca79_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libssh2-1.11.0-h492db2e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-aarch64-12.3.0-h8b5ab12_105.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-ng-13.2.0-h9a76618_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsystemd0-255-h91e93f8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsystemd0-255-h91e93f8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libtasn1-4.19.0-h4e544f5_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libtiff-4.6.0-h1708d11_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libunistring-0.9.10-hf897c2e_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libuuid-2.38.1-hb4cce97_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libvorbis-1.3.7-h01db608_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libvpx-1.13.1-h2f0025b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libvpx-1.14.0-h2f0025b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libwebp-base-1.3.2-h31becfc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxcb-1.15-h2a766a3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxcrypt-4.4.36-h31becfc_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxkbcommon-1.6.0-h217f472_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxml2-2.12.5-h3091e33_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxml2-2.12.6-h3091e33_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxslt-1.1.39-h1cc9640_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libyarp-3.9.0-h6d2be9b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libyarp-3.9.0-h6d2be9b_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libzlib-1.2.13-h31becfc_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lxml-4.9.4-py311h30c7647_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lz4-c-1.9.4-hd600fc2_0.conda
@@ -378,23 +389,27 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mumps-seq-5.6.2-hae18a20_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mysql-common-8.0.33-hb6794ad_6.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mysql-libs-8.0.33-hf629957_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ncurses-6.4-h0425590_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ncurses-6.4.20240210-h0425590_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/nettle-3.9.1-h9d1147b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ninja-1.11.1-hdd96247_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/nspr-4.35-h4de3ea5_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/nss-3.97-hc5a5cc2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/nss-3.98-hc5a5cc2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/numpy-1.26.4-py311h69ead2a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openexr-3.2.2-hdf561d4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openh264-2.4.1-h2f0025b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.2.1-h31becfc_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/osqp-eigen-0.8.1-h63a7d18_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.2.1-h31becfc_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/osqp-eigen-0.8.1-h63a7d18_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/p11-kit-0.24.1-h9f2702f_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pcre2-10.42-hd0f9c67_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pixman-0.43.2-h2f0025b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pcre2-10.43-hd0f9c67_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pixman-0.43.4-h2f0025b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/portaudio-19.6.0-h5c6c0ed_9.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pthread-stubs-0.4-hb9de7d4_1001.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pugixml-1.14-h2f0025b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pulseaudio-client-16.1-h729494f_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python-3.11.7-h43d1f9e_1_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python-3.11.8-h43d1f9e_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python_abi-3.11-4_cp311.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyyaml-5.4.1-py311hdfa8b44_4.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/qt-main-5.15.8-h5992497_18.conda
@@ -404,13 +419,19 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/scotch-7.0.4-habe6132_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sdl-1.2.68-h32cd00b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sdl2-2.28.5-h4e7748e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-69.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/snappy-1.1.10-he8610fa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/soxr-0.1.3-hb4cce97_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/svt-av1-1.8.0-h2f0025b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-aarch64-2.17-h5b4a56d_14.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tbb-2021.11.0-h2a328a1_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tinyxml-2.6.2-hd62202e_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tk-8.6.13-h194ca79_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/unixodbc-2.3.12-h7b6a552_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/wayland-1.22.0-hce5310f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.43.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/x264-1!164.3095-h4e544f5_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/x265-3.5-hdd96247_3.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-0.4.0-h31becfc_1.conda
@@ -426,95 +447,66 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libsm-1.2.4-h5a01bc2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libx11-1.8.7-h055a233_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxau-1.0.11-h31becfc_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxcursor-1.2.0-hb4cce97_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxdmcp-1.1.3-h3557bc0_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxext-1.3.4-h2a766a3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxfixes-5.0.3-h3557bc0_1004.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxi-1.7.10-h3557bc0_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxinerama-1.1.5-h4de3ea5_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxrandr-1.5.2-hf897c2e_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxrender-0.9.11-h7935292_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-randrproto-1.5.0-hf897c2e_1001.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-renderproto-0.11.1-h3557bc0_1002.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-xextproto-7.3.0-h2a766a3_1003.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-xf86vidmodeproto-2.3.1-hf897c2e_1002.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-xproto-7.0.31-h3557bc0_1007.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xz-5.2.6-h9cdd2b7_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/yaml-0.2.5-hf897c2e_2.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/yarp-3.9.0-h8af1aa0_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/yarp-python-3.9.0-py311h6b46aae_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/yarp-3.9.0-h8af1aa0_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/yarp-python-3.9.0-py311h6b46aae_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ycm-cmake-modules-0.16.2-h2f0025b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zlib-1.2.13-h31becfc_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zstd-1.5.5-h4c53e97_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/_sysroot_linux-aarch64_curr_repodata_hack-4-h57d6b7b_13.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/catkin_pkg-1.0.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-aarch64-4.18.0-h5b4a56d_13.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-aarch64-12.3.0-h8b5ab12_105.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-aarch64-12.3.0-h8b5ab12_105.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.8.2-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-69.0.3-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-aarch64-2.17-h5b4a56d_13.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.42.0-pyhd8ed1ab_0.conda
       osx-64:
-      - conda: https://conda.anaconda.org/conda-forge/noarch/catkin_pkg-1.0.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/compiler-rt_osx-64-16.0.6-ha38d28d_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.8.2-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-69.0.3-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.42.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ace-7.1.3-h73e2aa4_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ampl-mp-3.1.0-h2beb688_1006.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/aom-3.8.1-h73e2aa4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aom-3.8.2-h73e2aa4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/assimp-5.3.1-h460e769_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h10d778d_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.26.0-h10d778d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.27.0-h10d778d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/c-compiler-1.7.0-h282daa2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2024.2.2-h8857fd0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/cairo-1.18.0-h99e66fa_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/cctools-973.0.1-h40f6528_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/cctools_osx-64-973.0.1-ha1c5b94_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/clang-16-16.0.6-default_h7151d67_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/clang-16.0.6-hdae98eb_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/clang_impl_osx-64-16.0.6-h8787910_9.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/clang_osx-64-16.0.6-hb91bd55_9.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/clangxx-16.0.6-default_h7151d67_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/clangxx_impl_osx-64-16.0.6-h6d92fbe_9.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/clangxx_osx-64-16.0.6-hb91bd55_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/catkin_pkg-1.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cctools-986-h40f6528_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cctools_osx-64-986-ha1c5b94_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/clang-16-16.0.6-default_h7151d67_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/clang-16.0.6-hdae98eb_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/clang_impl_osx-64-16.0.6-h8787910_11.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/clang_osx-64-16.0.6-hb91bd55_11.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/clangxx-16.0.6-default_h7151d67_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/clangxx_impl_osx-64-16.0.6-h6d92fbe_11.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/clangxx_osx-64-16.0.6-hb91bd55_11.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/compiler-rt-16.0.6-ha38d28d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/compiler-rt_osx-64-16.0.6-ha38d28d_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/cxx-compiler-1.7.0-h7728843_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/dav1d-1.2.1-h0dc2134_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/docutils-0.20.1-py311h6eed73b_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/eigen-3.4.0-h1c7c39f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/expat-2.5.0-hf0c8a7f_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/ffmpeg-6.1.1-gpl_h73cf981_104.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/expat-2.6.2-h73e2aa4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ffmpeg-6.1.1-gpl_h71b6f88_106.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/fontconfig-2.14.2-h5bb23bf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/freetype-2.12.1-h60636b9_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/fribidi-1.0.10-hbcb3906_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/gdbm-1.18-h8a0c380_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/gettext-0.21.1-h8a4c099_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/glfw-3.3.9-h10d778d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/glib-2.78.3-hf4d7fad_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/glib-tools-2.78.3-hf4d7fad_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/gmp-6.3.0-h93d8f39_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/glfw-3.4-h10d778d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/glib-2.80.0-h81c1438_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/glib-tools-2.80.0-h49a7eea_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/gmp-6.3.0-h73e2aa4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/gnutls-3.7.9-h1951705_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/graphite2-1.3.13-h2e338ed_1001.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/gst-plugins-base-1.22.9-h3fb38fc_0.conda
@@ -523,33 +515,34 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/hdf5-1.14.3-nompi_h691f4bf_100.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/icu-73.2-hf5e326d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/idyntree-10.3.0-py311h616ed6d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/imath-3.1.11-h2d185b6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ipopt-3.14.14-h09c0c07_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/irrlicht-1.8.5-h5bfa9a0_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/jasper-4.2.0-h6ff19ee_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/jasper-4.2.2-h6ff19ee_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/krb5-1.21.2-hb884880_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/lame-3.100-hb7f2c08_1003.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/ld64-609-ha02d983_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/ld64_osx-64-609-ha20a434_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ld64-711-ha02d983_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ld64_osx-64-711-ha20a434_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/lerc-4.0.0-hb486fe8_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libabseil-20230802.1-cxx17_h048a20a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libaec-1.1.2-he965462_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libabseil-20240116.1-cxx17_hc1bcbd7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libaec-1.1.3-h73e2aa4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libass-0.17.1-h80904bb_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-21_osx64_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libboost-1.82.0-h99d8d82_6.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.9.0-21_osx64_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libclang-15.0.7-default_h6b1ee41_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libclang-cpp16-16.0.6-default_h7151d67_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libclang13-15.0.7-default_h89cd682_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.5.0-h726d00d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libclang-15.0.7-default_h7151d67_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libclang-cpp16-16.0.6-default_h7151d67_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libclang13-15.0.7-default_h0edc4dd_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.6.0-h726d00d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-16.0.6-hd57cbcb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libdeflate-1.19-ha4e1b8e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libedit-3.1.20191231-h0678c8f_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-h10d778d_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.5.0-hf0c8a7f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.6.2-h73e2aa4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.4.2-h0d85af4_5.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-5.0.0-13_2_0_h97931a8_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-13.2.0-h2873a65_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libglib-2.78.3-h198397b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libglib-2.80.0-h81c1438_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libhwloc-2.9.3-default_h24e0189_1009.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.17-hd75f5a5_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libidn2-2.3.7-h10d778d_0.conda
@@ -561,39 +554,39 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.58.0-h64cf6d3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libogg-1.3.4-h35c211d_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.26-openmp_hfef2a42_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopencv-4.9.0-py310ha3ab171_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-2023.3.0-h113ac47_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-auto-batch-plugin-2023.3.0-h9adb129_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-auto-plugin-2023.3.0-h9adb129_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-hetero-plugin-2023.3.0-hfe2fe54_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-intel-cpu-plugin-2023.3.0-h113ac47_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-ir-frontend-2023.3.0-hfe2fe54_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-onnx-frontend-2023.3.0-hd0b7f58_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-paddle-frontend-2023.3.0-hd0b7f58_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-pytorch-frontend-2023.3.0-hd427752_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-tensorflow-frontend-2023.3.0-h35b5a9d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-tensorflow-lite-frontend-2023.3.0-hd427752_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopencv-4.9.0-headless_py39h1cbcdfd_12.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-2024.0.0-h113ac47_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-auto-batch-plugin-2024.0.0-h9adb129_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-auto-plugin-2024.0.0-h9adb129_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-hetero-plugin-2024.0.0-hfe2fe54_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-intel-cpu-plugin-2024.0.0-h113ac47_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-ir-frontend-2024.0.0-hfe2fe54_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-onnx-frontend-2024.0.0-h1a3ed6a_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-paddle-frontend-2024.0.0-h1a3ed6a_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-pytorch-frontend-2024.0.0-hd427752_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-tensorflow-frontend-2024.0.0-h7d3639a_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-tensorflow-lite-frontend-2024.0.0-hd427752_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libopus-1.3.1-hc929b4f_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libosqp-0.6.3-he965462_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.42-h92b6c6a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libpq-16.2-ha925e61_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libprotobuf-4.25.1-hc4f2305_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.43-h92b6c6a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libpq-16.2-ha925e61_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libprotobuf-4.25.3-h4e4d658_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libqdldl-0.1.5-hf0c8a7f_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libscotch-7.0.4-hc2ac6e5_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.45.1-h92b6c6a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.45.2-h92b6c6a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libssh2-1.11.0-hd019ec5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libtasn1-4.19.0-hb7f2c08_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libtiff-4.6.0-h684deea_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libunistring-0.9.10-h0d85af4_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libvorbis-1.3.7-h046ec9c_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libvpx-1.13.1-he965462_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libvpx-1.14.0-h73e2aa4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libwebp-base-1.3.2-h0dc2134_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libxcb-1.15-hb7f2c08_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.12.5-hc0ae0f7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.12.6-hc0ae0f7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libxslt-1.1.39-h03b04e6_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libyarp-3.9.0-h9c0c770_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libyarp-3.9.0-h9c0c770_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.2.13-h8a1eda9_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-17.0.6-hb6ac08f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-18.1.2-hb6ac08f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-tools-16.0.6-hbedff68_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/lxml-4.9.4-py311h033124e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/metis-5.1.0-he965462_1007.conda
@@ -601,22 +594,26 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/mumps-seq-5.6.2-he3629b0_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/mysql-common-8.0.33-h1d20c9b_6.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/mysql-libs-8.0.33-hed35180_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.4-h93d8f39_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.4.20240210-h73e2aa4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/nettle-3.9.1-h8e11ae5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ninja-1.11.1-hb8565cd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/nspr-4.35-hea0b92c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/nss-3.97-ha05da47_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/nss-3.98-ha05da47_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-1.26.4-py311hc43a94b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/openexr-3.2.2-h3f0570e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/openh264-2.4.1-h73e2aa4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.2.1-hd75f5a5_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/osqp-eigen-0.8.1-hede6739_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.2.1-hd75f5a5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/osqp-eigen-0.8.1-hb7bbaee_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/p11-kit-0.24.1-h65f8906_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/pcre2-10.42-h0ad2156_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/pixman-0.43.2-h73e2aa4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pcre2-10.43-h0ad2156_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pixman-0.43.4-h73e2aa4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/portaudio-19.6.0-he965462_9.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pthread-stubs-0.4-hc929b4f_1001.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pugixml-1.14-he965462_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.11.7-h9f0c242_1_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.11.8-h9f0c242_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.11-4_cp311.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pyyaml-5.4.1-py311h5547dcb_4.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/qt-main-5.15.8-h4385fff_19.conda
@@ -626,7 +623,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/scotch-7.0.4-h52a132a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/sdl-1.2.68-hce1cd6f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/sdl2-2.28.5-h73e2aa4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-69.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/sigtool-0.1.3-h88f4db0_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/snappy-1.1.10-h225ccf5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/soxr-0.1.3-hbf74d83_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/svt-av1-1.8.0-h93d8f39_0.conda
@@ -634,7 +633,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tbb-2021.11.0-h7728843_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tinyxml-2.6.2-h65a07b1_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h1abcd95_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/unixodbc-2.3.12-he8a5cf4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.43.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/x264-1!164.3095-h775f41a_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/x265-3.5-hbb4e6a2_3.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-kbproto-1.0.7-h35c211d_1002.tar.bz2
@@ -646,59 +647,52 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-xproto-7.0.31-h35c211d_1007.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/xz-5.2.6-h775f41a_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-h0d85af4_2.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/yarp-3.9.0-h694c41f_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/yarp-python-3.9.0-py311h22f05a9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/yarp-3.9.0-h694c41f_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/yarp-python-3.9.0-py311h22f05a9_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ycm-cmake-modules-0.16.2-h73e2aa4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zlib-1.2.13-h8a1eda9_5.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.5-h829000d_0.conda
       osx-arm64:
-      - conda: https://conda.anaconda.org/conda-forge/noarch/catkin_pkg-1.0.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/compiler-rt_osx-arm64-16.0.6-h3808999_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.8.2-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-69.0.3-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.42.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ampl-mp-3.1.0-hbec66e7_1006.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aom-3.8.1-h078ce10_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aom-3.8.2-h078ce10_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/assimp-5.3.1-he63ff86_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h93a5062_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.26.0-h93a5062_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.27.0-h93a5062_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-compiler-1.7.0-h6aa9301_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2024.2.2-hf0a4a13_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cairo-1.18.0-hd1e100b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cctools-973.0.1-h4faf515_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cctools_osx-arm64-973.0.1-h62378fb_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang-16-16.0.6-default_he012953_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang-16.0.6-h30cc82d_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang_impl_osx-arm64-16.0.6-hc421ffc_9.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang_osx-arm64-16.0.6-h54d7cd3_9.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clangxx-16.0.6-default_h4cf2255_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clangxx_impl_osx-arm64-16.0.6-hcd7bac0_9.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clangxx_osx-arm64-16.0.6-h54d7cd3_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/catkin_pkg-1.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cctools-986-h4faf515_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cctools_osx-arm64-986-h62378fb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang-16-16.0.6-default_he012953_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang-16.0.6-h30cc82d_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang_impl_osx-arm64-16.0.6-hc421ffc_11.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang_osx-arm64-16.0.6-h54d7cd3_11.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clangxx-16.0.6-default_h4cf2255_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clangxx_impl_osx-arm64-16.0.6-hcd7bac0_11.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clangxx_osx-arm64-16.0.6-h54d7cd3_11.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/compiler-rt-16.0.6-h3808999_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/compiler-rt_osx-arm64-16.0.6-h3808999_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cxx-compiler-1.7.0-h2ffa867_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/dav1d-1.2.1-hb547adb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/docutils-0.20.1-py311h267d04e_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/eigen-3.4.0-h1995070_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/expat-2.5.0-hb7217d7_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ffmpeg-6.1.1-gpl_h31ea89b_104.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/expat-2.6.2-hebf3989_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ffmpeg-6.1.1-gpl_haa72bd2_106.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fontconfig-2.14.2-h82840c6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/freetype-2.12.1-hadb7bae_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fribidi-1.0.10-h27ca646_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gettext-0.21.1-h0186832_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/glfw-3.3.9-h93a5062_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/glib-2.78.3-h9e231a4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/glib-tools-2.78.3-h9e231a4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gmp-6.3.0-h965bd2d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/glfw-3.4-h93a5062_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/glib-2.80.0-hfc324ee_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/glib-tools-2.80.0-hb9a4d99_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gmp-6.3.0-hebf3989_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gnutls-3.7.9-hd26332c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/graphite2-1.3.13-h9f76cd9_1001.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gst-plugins-base-1.22.9-h09b4b5e_0.conda
@@ -707,33 +701,34 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-1.14.3-nompi_h5bb55e9_100.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-73.2-hc8870d7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/idyntree-10.3.0-py311ha38bcb2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/imath-3.1.11-h1059232_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ipopt-3.14.14-h6639f4a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/irrlicht-1.8.5-h1344824_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/jasper-4.2.0-h7c0e182_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/jasper-4.2.2-h7c0e182_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.21.2-h92f50d5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lame-3.100-h1a8c8d9_1003.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ld64-609-h634c8be_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ld64_osx-arm64-609-ha4bd21c_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ld64-711-h634c8be_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ld64_osx-arm64-711-ha4bd21c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lerc-4.0.0-h9a09cb3_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20230802.1-cxx17_h13dd4ca_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libaec-1.1.2-h13dd4ca_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20240116.1-cxx17_hebf3989_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libaec-1.1.3-hebf3989_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libass-0.17.1-hf7da4fe_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-21_osxarm64_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libboost-1.82.0-h489e689_6.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-21_osxarm64_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libclang-15.0.7-default_hd209bcb_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libclang-cpp16-16.0.6-default_he012953_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libclang-cpp16-16.0.6-default_he012953_6.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libclang13-15.0.7-default_ha49e599_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.5.0-h2d989ff_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.6.0-h2d989ff_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-16.0.6-h4653b0c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.19-hb547adb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20191231-hc8eb9b7_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h93a5062_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.5.0-hb7217d7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.6.2-hebf3989_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-5.0.0-13_2_0_hd922786_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-13.2.0-hf226fd6_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libglib-2.78.3-hb438215_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libglib-2.80.0-hfc324ee_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libhwloc-2.9.3-default_h4394839_1009.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.17-h0d3ecfb_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libidn2-2.3.7-h93a5062_0.conda
@@ -745,39 +740,39 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.58.0-ha4dd798_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libogg-1.3.4-h27ca646_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.26-openmp_h6c19121_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopencv-4.9.0-py311hdccf81a_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-2023.3.0-he6dadac_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-arm-cpu-plugin-2023.3.0-he6dadac_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-auto-batch-plugin-2023.3.0-hc9f00d9_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-auto-plugin-2023.3.0-hc9f00d9_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-hetero-plugin-2023.3.0-hf483cef_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-ir-frontend-2023.3.0-hf483cef_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-onnx-frontend-2023.3.0-h98f6304_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-paddle-frontend-2023.3.0-h98f6304_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-pytorch-frontend-2023.3.0-hebf3989_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-tensorflow-frontend-2023.3.0-hb5ee477_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-tensorflow-lite-frontend-2023.3.0-hebf3989_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopencv-4.9.0-headless_py311h18d748c_12.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-2024.0.0-he6dadac_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-arm-cpu-plugin-2024.0.0-he6dadac_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-auto-batch-plugin-2024.0.0-hc9f00d9_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-auto-plugin-2024.0.0-hc9f00d9_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-hetero-plugin-2024.0.0-hf483cef_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-ir-frontend-2024.0.0-hf483cef_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-onnx-frontend-2024.0.0-h298fcef_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-paddle-frontend-2024.0.0-h298fcef_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-pytorch-frontend-2024.0.0-hebf3989_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-tensorflow-frontend-2024.0.0-h356fca3_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-tensorflow-lite-frontend-2024.0.0-hebf3989_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopus-1.3.1-h27ca646_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libosqp-0.6.3-h13dd4ca_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.42-h091b4b1_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpq-16.2-h0f8b458_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-4.25.1-h810fc01_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.43-h091b4b1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpq-16.2-h0f8b458_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-4.25.3-hbfab5d5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libqdldl-0.1.5-hb7217d7_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libscotch-7.0.4-hc938e73_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.45.1-h091b4b1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.45.2-h091b4b1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libssh2-1.11.0-h7a5bd25_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libtasn1-4.19.0-h1a8c8d9_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.6.0-ha8a6c65_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libunistring-0.9.10-h3422bc3_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libvorbis-1.3.7-h9f76cd9_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libvpx-1.13.1-hb765f3a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libvpx-1.14.0-h078ce10_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libwebp-base-1.3.2-hb547adb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxcb-1.15-hf346824_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.12.5-h0d0cfa8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.12.6-h0d0cfa8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxslt-1.1.39-h223e5b9_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libyarp-3.9.0-hff4382b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libyarp-3.9.0-hff4382b_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.2.13-h53f4e23_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-17.0.6-hcd81f8e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-18.1.2-hcd81f8e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-tools-16.0.6-haab561b_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lxml-4.9.4-py311h85df328_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/metis-5.1.0-h13dd4ca_1007.conda
@@ -785,22 +780,26 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mumps-seq-5.6.2-hbbab245_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mysql-common-8.0.33-hf9e6398_6.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mysql-libs-8.0.33-he3dca8b_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.4-h463b476_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.4.20240210-h078ce10_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/nettle-3.9.1-h40ed0f5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ninja-1.11.1-hffc8910_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/nspr-4.35-hb7217d7_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/nss-3.97-h5ce2875_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/nss-3.98-h5ce2875_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-1.26.4-py311h7125741_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openexr-3.2.2-h2c51e1d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openh264-2.4.1-hebf3989_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.2.1-h0d3ecfb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/osqp-eigen-0.8.1-hfae311c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.2.1-h0d3ecfb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/osqp-eigen-0.8.1-h136a8c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/p11-kit-0.24.1-h29577a5_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pcre2-10.42-h26f9a81_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pixman-0.43.2-hebf3989_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pcre2-10.43-h26f9a81_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pixman-0.43.4-hebf3989_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/portaudio-19.6.0-h13dd4ca_9.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-h27ca646_1001.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pugixml-1.14-h13dd4ca_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.11.7-hdf0ec26_1_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.11.8-hdf0ec26_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.11-4_cp311.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-5.4.1-py311he2be06e_4.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/qt-main-5.15.8-h6bf1bb6_19.conda
@@ -810,7 +809,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scotch-7.0.4-heaa5b5c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sdl-1.2.68-hfc12253_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sdl2-2.28.5-hebf3989_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-69.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sigtool-0.1.3-h44b9a77_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/snappy-1.1.10-h17c5cce_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/soxr-0.1.3-h5008568_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/svt-av1-1.8.0-h463b476_0.conda
@@ -818,7 +819,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tbb-2021.11.0-h2ffa867_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tinyxml-2.6.2-h260d524_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h5083fa2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/unixodbc-2.3.12-h0e2417a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.43.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/x264-1!164.3095-h57fd34a_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/x265-3.5-hbc6ce65_3.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-kbproto-1.0.7-h27ca646_1002.tar.bz2
@@ -830,47 +833,39 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-xproto-7.0.31-h27ca646_1007.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.2.6-h57fd34a_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h3422bc3_2.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yarp-3.9.0-hce30654_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yarp-python-3.9.0-py311h1e2cc8c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yarp-3.9.0-hce30654_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yarp-python-3.9.0-py311h1e2cc8c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ycm-cmake-modules-0.16.2-hebf3989_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.2.13-h53f4e23_5.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.5-h4f39d0f_0.conda
       win-64:
-      - conda: https://conda.anaconda.org/conda-forge/noarch/catkin_pkg-1.0.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/llvm-meta-5.0.0-0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.8.2-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-69.0.3-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.42.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ace-7.1.3-h63175ca_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aom-3.8.1-h63175ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aom-3.8.2-h63175ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/assimp-5.3.1-h81f0834_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-hcfcfb64_5.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/c-compiler-1.7.0-hcfcfb64_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2024.2.2-h56e8100_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/cairo-1.18.0-h1fef639_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/catkin_pkg-1.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/cxx-compiler-1.7.0-h91493d7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/dav1d-1.2.1-hcfcfb64_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/docutils-0.20.1-py311h1ea47a8_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/eigen-3.4.0-h91493d7_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/expat-2.5.0-h63175ca_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/ffmpeg-6.1.1-gpl_hb766fab_104.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/expat-2.6.2-h63175ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ffmpeg-6.1.1-gpl_hb766fab_106.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/fontconfig-2.14.2-hbde0cde_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/freeglut-3.2.2-h63175ca_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/freetype-2.12.1-hdaf720e_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/gettext-0.21.1-h5728263_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/glfw-3.3.9-hcfcfb64_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/glib-2.78.3-h12be248_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/glib-tools-2.78.3-h12be248_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/glfw-3.4-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/glib-2.80.0-h39d0aa6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/glib-tools-2.80.0-h0a98069_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/graphite2-1.3.13-1000.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/gst-plugins-base-1.22.9-h001b923_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/gstreamer-1.22.9-hb4038d2_0.conda
@@ -878,75 +873,81 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/hdf5-1.14.3-nompi_h73e8ff5_100.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/icu-73.2-h63175ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/idyntree-10.3.0-py311heed4631_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/imath-3.1.11-h12be248_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2024.0.0-h57928b3_49841.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ipopt-3.14.14-h1709daf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/irrlicht-1.8.5-h65f4d7e_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/jasper-4.2.0-h28f2b1a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/jasper-4.2.2-h28f2b1a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/khronos-opencl-icd-loader-2023.04.17-h64bf75a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/krb5-1.21.2-heb0366b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/lerc-4.0.0-h63175ca_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libabseil-20230802.1-cxx17_h63175ca_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libaec-1.1.2-h63175ca_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libabseil-20240116.1-cxx17_h63175ca_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libaec-1.1.3-h63175ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-21_win64_mkl.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libboost-1.82.0-h65993cd_6.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-21_win64_mkl.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libclang-15.0.7-default_hde6756a_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libclang13-15.0.7-default_h85b4d89_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.5.0-hd5e4a3a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libclang-15.0.7-default_h3a3e6c3_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libclang13-15.0.7-default_hf64faad_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.6.0-hd5e4a3a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.19-hcfcfb64_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.5.0-h63175ca_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.6.2-h63175ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.4.2-h8ffe710_5.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/libflang-5.0.0-h6538335_20180525.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libglib-2.78.3-h16e383f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libglib-2.80.0-h39d0aa6_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.9.3-default_haede6df_1009.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.17-hcfcfb64_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libjpeg-turbo-3.0.0-hcfcfb64_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-21_win64_mkl.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/liblapacke-3.9.0-21_win64_mkl.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libogg-1.3.4-h8ffe710_1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libopencv-4.9.0-py312h766d233_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-2023.3.0-hc2557fa_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-auto-batch-plugin-2023.3.0-h002f227_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-auto-plugin-2023.3.0-h002f227_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-hetero-plugin-2023.3.0-h7e3b17c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-intel-cpu-plugin-2023.3.0-hc2557fa_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-intel-gpu-plugin-2023.3.0-hc2557fa_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-ir-frontend-2023.3.0-h7e3b17c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-onnx-frontend-2023.3.0-h8f0bfdc_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-paddle-frontend-2023.3.0-h8f0bfdc_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-pytorch-frontend-2023.3.0-h63175ca_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-tensorflow-frontend-2023.3.0-h815df86_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-tensorflow-lite-frontend-2023.3.0-h63175ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopencv-4.9.0-qt5_py312h563a59f_512.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-2024.0.0-hc2557fa_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-auto-batch-plugin-2024.0.0-h002f227_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-auto-plugin-2024.0.0-h002f227_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-hetero-plugin-2024.0.0-h7e3b17c_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-intel-cpu-plugin-2024.0.0-hc2557fa_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-intel-gpu-plugin-2024.0.0-hc2557fa_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-ir-frontend-2024.0.0-h7e3b17c_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-onnx-frontend-2024.0.0-h55b4db4_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-paddle-frontend-2024.0.0-h55b4db4_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-pytorch-frontend-2024.0.0-h63175ca_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-tensorflow-frontend-2024.0.0-ha362bc9_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-tensorflow-lite-frontend-2024.0.0-h63175ca_4.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libopus-1.3.1-h8ffe710_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/libosqp-0.6.3-h63175ca_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.42-h19919ed_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libprotobuf-4.25.1-hb8276f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.43-h19919ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libprotobuf-4.25.3-h503648d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libqdldl-0.1.5-h63175ca_1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.45.1-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.45.2-hcfcfb64_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libssh2-1.11.0-h7dfc565_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.6.0-h6e2ebb7_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libvorbis-1.3.7-h0e60522_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/libwebp-base-1.3.2-hcfcfb64_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.12.5-hc3477c8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.12.6-hc3477c8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libxslt-1.1.39-h3df6e99_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libyarp-3.9.0-ha0ae21b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libyarp-3.9.0-ha0ae21b_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.2.13-hcfcfb64_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/llvm-meta-5.0.0-0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/lxml-4.9.4-py311h064e5ff_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/metis-5.1.0-h63175ca_1007.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/mkl-2024.0.0-h66d3029_49657.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/mumps-seq-5.6.2-h1f49738_4.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ninja-1.11.1-h91493d7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/numpy-1.26.4-py311h0b4df5a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openexr-3.2.2-h72640d8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/openh264-2.4.1-h63175ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/openmp-5.0.0-vc14_1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.2.1-hcfcfb64_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/osqp-eigen-0.8.1-h6d7489e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pcre2-10.42-h17e33f8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pixman-0.43.2-h63175ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.2.1-hcfcfb64_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/osqp-eigen-0.8.1-h6d7489e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pcre2-10.43-h17e33f8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pixman-0.43.4-h63175ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/portaudio-19.6.0-h63175ca_9.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pthreads-win32-2.9.1-hfa6e2cd_3.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/pugixml-1.14-h63175ca_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.11.7-h2628c8c_1_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.11.8-h2628c8c_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.11-4_cp311.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyyaml-5.4.1-py311ha68e1ae_4.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/qt-main-5.15.8-h9e85ed6_19.conda
@@ -954,24 +955,28 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/ruby-3.2.2-h20ad4f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/sdl-1.2.68-h21dd15a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/sdl2-2.28.5-h63175ca_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-69.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/snappy-1.1.10-hfb803bf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/soxr-0.1.3-hcfcfb64_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/svt-av1-1.8.0-h63175ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.11.0-h91493d7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tinyxml-2.6.2-h2d74725_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h5226925_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-hcf57466_18.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.38.33130-h82b7239_18.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.38.33130-hcb4865c_18.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vs2019_win-64-19.29.30139-he1865b1_18.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vswhere-3.1.4-h57928b3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.43.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/x264-1!164.3095-h8ffe710_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/x265-3.5-h2d74725_3.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/xz-5.2.6-h8d14728_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/yaml-0.2.5-h8ffe710_2.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/yarp-3.9.0-h57928b3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/yarp-python-3.9.0-py311h49b8dee_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/yarp-3.9.0-h57928b3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/yarp-python-3.9.0-py311h49b8dee_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ycm-cmake-modules-0.16.2-h63175ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zlib-1.2.13-hcfcfb64_5.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.5-h12be248_0.conda
@@ -1025,17 +1030,17 @@ packages:
 - kind: conda
   name: _sysroot_linux-aarch64_curr_repodata_hack
   version: '4'
-  build: h57d6b7b_13
-  build_number: 13
+  build: h57d6b7b_14
+  build_number: 14
   subdir: noarch
   noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/_sysroot_linux-aarch64_curr_repodata_hack-4-h57d6b7b_13.conda
-  sha256: 45eaba02c457c78d1bb2ff2cf90bb3f6f9c25de40f43d83936a58e349f247a2b
-  md5: 56cba32729a63e97bfb1ef958940ff07
+  url: https://conda.anaconda.org/conda-forge/noarch/_sysroot_linux-aarch64_curr_repodata_hack-4-h57d6b7b_14.conda
+  sha256: edac93a8e3beb9383abf508f66085505950bc89962116ef149558350a6213749
+  md5: 18f0bdf689b6f345fecddbebaed945d6
   license: LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0
   license_family: GPL
-  size: 20799
-  timestamp: 1682995515087
+  size: 21238
+  timestamp: 1708000885951
 - kind: conda
   name: ace
   version: 7.1.3
@@ -1098,32 +1103,34 @@ packages:
   timestamp: 1707133447836
 - kind: conda
   name: alsa-lib
-  version: 1.2.10
-  build: h31becfc_0
+  version: 1.2.11
+  build: h31becfc_1
+  build_number: 1
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/alsa-lib-1.2.10-h31becfc_0.conda
-  sha256: 4ecf0c2f8cbe1112e6b1b983ed3606759deecc31e9f1c2bb15d3ceacea633047
-  md5: bbe8d80c6d5bfbcc4869470954f35de4
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/alsa-lib-1.2.11-h31becfc_1.conda
+  sha256: d062bc712dd307714dfdb0f7da095a510c138c5db76321494a516ac127f9e5cf
+  md5: 76bf292a85a0556cef4f500420cabe6c
   depends:
   - libgcc-ng >=12
   license: LGPL-2.1-or-later
   license_family: GPL
-  size: 584257
-  timestamp: 1693609522269
+  size: 584152
+  timestamp: 1709396718705
 - kind: conda
   name: alsa-lib
-  version: 1.2.10
-  build: hd590300_0
+  version: 1.2.11
+  build: hd590300_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.10-hd590300_0.conda
-  sha256: 51147922bad9d3176e780eb26f748f380cd3184896a9f9125d8ac64fe330158b
-  md5: 75dae9a4201732aa78a530b826ee5fe0
+  url: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.11-hd590300_1.conda
+  sha256: 0e2b75b9834a6e520b13db516f7cf5c9cea8f0bbc9157c978444173dacb98fec
+  md5: 0bb492cca54017ea314b809b1ee3a176
   depends:
   - libgcc-ng >=12
   license: LGPL-2.1-or-later
   license_family: GPL
-  size: 554938
-  timestamp: 1693607226431
+  size: 554699
+  timestamp: 1709396557528
 - kind: conda
   name: ampl-mp
   version: 3.1.0
@@ -1196,78 +1203,78 @@ packages:
   timestamp: 1645057976681
 - kind: conda
   name: aom
-  version: 3.8.1
+  version: 3.8.2
   build: h0425590_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/aom-3.8.1-h0425590_0.conda
-  sha256: 26b77fbfc09ae8924d94404177c2fc1c262b78cea775b58f429340341163c7e9
-  md5: 2ab54b9919d04aaa57dd6bf2b803dea8
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/aom-3.8.2-h0425590_0.conda
+  sha256: 04458a9a9b3dd71ac201c9570948f31dedbd7b336b9c66a047e1f3c79b830de3
+  md5: 20efd6f87ac241a7d9fd551cd4e26203
   depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   license: BSD-2-Clause
   license_family: BSD
-  size: 3219181
-  timestamp: 1706649146839
+  size: 3221283
+  timestamp: 1710388193204
 - kind: conda
   name: aom
-  version: 3.8.1
+  version: 3.8.2
   build: h078ce10_0
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aom-3.8.1-h078ce10_0.conda
-  sha256: 8a531d2ea3080b298231ebed2e0251e4bb861c4a7a1e91a2f7a5532335199139
-  md5: b84b3ce3dd4f5185dad3c00e03df598d
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aom-3.8.2-h078ce10_0.conda
+  sha256: d3a6cb707373a8d2d219259ad017a35c20fc3618e39c87db0d6200af0f984379
+  md5: 3c5057d1d4494caab891ed6f276c3f63
   depends:
-  - libcxx >=15
+  - libcxx >=16
   license: BSD-2-Clause
   license_family: BSD
-  size: 2203496
-  timestamp: 1706649351976
+  size: 2204439
+  timestamp: 1710388305837
 - kind: conda
   name: aom
-  version: 3.8.1
+  version: 3.8.2
   build: h59595ed_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/aom-3.8.1-h59595ed_0.conda
-  sha256: 42fd8fc28735deac6c578c9a07fc4c6b1912ba4300b63631e64fc0a6e0f22370
-  md5: 50871627bc8ba3a46ec5650f4a5b9d43
+  url: https://conda.anaconda.org/conda-forge/linux-64/aom-3.8.2-h59595ed_0.conda
+  sha256: 49b1352e2b9710b7b5400c0f2a86c0bb805091ecfc6c84d3dbf064effe33bfbf
+  md5: 625e1fed28a5139aed71b3a76117ef84
   depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   license: BSD-2-Clause
   license_family: BSD
-  size: 2700689
-  timestamp: 1706649284348
+  size: 2696998
+  timestamp: 1710388229587
 - kind: conda
   name: aom
-  version: 3.8.1
+  version: 3.8.2
   build: h63175ca_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/aom-3.8.1-h63175ca_0.conda
-  sha256: 35ffd4da72759b3ba61cd75050f902777926bccb7d24987585d9c7e3e77795a6
-  md5: ab5e0ac3be5f9aa615d0a52c5efeb196
+  url: https://conda.anaconda.org/conda-forge/win-64/aom-3.8.2-h63175ca_0.conda
+  sha256: dd79f4e3660ab169f4e2d9bf2d9e74001dcf6dfaa8d1168373b3450af5282286
+  md5: 6691dd6833a29c95e3a16e08841a0f43
   depends:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: BSD-2-Clause
   license_family: BSD
-  size: 1955126
-  timestamp: 1706649889826
+  size: 1968537
+  timestamp: 1710388705950
 - kind: conda
   name: aom
-  version: 3.8.1
+  version: 3.8.2
   build: h73e2aa4_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/aom-3.8.1-h73e2aa4_0.conda
-  sha256: ee8677cc9bea352c7fe12d5f42f0d277cee1d7e7f5518ae728dc1befc75fe49a
-  md5: 3194f8209de31e1e09f2ae915c5288d4
+  url: https://conda.anaconda.org/conda-forge/osx-64/aom-3.8.2-h73e2aa4_0.conda
+  sha256: 967d05b46e0a8153c57070a94262d38ffc03378803c1faa0bad258e8635d3775
+  md5: a519a6b9f8f0e2ce1b4ee77cbc6a0a09
   depends:
-  - libcxx >=15
+  - libcxx >=16
   license: BSD-2-Clause
   license_family: BSD
-  size: 2756364
-  timestamp: 1706649344166
+  size: 2922373
+  timestamp: 1710388791338
 - kind: conda
   name: assimp
   version: 5.3.1
@@ -1453,35 +1460,35 @@ packages:
 - kind: conda
   name: binutils_linux-64
   version: '2.40'
-  build: hbdbef99_2
-  build_number: 2
+  build: hdade7a5_3
+  build_number: 3
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.40-hbdbef99_2.conda
-  sha256: 333f3339d94c93bcc02a723e3e460cb6ff6075e05f5247e15bef5dcdcec541a3
-  md5: adfebae9fdc63a598495dfe3b006973a
+  url: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.40-hdade7a5_3.conda
+  sha256: d114b825acef51c1d065ca0a17f97e0e856c48765aecf2f8f164935635013dd2
+  md5: 2d9a60578bc28469d9aeef9aea5520c3
   depends:
   - binutils_impl_linux-64 2.40.*
   - sysroot_linux-64
   license: BSD-3-Clause
   license_family: BSD
-  size: 28178
-  timestamp: 1694604071236
+  size: 28868
+  timestamp: 1710259805994
 - kind: conda
   name: binutils_linux-aarch64
   version: '2.40'
-  build: h94bbfa1_2
-  build_number: 2
+  build: h95d2017_3
+  build_number: 3
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_linux-aarch64-2.40-h94bbfa1_2.conda
-  sha256: 239fa4ec306dc21459bc05a3cc411a318ba8eb45e31dc3e846f7e06ab7062368
-  md5: 1963001481680dde1bcc33e722172d14
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_linux-aarch64-2.40-h95d2017_3.conda
+  sha256: cd839ad41a573ebd84552b9ed946ea99ae48f8a07f4e38b8725022ff881f767c
+  md5: 561a4c45334781c962db079457e6f0f0
   depends:
   - binutils_impl_linux-aarch64 2.40.*
   - sysroot_linux-aarch64
   license: BSD-3-Clause
   license_family: BSD
-  size: 28319
-  timestamp: 1694604100748
+  size: 28888
+  timestamp: 1710259827989
 - kind: conda
   name: bzip2
   version: 1.0.8
@@ -1557,56 +1564,56 @@ packages:
   timestamp: 1699279927352
 - kind: conda
   name: c-ares
-  version: 1.26.0
+  version: 1.27.0
   build: h10d778d_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.26.0-h10d778d_0.conda
-  sha256: 4b01708ed02f3e2cf9e8919a6fc1d3116cdf84c1a771294031e880f54235f47c
-  md5: 04a8ab3d4f9a9446b286c4a90f665148
+  url: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.27.0-h10d778d_0.conda
+  sha256: a53e14c071dcce756ce80673f2a90a1c6dff695a26bc9f5e54d56b55e76ee3dc
+  md5: 713dd57081dfe8535eb961b45ed26a0c
   license: MIT
   license_family: MIT
-  size: 147816
-  timestamp: 1706300301840
+  size: 148568
+  timestamp: 1708685147963
 - kind: conda
   name: c-ares
-  version: 1.26.0
+  version: 1.27.0
   build: h31becfc_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/c-ares-1.26.0-h31becfc_0.conda
-  sha256: d9eebd51d89c68789957e92d73c0ca4651aef859c6caa5899dd0c8d46b936d8c
-  md5: f5094fec0d7d788152c7503140929bf2
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/c-ares-1.27.0-h31becfc_0.conda
+  sha256: 4152e674377179b35d59ddd9218411477a206ecff5f5939dfc963f997cf3b8b8
+  md5: f03f76a77d690f2d31ce12e7b4e12ae4
   depends:
   - libgcc-ng >=12
   license: MIT
   license_family: MIT
-  size: 168655
-  timestamp: 1706299916731
+  size: 170421
+  timestamp: 1708684764494
 - kind: conda
   name: c-ares
-  version: 1.26.0
+  version: 1.27.0
   build: h93a5062_0
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.26.0-h93a5062_0.conda
-  sha256: 1dfdbac985a74a905f2bcf62f13ce758a8356e50d4b28ddbc2027df8580717d8
-  md5: 58b9187431de0a2ffebc907f4590e2e5
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.27.0-h93a5062_0.conda
+  sha256: a168e53ee462980cd78b324e055afdd00080ded378ca974969a0917eb4ae1ccb
+  md5: d3579ba506791b1f8f8a16cfc2885326
   license: MIT
   license_family: MIT
-  size: 145325
-  timestamp: 1706300196534
+  size: 145697
+  timestamp: 1708685057216
 - kind: conda
   name: c-ares
-  version: 1.26.0
+  version: 1.27.0
   build: hd590300_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.26.0-hd590300_0.conda
-  sha256: 3771589a91303710a59d1d40bbcdca43743969fe993ea576538ba375ac8ab0fa
-  md5: a86d90025198fd411845fc245ebc06c8
+  url: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.27.0-hd590300_0.conda
+  sha256: 2a5866b19d28cb963fab291a62ff1c884291b9d6f59de14643e52f103e255749
+  md5: f6afff0e9ee08d2f1b897881a4f38cdb
   depends:
   - libgcc-ng >=12
   license: MIT
   license_family: MIT
-  size: 162725
-  timestamp: 1706299899438
+  size: 163578
+  timestamp: 1708684786032
 - kind: conda
   name: c-compiler
   version: 1.7.0
@@ -1886,95 +1893,91 @@ packages:
   timestamp: 1694652027818
 - kind: conda
   name: cctools
-  version: 973.0.1
-  build: h40f6528_16
-  build_number: 16
+  version: '986'
+  build: h40f6528_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/cctools-973.0.1-h40f6528_16.conda
-  sha256: ef3afa0ca2e159360575d5de6cba102494d2dd03c0fda77e858ae9fba73b9e61
-  md5: b7234c329d4503600b032f168f4b65e7
+  url: https://conda.anaconda.org/conda-forge/osx-64/cctools-986-h40f6528_0.conda
+  sha256: 4eac1d10ddafb1dc277ddff304a7d314607c7dc99d7a77d69ed75f8fcbdf93d4
+  md5: b7a2ca0062a6ee8bc4e83ec887bef942
   depends:
-  - cctools_osx-64 973.0.1 ha1c5b94_16
-  - ld64 609 ha02d983_16
+  - cctools_osx-64 986 ha1c5b94_0
+  - ld64 711 ha02d983_0
   - libllvm16 >=16.0.6,<16.1.0a0
   license: APSL-2.0
   license_family: Other
-  size: 22144
-  timestamp: 1706798167450
+  size: 21663
+  timestamp: 1710466476542
 - kind: conda
   name: cctools
-  version: 973.0.1
-  build: h4faf515_16
-  build_number: 16
+  version: '986'
+  build: h4faf515_0
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/cctools-973.0.1-h4faf515_16.conda
-  sha256: eb62575b0a4f306ed4fb8b874f109af7c622013eace2d9e533d6b3c88fea6c42
-  md5: 5fd71c6d5cef61d41af51b460265ef6f
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/cctools-986-h4faf515_0.conda
+  sha256: 505471dfa37dc42ba1a2c4cf65d4c4abe4c36164c8fcb0a375e3c4f3550ab3ee
+  md5: d81c4480e8445b13129024191231e6c5
   depends:
-  - cctools_osx-arm64 973.0.1 h62378fb_16
-  - ld64 609 h634c8be_16
+  - cctools_osx-arm64 986 h62378fb_0
+  - ld64 711 h634c8be_0
   - libllvm16 >=16.0.6,<16.1.0a0
   license: APSL-2.0
   license_family: Other
-  size: 22117
-  timestamp: 1706798232449
+  size: 21683
+  timestamp: 1710466813384
 - kind: conda
   name: cctools_osx-64
-  version: 973.0.1
-  build: ha1c5b94_16
-  build_number: 16
+  version: '986'
+  build: ha1c5b94_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/cctools_osx-64-973.0.1-ha1c5b94_16.conda
-  sha256: aa69f18388246169ac603148501bdd507bf935e97f384cf8f78ef94e3b296158
-  md5: 00eb71204323fa6449b38dd34ab9c65d
+  url: https://conda.anaconda.org/conda-forge/osx-64/cctools_osx-64-986-ha1c5b94_0.conda
+  sha256: 16ef6a8dd367d7d4d7b3446f73ed95b07603d6b5b3256c3acab9b3a9006ef7eb
+  md5: a8951de2506df5649f5a3295fdfd9f2c
   depends:
-  - ld64_osx-64 >=609,<610.0a0
+  - ld64_osx-64 >=711,<712.0a0
   - libcxx
   - libllvm16 >=16.0.6,<16.1.0a0
   - libzlib >=1.2.13,<1.3.0a0
   - sigtool
   constrains:
-  - cctools 973.0.1.*
+  - ld64 711.*
+  - cctools 986.*
   - clang 16.0.*
-  - ld64 609.*
   license: APSL-2.0
   license_family: Other
-  size: 1116102
-  timestamp: 1706798100072
+  size: 1118961
+  timestamp: 1710466421642
 - kind: conda
   name: cctools_osx-arm64
-  version: 973.0.1
-  build: h62378fb_16
-  build_number: 16
+  version: '986'
+  build: h62378fb_0
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/cctools_osx-arm64-973.0.1-h62378fb_16.conda
-  sha256: cdd2ce1a4d17084096626e9d074f19ab5abef1e330901358533455e12895572d
-  md5: be98824be7fa378bd06cb2670ad0b4cc
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/cctools_osx-arm64-986-h62378fb_0.conda
+  sha256: 35907653456fdd854b426060980025689670784c677e2bbecd2fcaf983cfa37c
+  md5: cb85035a5eceb3a0d3becc1026dbb31d
   depends:
-  - ld64_osx-arm64 >=609,<610.0a0
+  - ld64_osx-arm64 >=711,<712.0a0
   - libcxx
   - libllvm16 >=16.0.6,<16.1.0a0
   - libzlib >=1.2.13,<1.3.0a0
   - sigtool
   constrains:
-  - cctools 973.0.1.*
   - clang 16.0.*
-  - ld64 609.*
+  - ld64 711.*
+  - cctools 986.*
   license: APSL-2.0
   license_family: Other
-  size: 1124537
-  timestamp: 1706798177156
+  size: 1127544
+  timestamp: 1710466751857
 - kind: conda
   name: clang
   version: 16.0.6
-  build: h30cc82d_5
-  build_number: 5
+  build: h30cc82d_6
+  build_number: 6
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/clang-16.0.6-h30cc82d_5.conda
-  sha256: 09d5c870768512e3439bf2a33346a0092fc728bbf2ef3efba1c187220636507d
-  md5: f3bbbf40f13424248d9ff9650d9379af
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/clang-16.0.6-h30cc82d_6.conda
+  sha256: 7002fd391945934f6679863de5e22bd1cd329c626511355d943b83b1860162c3
+  md5: 7b09b50fbcd7e154e45e05cf2f81d7f7
   depends:
-  - clang-16 16.0.6 default_he012953_5
+  - clang-16 16.0.6 default_he012953_6
   constrains:
   - clang-tools 16.0.6.*
   - llvm 16.0.6.*
@@ -1982,19 +1985,19 @@ packages:
   - llvmdev 16.0.6.*
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 21610
-  timestamp: 1706894245139
+  size: 21987
+  timestamp: 1711067164939
 - kind: conda
   name: clang
   version: 16.0.6
-  build: hdae98eb_5
-  build_number: 5
+  build: hdae98eb_6
+  build_number: 6
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/clang-16.0.6-hdae98eb_5.conda
-  sha256: df7180f4ee7bed92849cb36e46a9641e71eb6c99b990dedc48f7469c080d5f5f
-  md5: 5f020dce5a00342141d87f952c9c0282
+  url: https://conda.anaconda.org/conda-forge/osx-64/clang-16.0.6-hdae98eb_6.conda
+  sha256: 71d2fa8174aedf549313fccf6fbc63ef08fdc898891ffba56dd376226649fa13
+  md5: 884e7b24306e4f21b7ee08dabadb2ecc
   depends:
-  - clang-16 16.0.6 default_h7151d67_5
+  - clang-16 16.0.6 default_h7151d67_6
   constrains:
   - clang-tools 16.0.6.*
   - llvm 16.0.6.*
@@ -2002,41 +2005,41 @@ packages:
   - llvmdev 16.0.6.*
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 21576
-  timestamp: 1706894282581
+  size: 21919
+  timestamp: 1711067981416
 - kind: conda
   name: clang-16
   version: 16.0.6
-  build: default_h7151d67_5
-  build_number: 5
+  build: default_h7151d67_6
+  build_number: 6
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/clang-16-16.0.6-default_h7151d67_5.conda
-  sha256: 1ddcdef73115b5584f171a0182c1fdbbf168c667d8dcde19178d18f5c837fb43
-  md5: e132cf98d775fd7ec3b43859373bc070
+  url: https://conda.anaconda.org/conda-forge/osx-64/clang-16-16.0.6-default_h7151d67_6.conda
+  sha256: 5a8dcab3b23552c6e93967ecc7e13c0e40c3f8e96ba26a4d942fa528ed5b449e
+  md5: 1c298568c30efe7d9369c7c15b748461
   depends:
-  - libclang-cpp16 16.0.6 default_h7151d67_5
+  - libclang-cpp16 16.0.6 default_h7151d67_6
   - libcxx >=16.0.6
   - libllvm16 >=16.0.6,<16.1.0a0
   constrains:
-  - clangxx 16.0.6
-  - clangdev 16.0.6
-  - llvm-tools 16.0.6
   - clang-tools 16.0.6
+  - clangxx 16.0.6
+  - llvm-tools 16.0.6
+  - clangdev 16.0.6
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 692571
-  timestamp: 1706894157239
+  size: 694124
+  timestamp: 1711067822905
 - kind: conda
   name: clang-16
   version: 16.0.6
-  build: default_he012953_5
-  build_number: 5
+  build: default_he012953_6
+  build_number: 6
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/clang-16-16.0.6-default_he012953_5.conda
-  sha256: 38ce232aab29ac5ab6ec6dcbeae855d331c192f756da19c1c95db45e9ad28cbb
-  md5: 5986bf8dc369fc4f55f0393bf94b4494
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/clang-16-16.0.6-default_he012953_6.conda
+  sha256: 7742b35001e7d81534a3ed63ce55da12998d1037d5ad594cf478d9fbabec8f7e
+  md5: 87c53ef6d2f5fe1427a9ef448dff1d09
   depends:
-  - libclang-cpp16 16.0.6 default_he012953_5
+  - libclang-cpp16 16.0.6 default_he012953_6
   - libcxx >=16.0.6
   - libllvm16 >=16.0.6,<16.1.0a0
   constrains:
@@ -2046,17 +2049,17 @@ packages:
   - clangxx 16.0.6
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 692537
-  timestamp: 1706894104516
+  size: 693018
+  timestamp: 1711067020001
 - kind: conda
   name: clang_impl_osx-64
   version: 16.0.6
-  build: h8787910_9
-  build_number: 9
+  build: h8787910_11
+  build_number: 11
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/clang_impl_osx-64-16.0.6-h8787910_9.conda
-  sha256: 3aeee43c777d67a334a7917a9a6cc43c67fabbf8acbceca31e2bef0702f0c81e
-  md5: 36dc72f20205cf43f63765334a5f0be7
+  url: https://conda.anaconda.org/conda-forge/osx-64/clang_impl_osx-64-16.0.6-h8787910_11.conda
+  sha256: 2174b2a01fb60da87b383405100bb6d5eac54fb8e84d2ce5f6a0488627c055fc
+  md5: ed9c90270c77481fc4cfccd0891d62a8
   depends:
   - cctools_osx-64
   - clang 16.0.6.*
@@ -2065,17 +2068,17 @@ packages:
   - llvm-tools 16.0.6.*
   license: BSD-3-Clause
   license_family: BSD
-  size: 17576
-  timestamp: 1706817889548
+  size: 17384
+  timestamp: 1711079620447
 - kind: conda
   name: clang_impl_osx-arm64
   version: 16.0.6
-  build: hc421ffc_9
-  build_number: 9
+  build: hc421ffc_11
+  build_number: 11
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/clang_impl_osx-arm64-16.0.6-hc421ffc_9.conda
-  sha256: db8d0f1418bd5a6284da7137f278b5ec373b8382791aa550b4af711f7e079f8b
-  md5: 6ba30ea4b866e03cb834447d934d8d5f
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/clang_impl_osx-arm64-16.0.6-hc421ffc_11.conda
+  sha256: b414939c7cdd4575429db2678651b370348561417162dd2dd1570d7afeac267e
+  md5: c211c6998c1d79131a82455abc70c0f7
   depends:
   - cctools_osx-arm64
   - clang 16.0.6.*
@@ -2084,136 +2087,136 @@ packages:
   - llvm-tools 16.0.6.*
   license: BSD-3-Clause
   license_family: BSD
-  size: 17585
-  timestamp: 1706831903732
+  size: 17559
+  timestamp: 1711079687149
 - kind: conda
   name: clang_osx-64
   version: 16.0.6
-  build: hb91bd55_9
-  build_number: 9
+  build: hb91bd55_11
+  build_number: 11
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/clang_osx-64-16.0.6-hb91bd55_9.conda
-  sha256: 970a919b17f6c5c04624b6a0269211bd3d7b41b3177e50f5dd7b5d036f4c25c9
-  md5: 3ebda8406efd8c09ebeeba80396ac6bd
+  url: https://conda.anaconda.org/conda-forge/osx-64/clang_osx-64-16.0.6-hb91bd55_11.conda
+  sha256: 86b4928261c21546b9bae5a58975a5ade6256be0aacd8d0f7a3126150bad3967
+  md5: 24123b15e9c0dad9c0d5fd9da0b4c7a9
   depends:
-  - clang_impl_osx-64 16.0.6 h8787910_9
+  - clang_impl_osx-64 16.0.6 h8787910_11
   license: BSD-3-Clause
   license_family: BSD
-  size: 20647
-  timestamp: 1706817901570
+  size: 20419
+  timestamp: 1711079628326
 - kind: conda
   name: clang_osx-arm64
   version: 16.0.6
-  build: h54d7cd3_9
-  build_number: 9
+  build: h54d7cd3_11
+  build_number: 11
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/clang_osx-arm64-16.0.6-h54d7cd3_9.conda
-  sha256: d712ced3aaf31275d3ca1f0b3dbe21ca82ba169e35a5e3e8115a67b381be2197
-  md5: 5df587e67413858308caac4c86b9c92a
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/clang_osx-arm64-16.0.6-h54d7cd3_11.conda
+  sha256: e5b2f86b89fd0b84fbf9d8eac628110d32fcd6cda0b5858f697033ffd67bdce8
+  md5: df62131bebfb7d6d086610373926aeb4
   depends:
-  - clang_impl_osx-arm64 16.0.6 hc421ffc_9
+  - clang_impl_osx-arm64 16.0.6 hc421ffc_11
   license: BSD-3-Clause
   license_family: BSD
-  size: 20568
-  timestamp: 1706831915550
+  size: 20564
+  timestamp: 1711079695189
 - kind: conda
   name: clangxx
   version: 16.0.6
-  build: default_h4cf2255_5
-  build_number: 5
+  build: default_h4cf2255_6
+  build_number: 6
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/clangxx-16.0.6-default_h4cf2255_5.conda
-  sha256: d5cdb838c3b67c4fdf1683e7659d011db228d5f762f85e2833e1c67c7c5cccdc
-  md5: 83d1eb2693ad27dec744ac21f1ad9812
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/clangxx-16.0.6-default_h4cf2255_6.conda
+  sha256: e0d5a68e361853221257d2842d431c45e61d0e41597087f7f311b4fc5fe13fa5
+  md5: 2c724daf018dc99394fdbb43d93bb23c
   depends:
-  - clang 16.0.6 h30cc82d_5
+  - clang 16.0.6 h30cc82d_6
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 21761
-  timestamp: 1706894272948
+  size: 22080
+  timestamp: 1711067198960
 - kind: conda
   name: clangxx
   version: 16.0.6
-  build: default_h7151d67_5
-  build_number: 5
+  build: default_h7151d67_6
+  build_number: 6
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/clangxx-16.0.6-default_h7151d67_5.conda
-  sha256: 9aafb8802adfe804ae38b66b01b00e133f1c14713ed1abed2710ed95ddbaa3e7
-  md5: 8c3fb5d2005174683f3958383643e335
+  url: https://conda.anaconda.org/conda-forge/osx-64/clangxx-16.0.6-default_h7151d67_6.conda
+  sha256: 422e471cb572b977c7ff3aec6c89fc6af365c5e5a4e29feaa780519c9a20e84d
+  md5: cc8c007a529a7cfaa5d29d8599df3fe6
   depends:
-  - clang 16.0.6 hdae98eb_5
+  - clang 16.0.6 hdae98eb_6
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 21699
-  timestamp: 1706894307583
+  size: 22112
+  timestamp: 1711068021002
 - kind: conda
   name: clangxx_impl_osx-64
   version: 16.0.6
-  build: h6d92fbe_9
-  build_number: 9
+  build: h6d92fbe_11
+  build_number: 11
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/clangxx_impl_osx-64-16.0.6-h6d92fbe_9.conda
-  sha256: d0d712b2ea90fd4e0c7215cb319830496ced15c56ee208f6ebba5e0d0b21f765
-  md5: bfea277f004e2815ebd59294e9c08746
+  url: https://conda.anaconda.org/conda-forge/osx-64/clangxx_impl_osx-64-16.0.6-h6d92fbe_11.conda
+  sha256: 944d9cb8052eefec3182380454bf8a3f1b2a93c5ea992f8681ef45e975492983
+  md5: a658c595675bde00373347b22a974810
   depends:
-  - clang_osx-64 16.0.6 hb91bd55_9
+  - clang_osx-64 16.0.6 hb91bd55_11
   - clangxx 16.0.6.*
   - libcxx >=16
   - libllvm16 >=16.0.6,<16.1.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 17667
-  timestamp: 1706817919437
+  size: 17481
+  timestamp: 1711079694850
 - kind: conda
   name: clangxx_impl_osx-arm64
   version: 16.0.6
-  build: hcd7bac0_9
-  build_number: 9
+  build: hcd7bac0_11
+  build_number: 11
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/clangxx_impl_osx-arm64-16.0.6-hcd7bac0_9.conda
-  sha256: db061d8e7d6c1410cb188bbc5485d630cb076ae6981dca42def058822497536f
-  md5: 949089893ce76c6d743b77d6eec251bf
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/clangxx_impl_osx-arm64-16.0.6-hcd7bac0_11.conda
+  sha256: 8c34bfd000ead5989535ce60b01471e1c008915fd12f23c364b9665a84d5c160
+  md5: 3dbd1a1276d73e09de7f0f047a8a661b
   depends:
-  - clang_osx-arm64 16.0.6 h54d7cd3_9
+  - clang_osx-arm64 16.0.6 h54d7cd3_11
   - clangxx 16.0.6.*
   - libcxx >=16
   - libllvm16 >=16.0.6,<16.1.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 17692
-  timestamp: 1706832802039
+  size: 17670
+  timestamp: 1711079761701
 - kind: conda
   name: clangxx_osx-64
   version: 16.0.6
-  build: hb91bd55_9
-  build_number: 9
+  build: hb91bd55_11
+  build_number: 11
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/clangxx_osx-64-16.0.6-hb91bd55_9.conda
-  sha256: 9225222bf1cd611e63f2b68c0838325f2fd5be930f81a7f3563ff5e2818955a5
-  md5: e7297accf408701c298308eeae807c5e
+  url: https://conda.anaconda.org/conda-forge/osx-64/clangxx_osx-64-16.0.6-hb91bd55_11.conda
+  sha256: 664e769eecf1d07d07729f4902ef07f2f5b11bc033adfd84637ce9742f3267a1
+  md5: e49aad30263abdcb785e610981b7c2c7
   depends:
-  - clang_osx-64 16.0.6 hb91bd55_9
-  - clangxx_impl_osx-64 16.0.6 h6d92fbe_9
+  - clang_osx-64 16.0.6 hb91bd55_11
+  - clangxx_impl_osx-64 16.0.6 h6d92fbe_11
   license: BSD-3-Clause
   license_family: BSD
-  size: 19414
-  timestamp: 1706817934575
+  size: 19169
+  timestamp: 1711079704320
 - kind: conda
   name: clangxx_osx-arm64
   version: 16.0.6
-  build: h54d7cd3_9
-  build_number: 9
+  build: h54d7cd3_11
+  build_number: 11
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/clangxx_osx-arm64-16.0.6-h54d7cd3_9.conda
-  sha256: ee39efac1691f9f2d646bc64f04548179577e3c65c1ca5947cd4f944e4ccbdee
-  md5: e47d40e35f855ad41af35ba60937e41c
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/clangxx_osx-arm64-16.0.6-h54d7cd3_11.conda
+  sha256: b3b96d2f7edde88548c29514fef327e7f72e2497d07d649e079ac1ecaa0511dc
+  md5: 6ec1b04f1f9a907794d3b42f326343f1
   depends:
-  - clang_osx-arm64 16.0.6 h54d7cd3_9
-  - clangxx_impl_osx-arm64 16.0.6 hcd7bac0_9
+  - clang_osx-arm64 16.0.6 h54d7cd3_11
+  - clangxx_impl_osx-arm64 16.0.6 hcd7bac0_11
   license: BSD-3-Clause
   license_family: BSD
-  size: 19330
-  timestamp: 1706832814124
+  size: 19268
+  timestamp: 1711079770802
 - kind: conda
   name: compiler-rt
   version: 16.0.6
@@ -2611,184 +2614,85 @@ packages:
   timestamp: 1690273089254
 - kind: conda
   name: expat
-  version: 2.5.0
-  build: h63175ca_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/expat-2.5.0-h63175ca_1.conda
-  sha256: 3bcd88290cd462d5573c2923c796599d0dece2ff9d9c9d6c914d31e9c5881aaf
-  md5: 87c77fe1b445aedb5c6d207dd236fa3e
-  depends:
-  - libexpat 2.5.0 h63175ca_1
-  license: MIT
-  license_family: MIT
-  size: 226571
-  timestamp: 1680190888036
-- kind: conda
-  name: expat
-  version: 2.5.0
-  build: hb7217d7_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/expat-2.5.0-hb7217d7_1.conda
-  sha256: 9f06afbe4604decf6a2e8e7e87f5ca218a3e9049d57d5b3fcd538ca6240d21a0
-  md5: 624fa0dd6fdeaa650b71a62296fdfedf
-  depends:
-  - libexpat 2.5.0 hb7217d7_1
-  license: MIT
-  license_family: MIT
-  size: 117851
-  timestamp: 1680190940654
-- kind: conda
-  name: expat
-  version: 2.5.0
-  build: hcb278e6_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/expat-2.5.0-hcb278e6_1.conda
-  sha256: 36dfeb4375059b3bba75ce9b38c29c69fd257342a79e6cf20e9f25c1523f785f
-  md5: 8b9b5aca60558d02ddaa09d599e55920
-  depends:
-  - libexpat 2.5.0 hcb278e6_1
-  - libgcc-ng >=12
-  license: MIT
-  license_family: MIT
-  size: 136778
-  timestamp: 1680190541750
-- kind: conda
-  name: expat
-  version: 2.5.0
-  build: hd600fc2_1
-  build_number: 1
+  version: 2.6.2
+  build: h2f0025b_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/expat-2.5.0-hd600fc2_1.conda
-  sha256: a00bae815836f8fc73e47701c25998be81284dcefab28e002efde68e0bb7eee0
-  md5: 6dfca4be3e0080934b1105d009747e98
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/expat-2.6.2-h2f0025b_0.conda
+  sha256: a7a998faf6b9ed71d8c5c67f996e7faa52a7b9b02ed2d2f2ab6cfa1db8e5aca4
+  md5: 6d31100ba1e12773b4f1ef0693fb0169
   depends:
-  - libexpat 2.5.0 hd600fc2_1
+  - libexpat 2.6.2 h2f0025b_0
   - libgcc-ng >=12
   license: MIT
   license_family: MIT
-  size: 126442
-  timestamp: 1680190687808
+  size: 128302
+  timestamp: 1710362329008
 - kind: conda
   name: expat
-  version: 2.5.0
-  build: hf0c8a7f_1
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/expat-2.5.0-hf0c8a7f_1.conda
-  sha256: 15c04a5a690b337b50fb7550cce057d843cf94dd0109d576ec9bc3448a8571d0
-  md5: e12630038077877cbb6c7851e139c17c
+  version: 2.6.2
+  build: h59595ed_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/expat-2.6.2-h59595ed_0.conda
+  sha256: 89916c536ae5b85bb8bf0cfa27d751e274ea0911f04e4a928744735c14ef5155
+  md5: 53fb86322bdb89496d7579fe3f02fd61
   depends:
-  - libexpat 2.5.0 hf0c8a7f_1
+  - libexpat 2.6.2 h59595ed_0
+  - libgcc-ng >=12
   license: MIT
   license_family: MIT
-  size: 120323
-  timestamp: 1680191057827
+  size: 137627
+  timestamp: 1710362144873
 - kind: conda
-  name: ffmpeg
-  version: 6.1.1
-  build: gpl_h31ea89b_104
-  build_number: 104
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ffmpeg-6.1.1-gpl_h31ea89b_104.conda
-  sha256: aa69abad947cf935ce8973687592d58c66f81c1f9634e2043cbab472d2cd78f3
-  md5: 80205476e9cbfc243e0f45369f9d347e
+  name: expat
+  version: 2.6.2
+  build: h63175ca_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/expat-2.6.2-h63175ca_0.conda
+  sha256: f5a13d4bc591a4dc210954f492dd59a0ecf9b9d2ab28bf2ece755ca8f69ec1b4
+  md5: 52f9dec6758ceb8ce0ea8af9fa13eb1a
   depends:
-  - aom >=3.8.1,<3.9.0a0
-  - bzip2 >=1.0.8,<2.0a0
-  - dav1d >=1.2.1,<1.2.2.0a0
-  - fontconfig >=2.14.2,<3.0a0
-  - fonts-conda-ecosystem
-  - freetype >=2.12.1,<3.0a0
-  - gmp >=6.3.0,<7.0a0
-  - gnutls >=3.7.9,<3.8.0a0
-  - harfbuzz >=8.3.0,<9.0a0
-  - lame >=3.100,<3.101.0a0
-  - libass >=0.17.1,<0.17.2.0a0
-  - libcxx >=16
-  - libiconv >=1.17,<2.0a0
-  - libopenvino >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-arm-cpu-plugin >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-auto-batch-plugin >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-auto-plugin >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-hetero-plugin >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-ir-frontend >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-onnx-frontend >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-paddle-frontend >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-pytorch-frontend >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-tensorflow-frontend >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-tensorflow-lite-frontend >=2023.3.0,<2023.3.1.0a0
-  - libopus >=1.3.1,<2.0a0
-  - libvpx >=1.13.1,<1.14.0a0
-  - libxml2 >=2.12.4,<3.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - openh264 >=2.4.1,<2.4.2.0a0
-  - svt-av1 >=1.8.0,<1.8.1.0a0
-  - x264 >=1!164.3095,<1!165
-  - x265 >=3.5,<3.6.0a0
-  - xz >=5.2.6,<6.0a0
-  license: GPL-2.0-or-later
-  license_family: GPL
-  size: 21451640
-  timestamp: 1706919814873
+  - libexpat 2.6.2 h63175ca_0
+  license: MIT
+  license_family: MIT
+  size: 229627
+  timestamp: 1710362661692
 - kind: conda
-  name: ffmpeg
-  version: 6.1.1
-  build: gpl_h73cf981_104
-  build_number: 104
+  name: expat
+  version: 2.6.2
+  build: h73e2aa4_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/ffmpeg-6.1.1-gpl_h73cf981_104.conda
-  sha256: b018f5d1243b2c7051913f34b009ffdd801eae6f8f06ae246087012f64117498
-  md5: 4bd5cae498e5dd672143414e2b21a5c7
+  url: https://conda.anaconda.org/conda-forge/osx-64/expat-2.6.2-h73e2aa4_0.conda
+  sha256: 0fd1befb18d9d937358a90d5b8f97ac2402761e9d4295779cbad9d7adfb47976
+  md5: dc0882915da2ec74696ad87aa2350f27
   depends:
-  - aom >=3.8.1,<3.9.0a0
-  - bzip2 >=1.0.8,<2.0a0
-  - dav1d >=1.2.1,<1.2.2.0a0
-  - fontconfig >=2.14.2,<3.0a0
-  - fonts-conda-ecosystem
-  - freetype >=2.12.1,<3.0a0
-  - gmp >=6.3.0,<7.0a0
-  - gnutls >=3.7.9,<3.8.0a0
-  - harfbuzz >=8.3.0,<9.0a0
-  - lame >=3.100,<3.101.0a0
-  - libass >=0.17.1,<0.17.2.0a0
-  - libcxx >=16
-  - libiconv >=1.17,<2.0a0
-  - libopenvino >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-auto-batch-plugin >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-auto-plugin >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-hetero-plugin >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-intel-cpu-plugin >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-ir-frontend >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-onnx-frontend >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-paddle-frontend >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-pytorch-frontend >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-tensorflow-frontend >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-tensorflow-lite-frontend >=2023.3.0,<2023.3.1.0a0
-  - libopus >=1.3.1,<2.0a0
-  - libvpx >=1.13.1,<1.14.0a0
-  - libxml2 >=2.12.4,<3.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - openh264 >=2.4.1,<2.4.2.0a0
-  - svt-av1 >=1.8.0,<1.8.1.0a0
-  - x264 >=1!164.3095,<1!165
-  - x265 >=3.5,<3.6.0a0
-  - xz >=5.2.6,<6.0a0
-  license: GPL-2.0-or-later
-  license_family: GPL
-  size: 9670063
-  timestamp: 1706919839093
+  - libexpat 2.6.2 h73e2aa4_0
+  license: MIT
+  license_family: MIT
+  size: 126612
+  timestamp: 1710362607162
+- kind: conda
+  name: expat
+  version: 2.6.2
+  build: hebf3989_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/expat-2.6.2-hebf3989_0.conda
+  sha256: 9ac22553a4d595d7e4c9ca9aa09a0b38da65314529a7a7008edc73d3f9e7904a
+  md5: de0cff0ec74f273c4b6aa281479906c3
+  depends:
+  - libexpat 2.6.2 hebf3989_0
+  license: MIT
+  license_family: MIT
+  size: 124594
+  timestamp: 1710362455984
 - kind: conda
   name: ffmpeg
   version: 6.1.1
-  build: gpl_h8007c5b_104
-  build_number: 104
+  build: gpl_h38e077a_106
+  build_number: 106
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/ffmpeg-6.1.1-gpl_h8007c5b_104.conda
-  sha256: 94e86b86c0815d961f6a837eaa7783bf011946aaa7e8c7c1ac9417caf298f8d2
-  md5: 5d86b2425076a811f7321a97928eaccd
+  url: https://conda.anaconda.org/conda-forge/linux-64/ffmpeg-6.1.1-gpl_h38e077a_106.conda
+  sha256: 394dbcac10a6d65c8dae456bc4a2a2717005f598f86a423fe11235392a9d00ea
+  md5: 23fe0f8b47e7b5527bcc1dfb6087dba6
   depends:
   - aom >=3.8.1,<3.9.0a0
   - bzip2 >=1.0.8,<2.0a0
@@ -2801,26 +2705,24 @@ packages:
   - harfbuzz >=8.3.0,<9.0a0
   - lame >=3.100,<3.101.0a0
   - libass >=0.17.1,<0.17.2.0a0
-  - libgcc-ng >=12
   - libiconv >=1.17,<2.0a0
-  - libopenvino >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-auto-batch-plugin >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-auto-plugin >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-hetero-plugin >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-intel-cpu-plugin >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-intel-gpu-plugin >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-ir-frontend >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-onnx-frontend >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-paddle-frontend >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-pytorch-frontend >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-tensorflow-frontend >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-tensorflow-lite-frontend >=2023.3.0,<2023.3.1.0a0
+  - libopenvino >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-auto-batch-plugin >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-auto-plugin >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-hetero-plugin >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-intel-cpu-plugin >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-intel-gpu-plugin >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-ir-frontend >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-onnx-frontend >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-paddle-frontend >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-pytorch-frontend >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-tensorflow-frontend >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-tensorflow-lite-frontend >=2024.0.0,<2024.0.1.0a0
   - libopus >=1.3.1,<2.0a0
-  - libstdcxx-ng >=12
   - libva >=2.20.0,<3.0a0
-  - libvpx >=1.13.1,<1.14.0a0
+  - libvpx >=1.14.0,<1.15.0a0
   - libxcb >=1.15,<1.16.0a0
-  - libxml2 >=2.12.4,<3.0a0
+  - libxml2 >=2.12.5,<3.0a0
   - libzlib >=1.2.13,<1.3.0a0
   - openh264 >=2.4.1,<2.4.2.0a0
   - svt-av1 >=1.8.0,<1.8.1.0a0
@@ -2830,17 +2732,161 @@ packages:
   - xz >=5.2.6,<6.0a0
   license: GPL-2.0-or-later
   license_family: GPL
-  size: 9779948
-  timestamp: 1706919059782
+  size: 9776719
+  timestamp: 1710227916961
 - kind: conda
   name: ffmpeg
   version: 6.1.1
-  build: gpl_hb766fab_104
-  build_number: 104
+  build: gpl_h71b6f88_106
+  build_number: 106
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/ffmpeg-6.1.1-gpl_h71b6f88_106.conda
+  sha256: 240fcb6b0b5b65902b909f87947ae189e9719404da64432f7cea7cb9e226678d
+  md5: 1f6fb99fff1e82f0cc33f32a7ae40914
+  depends:
+  - aom >=3.8.1,<3.9.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - dav1d >=1.2.1,<1.2.2.0a0
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - gmp >=6.3.0,<7.0a0
+  - gnutls >=3.7.9,<3.8.0a0
+  - harfbuzz >=8.3.0,<9.0a0
+  - lame >=3.100,<3.101.0a0
+  - libass >=0.17.1,<0.17.2.0a0
+  - libcxx >=16
+  - libiconv >=1.17,<2.0a0
+  - libopenvino >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-auto-batch-plugin >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-auto-plugin >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-hetero-plugin >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-intel-cpu-plugin >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-ir-frontend >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-onnx-frontend >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-paddle-frontend >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-pytorch-frontend >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-tensorflow-frontend >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-tensorflow-lite-frontend >=2024.0.0,<2024.0.1.0a0
+  - libopus >=1.3.1,<2.0a0
+  - libvpx >=1.14.0,<1.15.0a0
+  - libxml2 >=2.12.5,<3.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - openh264 >=2.4.1,<2.4.2.0a0
+  - svt-av1 >=1.8.0,<1.8.1.0a0
+  - x264 >=1!164.3095,<1!165
+  - x265 >=3.5,<3.6.0a0
+  - xz >=5.2.6,<6.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 9675951
+  timestamp: 1710228627269
+- kind: conda
+  name: ffmpeg
+  version: 6.1.1
+  build: gpl_h991a198_106
+  build_number: 106
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/ffmpeg-6.1.1-gpl_h991a198_106.conda
+  sha256: cdd638f5117ec0c77a62c793b09b466c2d8f4cc9ac42386c91a12b99dfd5ef77
+  md5: c777652f97e1fbba79b32e7f5e678ffa
+  depends:
+  - aom >=3.8.1,<3.9.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - dav1d >=1.2.1,<1.2.2.0a0
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - gmp >=6.3.0,<7.0a0
+  - gnutls >=3.7.9,<3.8.0a0
+  - harfbuzz >=8.3.0,<9.0a0
+  - lame >=3.100,<3.101.0a0
+  - libass >=0.17.1,<0.17.2.0a0
+  - libgcc-ng >=12
+  - libiconv >=1.17,<2.0a0
+  - libopenvino >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-arm-cpu-plugin >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-auto-batch-plugin >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-auto-plugin >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-hetero-plugin >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-ir-frontend >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-onnx-frontend >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-paddle-frontend >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-pytorch-frontend >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-tensorflow-frontend >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-tensorflow-lite-frontend >=2024.0.0,<2024.0.1.0a0
+  - libopus >=1.3.1,<2.0a0
+  - libstdcxx-ng >=12
+  - libvpx >=1.14.0,<1.15.0a0
+  - libxcb >=1.15,<1.16.0a0
+  - libxml2 >=2.12.5,<3.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - openh264 >=2.4.1,<2.4.2.0a0
+  - svt-av1 >=1.8.0,<1.8.1.0a0
+  - x264 >=1!164.3095,<1!165
+  - x265 >=3.5,<3.6.0a0
+  - xorg-libx11 >=1.8.7,<2.0a0
+  - xz >=5.2.6,<6.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 9354599
+  timestamp: 1710227859206
+- kind: conda
+  name: ffmpeg
+  version: 6.1.1
+  build: gpl_haa72bd2_106
+  build_number: 106
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ffmpeg-6.1.1-gpl_haa72bd2_106.conda
+  sha256: 6d63b78f000c1d295bacc3b154e5e458ef7f72abdcd5dfe6a74d7e3da414d34e
+  md5: fec1e360e205190389623f7bc62852f6
+  depends:
+  - aom >=3.8.1,<3.9.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - dav1d >=1.2.1,<1.2.2.0a0
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - gmp >=6.3.0,<7.0a0
+  - gnutls >=3.7.9,<3.8.0a0
+  - harfbuzz >=8.3.0,<9.0a0
+  - lame >=3.100,<3.101.0a0
+  - libass >=0.17.1,<0.17.2.0a0
+  - libcxx >=16
+  - libiconv >=1.17,<2.0a0
+  - libopenvino >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-arm-cpu-plugin >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-auto-batch-plugin >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-auto-plugin >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-hetero-plugin >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-ir-frontend >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-onnx-frontend >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-paddle-frontend >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-pytorch-frontend >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-tensorflow-frontend >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-tensorflow-lite-frontend >=2024.0.0,<2024.0.1.0a0
+  - libopus >=1.3.1,<2.0a0
+  - libvpx >=1.14.0,<1.15.0a0
+  - libxml2 >=2.12.5,<3.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - openh264 >=2.4.1,<2.4.2.0a0
+  - svt-av1 >=1.8.0,<1.8.1.0a0
+  - x264 >=1!164.3095,<1!165
+  - x265 >=3.5,<3.6.0a0
+  - xz >=5.2.6,<6.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 8636253
+  timestamp: 1710228709761
+- kind: conda
+  name: ffmpeg
+  version: 6.1.1
+  build: gpl_hb766fab_106
+  build_number: 106
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/ffmpeg-6.1.1-gpl_hb766fab_104.conda
-  sha256: 19a4d76f5e7c6120cfa81dd082021e37a233371342f30d922701c3c7518e362c
-  md5: f108e2770fbe8546b921e2a6c90576e5
+  url: https://conda.anaconda.org/conda-forge/win-64/ffmpeg-6.1.1-gpl_hb766fab_106.conda
+  sha256: b64e111bb95c157eb6d5a442257147e85c1abbbd1c2ea1d3bf7fd56d09e3fdfc
+  md5: ae0ba1265579555268923e2b993845de
   depends:
   - aom >=3.8.1,<3.9.0a0
   - bzip2 >=1.0.8,<2.0a0
@@ -2851,7 +2897,7 @@ packages:
   - harfbuzz >=8.3.0,<9.0a0
   - libiconv >=1.17,<2.0a0
   - libopus >=1.3.1,<2.0a0
-  - libxml2 >=2.12.4,<3.0a0
+  - libxml2 >=2.12.5,<3.0a0
   - libzlib >=1.2.13,<1.3.0a0
   - openh264 >=2.4.1,<2.4.2.0a0
   - svt-av1 >=1.8.0,<1.8.1.0a0
@@ -2863,58 +2909,8 @@ packages:
   - xz >=5.2.6,<6.0a0
   license: GPL-2.0-or-later
   license_family: GPL
-  size: 9695911
-  timestamp: 1706920715649
-- kind: conda
-  name: ffmpeg
-  version: 6.1.1
-  build: gpl_hd8c5532_104
-  build_number: 104
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/ffmpeg-6.1.1-gpl_hd8c5532_104.conda
-  sha256: 6cf2b6f7acc6602827cc5bebd0d15a00d707938536b18a871cad4c18d33d3aca
-  md5: e1ef2221ec735d299722003e18c7db56
-  depends:
-  - aom >=3.8.1,<3.9.0a0
-  - bzip2 >=1.0.8,<2.0a0
-  - dav1d >=1.2.1,<1.2.2.0a0
-  - fontconfig >=2.14.2,<3.0a0
-  - fonts-conda-ecosystem
-  - freetype >=2.12.1,<3.0a0
-  - gmp >=6.3.0,<7.0a0
-  - gnutls >=3.7.9,<3.8.0a0
-  - harfbuzz >=8.3.0,<9.0a0
-  - lame >=3.100,<3.101.0a0
-  - libass >=0.17.1,<0.17.2.0a0
-  - libgcc-ng >=12
-  - libiconv >=1.17,<2.0a0
-  - libopenvino >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-arm-cpu-plugin >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-auto-batch-plugin >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-auto-plugin >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-hetero-plugin >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-ir-frontend >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-onnx-frontend >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-paddle-frontend >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-pytorch-frontend >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-tensorflow-frontend >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-tensorflow-lite-frontend >=2023.3.0,<2023.3.1.0a0
-  - libopus >=1.3.1,<2.0a0
-  - libstdcxx-ng >=12
-  - libvpx >=1.13.1,<1.14.0a0
-  - libxcb >=1.15,<1.16.0a0
-  - libxml2 >=2.12.4,<3.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - openh264 >=2.4.1,<2.4.2.0a0
-  - svt-av1 >=1.8.0,<1.8.1.0a0
-  - x264 >=1!164.3095,<1!165
-  - x265 >=3.5,<3.6.0a0
-  - xorg-libx11 >=1.8.7,<2.0a0
-  - xz >=5.2.6,<6.0a0
-  license: GPL-2.0-or-later
-  license_family: GPL
-  size: 9352167
-  timestamp: 1706919357006
+  size: 9704858
+  timestamp: 1710228932901
 - kind: conda
   name: font-ttf-dejavu-sans-mono
   version: '2.37'
@@ -3281,33 +3277,33 @@ packages:
 - kind: conda
   name: gcc
   version: 12.3.0
-  build: h8d2909c_2
-  build_number: 2
+  build: h95e488c_3
+  build_number: 3
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gcc-12.3.0-h8d2909c_2.conda
-  sha256: 1bbf077688822993c39518056fb43d83ff0920eb42fef11e8714d2a298cc0f27
-  md5: e2f2f81f367e14ca1f77a870bda2fe59
+  url: https://conda.anaconda.org/conda-forge/linux-64/gcc-12.3.0-h95e488c_3.conda
+  sha256: 60669bb79c79d6f6929c67b334acd9dc885dccfb7371e41de7626090dc06e408
+  md5: 413e326f8a01d041ffbfbb51cea46a93
   depends:
   - gcc_impl_linux-64 12.3.0.*
   license: BSD-3-Clause
   license_family: BSD
-  size: 27086
-  timestamp: 1694604171830
+  size: 27727
+  timestamp: 1710259826549
 - kind: conda
   name: gcc
   version: 12.3.0
-  build: hc1b51f9_2
-  build_number: 2
+  build: he80d746_3
+  build_number: 3
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc-12.3.0-hc1b51f9_2.conda
-  sha256: 36ff01aef1b38e02539fae8c4637e661f380d5ca768cf27854cbbd5b54e85441
-  md5: 97aac23de07980a315aa0133d6efa742
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc-12.3.0-he80d746_3.conda
+  sha256: b85e2482a76145f01932513304ee1eca58115f48a4d02107035272c2a2c4bed2
+  md5: fe4071326b5c555a0c87081bb0427724
   depends:
   - gcc_impl_linux-aarch64 12.3.0.*
   license: BSD-3-Clause
   license_family: BSD
-  size: 27218
-  timestamp: 1694604210046
+  size: 27793
+  timestamp: 1710259900584
 - kind: conda
   name: gcc_impl_linux-64
   version: 12.3.0
@@ -3353,37 +3349,37 @@ packages:
 - kind: conda
   name: gcc_linux-64
   version: 12.3.0
-  build: h76fc315_2
-  build_number: 2
+  build: h6477408_3
+  build_number: 3
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-12.3.0-h76fc315_2.conda
-  sha256: 86f6db7399ec0362e4c4025939debbfebc8ad9ccef75e3c0e4069f85b149f24d
-  md5: 11517e7b5c910c5b5d6985c0c7eb7f50
+  url: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-12.3.0-h6477408_3.conda
+  sha256: 836692c3d4948f25a19f9071db40f7788edcb342d771786a206a6a122f92365d
+  md5: 7a53f84c45bdf4656ba27b9e9ed68b3d
   depends:
-  - binutils_linux-64 2.40 hbdbef99_2
+  - binutils_linux-64 2.40 hdade7a5_3
   - gcc_impl_linux-64 12.3.0.*
   - sysroot_linux-64
   license: BSD-3-Clause
   license_family: BSD
-  size: 30351
-  timestamp: 1694604476800
+  size: 30977
+  timestamp: 1710260096918
 - kind: conda
   name: gcc_linux-aarch64
   version: 12.3.0
-  build: h464a8f7_2
-  build_number: 2
+  build: h9622932_3
+  build_number: 3
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_linux-aarch64-12.3.0-h464a8f7_2.conda
-  sha256: 169b506c0d74e6f4d531fd75ea7a73dbd484e55bad5674c7bc55dbfec9b7a882
-  md5: 955e5b68fde8c90f0db374f4fa8af401
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_linux-aarch64-12.3.0-h9622932_3.conda
+  sha256: fabd666508f2c814d9372a46e5abb19bd5f53b66e67c9fee0d577fc0bdc292f2
+  md5: 0f77e0c3b8902a8c44b9814701e6f0a5
   depends:
-  - binutils_linux-aarch64 2.40 h94bbfa1_2
+  - binutils_linux-aarch64 2.40 h95d2017_3
   - gcc_impl_linux-aarch64 12.3.0.*
   - sysroot_linux-aarch64
   license: BSD-3-Clause
   license_family: BSD
-  size: 30487
-  timestamp: 1694604559822
+  size: 30943
+  timestamp: 1710260225977
 - kind: conda
   name: gdbm
   version: '1.18'
@@ -3482,308 +3478,297 @@ packages:
   timestamp: 1665673486488
 - kind: conda
   name: glfw
-  version: 3.3.9
+  version: '3.4'
   build: h10d778d_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/glfw-3.3.9-h10d778d_0.conda
-  sha256: 9b3f8d8ff33b9689d3a26b1e1255ef2f1357319f7319ed3435124de2e1802fbb
-  md5: ed02678bc45a4ba8787ec6ba53402a2f
+  url: https://conda.anaconda.org/conda-forge/osx-64/glfw-3.4-h10d778d_0.conda
+  sha256: 4429c311b064e19f58b4484ff07346eed2fb862a93db322daaedd1cebd9f7df9
+  md5: 1e64b2a03d3978cc25b5b83985275272
   license: Zlib
-  size: 103972
-  timestamp: 1702521488886
+  size: 114753
+  timestamp: 1708788983681
 - kind: conda
   name: glfw
-  version: 3.3.9
+  version: '3.4'
   build: h31becfc_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/glfw-3.3.9-h31becfc_0.conda
-  sha256: 7170ac780926ed9a782b75ee3bcce48763931bb14684b7d08ef52a721ed7e8e6
-  md5: 3e229580bd30a396e5797de474b0130e
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/glfw-3.4-h31becfc_0.conda
+  sha256: ec1037514938e6a582998c4f156c7165deb470d964dc2d53717e690ea25a22d3
+  md5: 48479e59b512a1dc883aa8d9ea2e29a6
   depends:
   - libgcc-ng >=12
+  - libxkbcommon >=1.6.0,<2.0a0
+  - wayland >=1.22.0,<2.0a0
   - xorg-libx11 >=1.8.7,<2.0a0
-  - xorg-libxcursor
   - xorg-libxinerama >=1.1.5,<1.2.0a0
-  - xorg-libxrandr
   license: Zlib
-  size: 130930
-  timestamp: 1702523214498
+  size: 170592
+  timestamp: 1708788896757
 - kind: conda
   name: glfw
-  version: 3.3.9
+  version: '3.4'
   build: h93a5062_0
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/glfw-3.3.9-h93a5062_0.conda
-  sha256: e35d9593ff3392d04565a6a44bfb7adc1357074af197bd0c470bfd084520255f
-  md5: 58a97fac8b80f01c8eb6108567e25d7d
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/glfw-3.4-h93a5062_0.conda
+  sha256: fd01d62b690e42adf9b9d3fd7f4bbe7185dd8d9fa60aca315137f0367e9c989d
+  md5: b7bf4ccb27f1e75c9292a218974dcfac
   license: Zlib
-  size: 102485
-  timestamp: 1702521314984
+  size: 113768
+  timestamp: 1708789054033
 - kind: conda
   name: glfw
-  version: 3.3.9
+  version: '3.4'
   build: hcfcfb64_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/glfw-3.3.9-hcfcfb64_0.conda
-  sha256: 3889c0bb9aafcba685c862accce0e641df719151f27c806f3ea465d8d5770ca4
-  md5: 3bbd2159f1ad6a42290661031148d969
+  url: https://conda.anaconda.org/conda-forge/win-64/glfw-3.4-hcfcfb64_0.conda
+  sha256: f7759a2d1e473d36b39a65096c1b0660fe3574b7aa8fa330ef13626926292d13
+  md5: 5d41478e933d70273686b267827d2ae6
   depends:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: Zlib
-  size: 107154
-  timestamp: 1702521596413
+  size: 118348
+  timestamp: 1708789270458
 - kind: conda
   name: glfw
-  version: 3.3.9
+  version: '3.4'
   build: hd590300_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/glfw-3.3.9-hd590300_0.conda
-  sha256: 7aa72cab0063ccb205860f09be409d9e1469a179ebd7fdfbaa45ad576492dc7e
-  md5: 0bcf0fbbc357108ce6915c55c1f4b5a6
+  url: https://conda.anaconda.org/conda-forge/linux-64/glfw-3.4-hd590300_0.conda
+  sha256: 852298b9d1b6e58d8653d943049f7bce0ef3774c87fccd5ac1e8b04d5d702d40
+  md5: 4c7a044d25e000fef39b77c10a102ea1
   depends:
   - libgcc-ng >=12
+  - libxkbcommon >=1.6.0,<2.0a0
+  - wayland >=1.22.0,<2.0a0
   - xorg-libx11 >=1.8.7,<2.0a0
-  - xorg-libxcursor
   - xorg-libxinerama >=1.1.5,<1.2.0a0
-  - xorg-libxrandr
   license: Zlib
-  size: 128209
-  timestamp: 1702521018709
+  size: 167421
+  timestamp: 1708788896752
 - kind: conda
   name: glib
-  version: 2.78.3
-  build: h12be248_0
+  version: 2.80.0
+  build: h39d0aa6_1
+  build_number: 1
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/glib-2.78.3-h12be248_0.conda
-  sha256: 1d3176b93c17a4cae930441691e18bf2824a235903895dd54c65c641f3da3e64
-  md5: a14440f1d004a2ddccd9c1354dbeffdf
+  url: https://conda.anaconda.org/conda-forge/win-64/glib-2.80.0-h39d0aa6_1.conda
+  sha256: a76ad2d20164be5425269ac9c65dc8a071ea6dbd5ac3090f9b16dc29a7af1dbc
+  md5: 0384fcbea19fea38cdbf4b3b8924e436
   depends:
-  - gettext >=0.21.1,<1.0a0
-  - glib-tools 2.78.3 h12be248_0
-  - libglib 2.78.3 h16e383f_0
-  - libzlib >=1.2.13,<1.3.0a0
+  - glib-tools 2.80.0 h0a98069_1
+  - libglib 2.80.0 h39d0aa6_1
   - python *
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: LGPL-2.1-or-later
-  size: 506931
-  timestamp: 1702003592251
+  size: 491857
+  timestamp: 1710939590211
 - kind: conda
   name: glib
-  version: 2.78.3
-  build: h9e231a4_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/glib-2.78.3-h9e231a4_0.conda
-  sha256: d30d8d81a5a153a397c5d464e7ebb3c4ed6ff8d49e0e944c0807693b9241ff67
-  md5: afccd23fd84928932e9a215cac1c0b69
-  depends:
-  - __osx >=10.9
-  - gettext >=0.21.1,<1.0a0
-  - glib-tools 2.78.3 h9e231a4_0
-  - libcxx >=16.0.6
-  - libglib 2.78.3 hb438215_0
-  - libzlib >=1.2.13,<1.3.0a0
-  - python *
-  license: LGPL-2.1-or-later
-  size: 488582
-  timestamp: 1702003388910
-- kind: conda
-  name: glib
-  version: 2.78.3
-  build: hd84c7bf_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/glib-2.78.3-hd84c7bf_0.conda
-  sha256: cc609469a4e3e36acea15641c4b99857940788474d07420877806484c9e1e4da
-  md5: fcbd147637a60cb5437020b784e595a0
-  depends:
-  - gettext >=0.21.1,<1.0a0
-  - glib-tools 2.78.3 hd84c7bf_0
-  - libgcc-ng >=12
-  - libglib 2.78.3 h311d5f7_0
-  - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
-  - python *
-  license: LGPL-2.1-or-later
-  size: 497505
-  timestamp: 1702002962229
-- kind: conda
-  name: glib
-  version: 2.78.3
-  build: hf4d7fad_0
+  version: 2.80.0
+  build: h81c1438_1
+  build_number: 1
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/glib-2.78.3-hf4d7fad_0.conda
-  sha256: 99276582071aacbd482ba8e86f35ea64b3b9b81055db42081afbc1d620e13b83
-  md5: 66a951ef12f9e9d00331b83511a34d1d
+  url: https://conda.anaconda.org/conda-forge/osx-64/glib-2.80.0-h81c1438_1.conda
+  sha256: 9bf57bc4cb0cfe72fe37dd01de41d74f5761fb21bd6bb76e11bb44adacfeeb99
+  md5: 5a6fd8f9e20c7e18edec5bbab75565c3
   depends:
-  - __osx >=10.9
   - gettext >=0.21.1,<1.0a0
-  - glib-tools 2.78.3 hf4d7fad_0
-  - libcxx >=16.0.6
-  - libglib 2.78.3 h198397b_0
-  - libzlib >=1.2.13,<1.3.0a0
+  - glib-tools 2.80.0 h49a7eea_1
+  - libglib 2.80.0 h81c1438_1
   - python *
   license: LGPL-2.1-or-later
-  size: 488601
-  timestamp: 1702003422773
+  size: 503338
+  timestamp: 1710939853223
 - kind: conda
   name: glib
-  version: 2.78.3
-  build: hfc55251_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/glib-2.78.3-hfc55251_0.conda
-  sha256: 5c0630146185d806a4dd8cedd0e1983bc3a4ad8f9c0f1db8ee5fd28011396316
-  md5: e08e51acc7d1ae8dbe13255e7b4c64ac
+  version: 2.80.0
+  build: h9d8fbc1_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/glib-2.80.0-h9d8fbc1_1.conda
+  sha256: 6560c165eadee8a1c5ca77f23e787d125662ddd636b4d4dfb3d4fbb7ab594afd
+  md5: 84be9b2d2d447b856ab0c6b8b913b506
   depends:
-  - gettext >=0.21.1,<1.0a0
-  - glib-tools 2.78.3 hfc55251_0
+  - glib-tools 2.80.0 hfbcf09e_1
   - libgcc-ng >=12
-  - libglib 2.78.3 h783c2da_0
-  - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
+  - libglib 2.80.0 h9d8fbc1_1
   - python *
   license: LGPL-2.1-or-later
-  size: 489536
-  timestamp: 1702003193690
+  size: 511720
+  timestamp: 1710938879461
+- kind: conda
+  name: glib
+  version: 2.80.0
+  build: hf2295e7_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/glib-2.80.0-hf2295e7_1.conda
+  sha256: 92e0344072050dafd9f478498a2662cb6e309697b58283793145fd05c413a921
+  md5: d3bcc5c186f78feba6f39ea047c35950
+  depends:
+  - glib-tools 2.80.0 hde27a5a_1
+  - libgcc-ng >=12
+  - libglib 2.80.0 hf2295e7_1
+  - python *
+  license: LGPL-2.1-or-later
+  size: 503830
+  timestamp: 1710939217743
+- kind: conda
+  name: glib
+  version: 2.80.0
+  build: hfc324ee_1
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/glib-2.80.0-hfc324ee_1.conda
+  sha256: e0259eaa28f47dd266a43b428f75cc450e9e37eb8065c14ec294ff936819b581
+  md5: 5d751a74ba034a7e2e5be201a00d5758
+  depends:
+  - gettext >=0.21.1,<1.0a0
+  - glib-tools 2.80.0 hb9a4d99_1
+  - libglib 2.80.0 hfc324ee_1
+  - python *
+  license: LGPL-2.1-or-later
+  size: 503216
+  timestamp: 1710939538458
 - kind: conda
   name: glib-tools
-  version: 2.78.3
-  build: h12be248_0
+  version: 2.80.0
+  build: h0a98069_1
+  build_number: 1
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/glib-tools-2.78.3-h12be248_0.conda
-  sha256: 70078a3ec46898e857ba90840446b82a3da5cf658c56980c73ba789fd176c09c
-  md5: 03c45e65dbac2ba6c247dfd4896b664c
+  url: https://conda.anaconda.org/conda-forge/win-64/glib-tools-2.80.0-h0a98069_1.conda
+  sha256: 079b56c014b5f70381924db7a70000676e616079045e7a70081e2f3cf69bc969
+  md5: b6a4948e65ee42739ce14967e4cacdca
   depends:
-  - libglib 2.78.3 h16e383f_0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libglib 2.80.0 h39d0aa6_1
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: LGPL-2.1-or-later
-  size: 144752
-  timestamp: 1702003510059
+  size: 94114
+  timestamp: 1710939517930
 - kind: conda
   name: glib-tools
-  version: 2.78.3
-  build: h9e231a4_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/glib-tools-2.78.3-h9e231a4_0.conda
-  sha256: cfeb45f030ab0909242e2a13ef9bf238d0f3f92ef4e8388a98ba79a6287d077f
-  md5: 3af7028006d041755cfc3669002070ba
-  depends:
-  - __osx >=10.9
-  - libcxx >=16.0.6
-  - libglib 2.78.3 hb438215_0
-  - libzlib >=1.2.13,<1.3.0a0
-  license: LGPL-2.1-or-later
-  size: 97158
-  timestamp: 1702003287146
-- kind: conda
-  name: glib-tools
-  version: 2.78.3
-  build: hd84c7bf_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/glib-tools-2.78.3-hd84c7bf_0.conda
-  sha256: ff33d19ed7dbd1a16eefda3614a0e32e16d5cdf231642422cfa75173a8af5b5d
-  md5: 0761f585c27dbba88273065ff93ef9b8
-  depends:
-  - libgcc-ng >=12
-  - libglib 2.78.3 h311d5f7_0
-  - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
-  license: LGPL-2.1-or-later
-  size: 123498
-  timestamp: 1702002895464
-- kind: conda
-  name: glib-tools
-  version: 2.78.3
-  build: hf4d7fad_0
+  version: 2.80.0
+  build: h49a7eea_1
+  build_number: 1
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/glib-tools-2.78.3-hf4d7fad_0.conda
-  sha256: f0f62e9505b92c5349cbf3a7e5069f95eef99a348bb460638429dc9f9c249db0
-  md5: c424dbfa0ca7fd1405c1c6d543e6762e
+  url: https://conda.anaconda.org/conda-forge/osx-64/glib-tools-2.80.0-h49a7eea_1.conda
+  sha256: 3174f5169a75abebba34de48f5f1ba44ae875abd9abefc0116792d2d13cb9e59
+  md5: 3d9331d7bb0435d1a054aa50b513f9ac
   depends:
-  - __osx >=10.9
-  - libcxx >=16.0.6
-  - libglib 2.78.3 h198397b_0
-  - libzlib >=1.2.13,<1.3.0a0
+  - gettext >=0.21.1,<1.0a0
+  - libglib 2.80.0 h81c1438_1
   license: LGPL-2.1-or-later
-  size: 97399
-  timestamp: 1702003308254
+  size: 97279
+  timestamp: 1710939727447
 - kind: conda
   name: glib-tools
-  version: 2.78.3
-  build: hfc55251_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.78.3-hfc55251_0.conda
-  sha256: f7f9ed77beb5d0012a501abc7711f338ab9036f8d1e0259e71e3236bfcae2ad2
-  md5: 41d2f46e0ac8372eeb959860713d9b21
-  depends:
-  - libgcc-ng >=12
-  - libglib 2.78.3 h783c2da_0
-  - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
-  license: LGPL-2.1-or-later
-  size: 110689
-  timestamp: 1702003133163
-- kind: conda
-  name: gmp
-  version: 6.3.0
-  build: h2f0025b_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gmp-6.3.0-h2f0025b_0.conda
-  sha256: ef427440346cb6e794e6c6eb190b362aa25afb5ee91bac0567b206b1eb9bfed8
-  md5: 95351a6fb62c7d1292210f4fb761f69b
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  license: GPL-2.0-or-later AND LGPL-3.0-or-later
-  size: 502848
-  timestamp: 1699629968394
-- kind: conda
-  name: gmp
-  version: 6.3.0
-  build: h59595ed_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.3.0-h59595ed_0.conda
-  sha256: 2a50495b6bbbacb03107ea0b752d8358d4a40b572d124a8cade068c147f344f5
-  md5: 0e33ef437202db431aa5a928248cf2e8
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  license: GPL-2.0-or-later AND LGPL-3.0-or-later
-  size: 563123
-  timestamp: 1699629991732
-- kind: conda
-  name: gmp
-  version: 6.3.0
-  build: h93d8f39_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/gmp-6.3.0-h93d8f39_0.conda
-  sha256: 49443e6c41070e3967936c7f09b7686d3dd715f3351918c4edfd8072e1776013
-  md5: a4ffd4bfd88659cbecbd36b61594bf0d
-  depends:
-  - __osx >=10.9
-  - libcxx >=16.0.6
-  license: GPL-2.0-or-later AND LGPL-3.0-or-later
-  size: 520933
-  timestamp: 1699630591994
-- kind: conda
-  name: gmp
-  version: 6.3.0
-  build: h965bd2d_0
+  version: 2.80.0
+  build: hb9a4d99_1
+  build_number: 1
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/gmp-6.3.0-h965bd2d_0.conda
-  sha256: d13f09ba46dc4732a3513da76da2352b9a6b71376dc3ba8210bbf1ca0c2e51e3
-  md5: bb8f17b25ebdb9d8819c2c5bf3ccb180
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/glib-tools-2.80.0-hb9a4d99_1.conda
+  sha256: 80c474aa2214b57bff6ed61e6906ed9c09e2b64ac2c367534804e59d287b892b
+  md5: 31519ccdedc9a30d6752fbbf0ac2a18e
   depends:
-  - __osx >=10.9
-  - libcxx >=16.0.6
-  license: GPL-2.0-or-later AND LGPL-3.0-or-later
-  size: 446486
-  timestamp: 1699630529917
+  - gettext >=0.21.1,<1.0a0
+  - libglib 2.80.0 hfc324ee_1
+  license: LGPL-2.1-or-later
+  size: 97756
+  timestamp: 1710939468243
+- kind: conda
+  name: glib-tools
+  version: 2.80.0
+  build: hde27a5a_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.80.0-hde27a5a_1.conda
+  sha256: 8d736e120bb1fe3b57f957d8f6b90c9bb035ee1dac167714c9afba395af6878c
+  md5: 939ddd853b1d98bf6fd22cc0adeda317
+  depends:
+  - libgcc-ng >=12
+  - libglib 2.80.0 hf2295e7_1
+  license: LGPL-2.1-or-later
+  size: 112852
+  timestamp: 1710939161164
+- kind: conda
+  name: glib-tools
+  version: 2.80.0
+  build: hfbcf09e_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/glib-tools-2.80.0-hfbcf09e_1.conda
+  sha256: 0d43a765b0a01591a93206a6c147142236ed7ea46d58871f00746738b5400955
+  md5: 823b03c3c671b0ab75de3cf0bc8fc34f
+  depends:
+  - libgcc-ng >=12
+  - libglib 2.80.0 h9d8fbc1_1
+  license: LGPL-2.1-or-later
+  size: 122487
+  timestamp: 1710938839342
+- kind: conda
+  name: gmp
+  version: 6.3.0
+  build: h2f0025b_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gmp-6.3.0-h2f0025b_1.conda
+  sha256: a839590a28ea9938e01e4a7fcf6d240611ef9a645c7b4cb6767c7b1397d06f22
+  md5: 0fdc64cdb43430acdca4d54fdfc64317
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: GPL-2.0-or-later OR LGPL-3.0-or-later
+  size: 517903
+  timestamp: 1710169423575
+- kind: conda
+  name: gmp
+  version: 6.3.0
+  build: h59595ed_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.3.0-h59595ed_1.conda
+  sha256: cfc4202c23d6895d9c84042d08d5cda47d597772df870d4d2a10fc86dded5576
+  md5: e358c7c5f6824c272b5034b3816438a7
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: GPL-2.0-or-later OR LGPL-3.0-or-later
+  size: 569852
+  timestamp: 1710169507479
+- kind: conda
+  name: gmp
+  version: 6.3.0
+  build: h73e2aa4_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/gmp-6.3.0-h73e2aa4_1.conda
+  sha256: 1a5b117908deb5a12288aba84dd0cb913f779c31c75f5a57d1a00e659e8fa3d3
+  md5: 92f8d748d95d97f92fc26cfac9bb5b6e
+  depends:
+  - libcxx >=16
+  license: GPL-2.0-or-later OR LGPL-3.0-or-later
+  size: 519804
+  timestamp: 1710170159201
+- kind: conda
+  name: gmp
+  version: 6.3.0
+  build: hebf3989_1
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/gmp-6.3.0-hebf3989_1.conda
+  sha256: 0ed5aff70675dc0ed5c2f39bb02b908b864e8eee4ceb56e1c798ba8d7509551f
+  md5: 64f45819921ba710398706e1a6404eb5
+  depends:
+  - libcxx >=16
+  license: GPL-2.0-or-later OR LGPL-3.0-or-later
+  size: 448714
+  timestamp: 1710169869298
 - kind: conda
   name: gnutls
   version: 3.7.9
@@ -4009,7 +3994,7 @@ packages:
   sha256: 3590c472419063398d53efe1c14342a8cb566e4caad71e30cd01b61498a1afcd
   md5: f931eeddcd3ae8698ab520656b4509aa
   depends:
-  - alsa-lib >=1.2.10,<1.2.11.0a0
+  - alsa-lib >=1.2.10,<1.3.0.0a0
   - gettext >=0.21.1,<1.0a0
   - gstreamer 1.22.9 hed71854_0
   - libexpat >=2.5.0,<3.0a0
@@ -4040,7 +4025,7 @@ packages:
   md5: 614b81f8ed66c56b640faee7076ad14a
   depends:
   - __glibc >=2.17,<3.0.a0
-  - alsa-lib >=1.2.10,<1.2.11.0a0
+  - alsa-lib >=1.2.10,<1.3.0.0a0
   - gettext >=0.21.1,<1.0a0
   - gstreamer 1.22.9 h98fc4e7_0
   - libexpat >=2.5.0,<3.0a0
@@ -4159,35 +4144,35 @@ packages:
 - kind: conda
   name: gxx
   version: 12.3.0
-  build: h8d2909c_2
-  build_number: 2
+  build: h95e488c_3
+  build_number: 3
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gxx-12.3.0-h8d2909c_2.conda
-  sha256: 5fd65768fb602fd21466831c96e7a2355a4df692507abbd481aa65a777151d85
-  md5: 673bac341be6b90ef9e8abae7e52ca46
+  url: https://conda.anaconda.org/conda-forge/linux-64/gxx-12.3.0-h95e488c_3.conda
+  sha256: 12c8d969b1b6acf1bf4f7c7399993dd3d422a713ad6d7ab9343f6b990f8373a0
+  md5: 8c50a4d15a8d4812af563a684d598910
   depends:
   - gcc 12.3.0.*
   - gxx_impl_linux-64 12.3.0.*
   license: BSD-3-Clause
   license_family: BSD
-  size: 26539
-  timestamp: 1694604501713
+  size: 27244
+  timestamp: 1710260136609
 - kind: conda
   name: gxx
   version: 12.3.0
-  build: hc1b51f9_2
-  build_number: 2
+  build: he80d746_3
+  build_number: 3
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx-12.3.0-hc1b51f9_2.conda
-  sha256: a22b61ccc63e2e1630654f840703cef734cfcd46aece2e36c858a50a5c3e9584
-  md5: 0c8ed54684ba4ac4753d08d18f8522a4
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx-12.3.0-he80d746_3.conda
+  sha256: b26da37112ab50b8a7ae316ccd19451c486e6f4042011fa0292b97baa4140d2a
+  md5: 73d7d6aaf1c41cefe3585ddd89eb4035
   depends:
   - gcc 12.3.0.*
   - gxx_impl_linux-aarch64 12.3.0.*
   license: BSD-3-Clause
   license_family: BSD
-  size: 26664
-  timestamp: 1694604587289
+  size: 27304
+  timestamp: 1710260259320
 - kind: conda
   name: gxx_impl_linux-64
   version: 12.3.0
@@ -4225,39 +4210,39 @@ packages:
 - kind: conda
   name: gxx_linux-64
   version: 12.3.0
-  build: h8a814eb_2
-  build_number: 2
+  build: h4a1b8e8_3
+  build_number: 3
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-12.3.0-h8a814eb_2.conda
-  sha256: 9878771cf1316230150a795d213a2f1dd7dead07dc0bccafae20533d631d5e69
-  md5: f517b1525e9783849bd56a5dc45a9960
+  url: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-12.3.0-h4a1b8e8_3.conda
+  sha256: 5a842fc69c03ac513a2c021f3f21afd9d9ca50b10b95c0dcd236aa77d6d42373
+  md5: 9ec22c7c544f4a4f6d660f0a3b0fd15c
   depends:
-  - binutils_linux-64 2.40 hbdbef99_2
-  - gcc_linux-64 12.3.0 h76fc315_2
+  - binutils_linux-64 2.40 hdade7a5_3
+  - gcc_linux-64 12.3.0 h6477408_3
   - gxx_impl_linux-64 12.3.0.*
   - sysroot_linux-64
   license: BSD-3-Clause
   license_family: BSD
-  size: 28640
-  timestamp: 1694604524890
+  size: 29304
+  timestamp: 1710260169322
 - kind: conda
   name: gxx_linux-aarch64
   version: 12.3.0
-  build: h21accf6_2
-  build_number: 2
+  build: h3d1e521_3
+  build_number: 3
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_linux-aarch64-12.3.0-h21accf6_2.conda
-  sha256: 00bb0edc85120809ef2b43cb07b49214495adb8014767d489ea0be3747a06b0c
-  md5: 17030cb823d5e2cc5e0c4461ed01b9b0
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_linux-aarch64-12.3.0-h3d1e521_3.conda
+  sha256: 9d2c7649e9341ed218aef701e1db15d8cea4e70d19c4dbf8f9efe06d2c5a0b14
+  md5: f1ac1d0d0b1afcbe3a8ad3a0b33aeaf4
   depends:
-  - binutils_linux-aarch64 2.40 h94bbfa1_2
-  - gcc_linux-aarch64 12.3.0 h464a8f7_2
+  - binutils_linux-aarch64 2.40 h95d2017_3
+  - gcc_linux-aarch64 12.3.0 h9622932_3
   - gxx_impl_linux-aarch64 12.3.0.*
   - sysroot_linux-aarch64
   license: BSD-3-Clause
   license_family: BSD
-  size: 28794
-  timestamp: 1694604612545
+  size: 29283
+  timestamp: 1710260291746
 - kind: conda
   name: harfbuzz
   version: 8.3.0
@@ -4666,6 +4651,85 @@ packages:
   size: 7139439
   timestamp: 1707302571942
 - kind: conda
+  name: imath
+  version: 3.1.11
+  build: h1059232_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/imath-3.1.11-h1059232_0.conda
+  sha256: cc6d59bcadde846a81d0c141af6a850f28c397a1c8b8546cee1e1c935b6f8dd6
+  md5: e95ef5164e69abc370842b41438065fa
+  depends:
+  - libcxx >=16
+  - libzlib >=1.2.13,<1.3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 154276
+  timestamp: 1709194436403
+- kind: conda
+  name: imath
+  version: 3.1.11
+  build: h12be248_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/imath-3.1.11-h12be248_0.conda
+  sha256: fa7e36df9074ac6d1e67bd655a784b280e83d1cbac24fecdc5c21c716b832809
+  md5: c6849d593fda3d4992a8126d251f50c3
+  depends:
+  - libzlib >=1.2.13,<1.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 160297
+  timestamp: 1709194525395
+- kind: conda
+  name: imath
+  version: 3.1.11
+  build: h2d185b6_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/imath-3.1.11-h2d185b6_0.conda
+  sha256: dfd7540dbfc216a2c1b4c51c6553986e70c7ea7b64453f515d0558c043891b2e
+  md5: 39c1f288d263e971db74f8803e28dabd
+  depends:
+  - libcxx >=16
+  - libzlib >=1.2.13,<1.3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 155338
+  timestamp: 1709194419684
+- kind: conda
+  name: imath
+  version: 3.1.11
+  build: hd84c7bf_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/imath-3.1.11-hd84c7bf_0.conda
+  sha256: d638c7d4b83752864f9c4cbd088c06186086bd38925cc51168fd2ef43f0984ca
+  md5: 3029ebe5cd9a477ee282d80e09e7522a
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 154784
+  timestamp: 1709193935481
+- kind: conda
+  name: imath
+  version: 3.1.11
+  build: hfc55251_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/imath-3.1.11-hfc55251_0.conda
+  sha256: b394465d3c6a9c5b17351562a87df2a5ef541d66f1a2d95d80fe28c9ca7638c3
+  md5: 07268e57799c7ad50809cadc297a515e
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 162530
+  timestamp: 1709194196768
+- kind: conda
   name: intel-openmp
   version: 2024.0.0
   build: h57928b3_49841
@@ -4900,12 +4964,12 @@ packages:
   timestamp: 1695760464370
 - kind: conda
   name: jasper
-  version: 4.2.0
+  version: 4.2.2
   build: h28f2b1a_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/jasper-4.2.0-h28f2b1a_0.conda
-  sha256: eb5d4f5375f7830f868482fdc7f2809941af5344c1184fb179a4954ccb34d0cc
-  md5: e9241354826dbecd9d7f4ae95d7341e1
+  url: https://conda.anaconda.org/conda-forge/win-64/jasper-4.2.2-h28f2b1a_0.conda
+  sha256: 2d2243a632ad090d5e16da022edf15ffb614ac2b1b8259f7d36a7b0f6586b8ba
+  md5: 6e0fea3372dd7fe1ba8bb6de0ba53214
   depends:
   - freeglut >=3.2.2,<4.0a0
   - libjpeg-turbo >=3.0.0,<4.0a0
@@ -4913,98 +4977,99 @@ packages:
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: JasPer-2.0
-  size: 441542
-  timestamp: 1707216567670
+  size: 441457
+  timestamp: 1710248020717
 - kind: conda
   name: jasper
-  version: 4.2.0
+  version: 4.2.2
   build: h381c573_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/jasper-4.2.0-h381c573_0.conda
-  sha256: 1fe07acdddec181b1f75e2a903a6104a6e9aede618dc2639f9f8613464fbcba9
-  md5: aa2adc330527a025bf96cfb86b7ae553
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/jasper-4.2.2-h381c573_0.conda
+  sha256: e4ccd4ad2ce67e6d919c99ae971f8f250c087ba6df15f39982ed7fedf354a72d
+  md5: 7356170c40071693f44e2e72f987b8e8
   depends:
   - freeglut >=3.2.2,<4.0a0
   - libgcc-ng >=12
   - libglu >=9.0.0,<10.0a0
   - libjpeg-turbo >=3.0.0,<4.0a0
   license: JasPer-2.0
-  size: 718821
-  timestamp: 1707216422288
+  size: 710282
+  timestamp: 1710247626426
 - kind: conda
   name: jasper
-  version: 4.2.0
+  version: 4.2.2
   build: h6ff19ee_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/jasper-4.2.0-h6ff19ee_0.conda
-  sha256: 73403dee7eecc78d430ec371f4bbd8d8645b53ef10809c38b1835d971dbe2765
-  md5: a34e037a284f9029b962f9375e7b7770
+  url: https://conda.anaconda.org/conda-forge/osx-64/jasper-4.2.2-h6ff19ee_0.conda
+  sha256: 4df291df2b8635775db6fedb7653b2c8c0f39ef189ec28392436e1a34a52d95f
+  md5: c78b81fac38c6087dac6b5928e2c0580
   depends:
   - libjpeg-turbo >=3.0.0,<4.0a0
   license: JasPer-2.0
-  size: 570602
-  timestamp: 1707219763546
+  size: 571794
+  timestamp: 1710248000619
 - kind: conda
   name: jasper
-  version: 4.2.0
+  version: 4.2.2
   build: h7c0e182_0
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/jasper-4.2.0-h7c0e182_0.conda
-  sha256: 319b5f6a48f0574703a129e83f0e68a1e91826c203f6298e5004e64a6f7c98ef
-  md5: 100e3e14c13a78c72c50bba021f7e88c
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/jasper-4.2.2-h7c0e182_0.conda
+  sha256: dbaf7e5593d94b279604b77715b28dd747c5cf077eca6d85face5386fac48be9
+  md5: e435608987d8e3cb708a6787c0ec1ec9
   depends:
   - libjpeg-turbo >=3.0.0,<4.0a0
   license: JasPer-2.0
-  size: 583986
-  timestamp: 1707216785448
+  size: 583791
+  timestamp: 1710247861728
 - kind: conda
   name: jasper
-  version: 4.2.0
+  version: 4.2.2
   build: he6dfbbe_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/jasper-4.2.0-he6dfbbe_0.conda
-  sha256: 2c7402313dfe18027b5a04968ed61da2f5fd4db412b30473bb634d3f0fd37b3e
-  md5: ba48f3659627380d18e236312c65bd76
+  url: https://conda.anaconda.org/conda-forge/linux-64/jasper-4.2.2-he6dfbbe_0.conda
+  sha256: d9b469f4db600e68d9f78d291e64161a45699c7a8a04cadf1f96dfe6090a5097
+  md5: 629e33f68784c1fb678ac7e6f0d9b249
   depends:
   - freeglut >=3.2.2,<4.0a0
-  - libgcc-ng >=12
   - libglu >=9.0.0,<10.0a0
   - libjpeg-turbo >=3.0.0,<4.0a0
   license: JasPer-2.0
-  size: 676385
-  timestamp: 1707216242945
+  size: 680136
+  timestamp: 1710247563229
 - kind: conda
   name: kernel-headers_linux-64
   version: 2.6.32
-  build: he073ed8_16
-  build_number: 16
+  build: he073ed8_17
+  build_number: 17
   subdir: noarch
   noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-2.6.32-he073ed8_16.conda
-  sha256: aaa8aa6dc776d734a6702032588ff3c496721da905366d91162e3654c082aef0
-  md5: 7ca122655873935e02c91279c5b03c8c
+  url: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-2.6.32-he073ed8_17.conda
+  sha256: fb39d64b48f3d9d1acc3df208911a41f25b6a00bd54935d5973b4739a9edd5b6
+  md5: d731b543793afc0433c4fd593e693fce
   constrains:
   - sysroot_linux-64 ==2.12
   license: LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0
   license_family: GPL
-  size: 709007
-  timestamp: 1689214970644
+  size: 710627
+  timestamp: 1708000830116
 - kind: conda
   name: kernel-headers_linux-aarch64
   version: 4.18.0
-  build: h5b4a56d_13
-  build_number: 13
+  build: h5b4a56d_14
+  build_number: 14
   subdir: noarch
   noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-aarch64-4.18.0-h5b4a56d_13.tar.bz2
-  sha256: 14e227d98193550f9da275e58e27de104ab569849f1ce16b810fae4d7b351d49
-  md5: a9385e5b11a076c40d75915986f498d7
+  url: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-aarch64-4.18.0-h5b4a56d_14.conda
+  sha256: c44b178b38de4126d50a71501ac9e1c49119bb7aba9d09ab861ba12bc8d4e21c
+  md5: 9b0446ad203105e5bbdda273a78d1d0f
+  depends:
+  - _sysroot_linux-aarch64_curr_repodata_hack 4.*
   constrains:
   - sysroot_linux-aarch64 ==2.17
   license: LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0
   license_family: GPL
-  size: 1163630
-  timestamp: 1635519647658
+  size: 1114567
+  timestamp: 1708000894708
 - kind: conda
   name: keyutils
   version: 1.6.1
@@ -5194,88 +5259,84 @@ packages:
   timestamp: 1664996421531
 - kind: conda
   name: ld64
-  version: '609'
-  build: h634c8be_16
-  build_number: 16
+  version: '711'
+  build: h634c8be_0
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ld64-609-h634c8be_16.conda
-  sha256: 50c54ec77602fd553d1ca7965bb63fee0983154bbc044fe3209575881be42310
-  md5: 82582e7ed6bb5db878d4a01d9b70aad7
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ld64-711-h634c8be_0.conda
+  sha256: bf1fa905f08aa2044d5ca9a387c4d626c1b92a81773665268e87cf03a4db1159
+  md5: 5fb1c87739bf8f52d36cb001248e29b6
   depends:
-  - ld64_osx-arm64 609 ha4bd21c_16
+  - ld64_osx-arm64 711 ha4bd21c_0
   - libllvm16 >=16.0.6,<16.1.0a0
   constrains:
-  - cctools 973.0.1.*
-  - cctools_osx-arm64 973.0.1.*
+  - cctools 986.*
+  - cctools_osx-arm64 986.*
   license: APSL-2.0
   license_family: Other
-  size: 19326
-  timestamp: 1706798204562
+  size: 18884
+  timestamp: 1710466784602
 - kind: conda
   name: ld64
-  version: '609'
-  build: ha02d983_16
-  build_number: 16
+  version: '711'
+  build: ha02d983_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/ld64-609-ha02d983_16.conda
-  sha256: 63cd1976379a7e0ff8b0e57b0e16b112a0077acce83af364251ab309128a227d
-  md5: 6dfb00e6cab263fe598d48df153d3288
+  url: https://conda.anaconda.org/conda-forge/osx-64/ld64-711-ha02d983_0.conda
+  sha256: 189f5a0f9f923ee7f165fd9f18633ffa5680c24118d731c0a9956ac21dd42720
+  md5: 3ae4930ec076735cce481e906f5192e0
   depends:
-  - ld64_osx-64 609 ha20a434_16
+  - ld64_osx-64 711 ha20a434_0
   - libllvm16 >=16.0.6,<16.1.0a0
   constrains:
-  - cctools_osx-64 973.0.1.*
-  - cctools 973.0.1.*
+  - cctools 986.*
+  - cctools_osx-64 986.*
   license: APSL-2.0
   license_family: Other
-  size: 19310
-  timestamp: 1706798136816
+  size: 18819
+  timestamp: 1710466446391
 - kind: conda
   name: ld64_osx-64
-  version: '609'
-  build: ha20a434_16
-  build_number: 16
+  version: '711'
+  build: ha20a434_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/ld64_osx-64-609-ha20a434_16.conda
-  sha256: eef540c95a418169617bdda1699d8f5441f819ed673d81f363c5c728a6273749
-  md5: db19844278d11471e5f4eddf50277f4f
+  url: https://conda.anaconda.org/conda-forge/osx-64/ld64_osx-64-711-ha20a434_0.conda
+  sha256: 8c4cdd119ff4d8c83f6ae044c76560be302e4986ec1d5f278943ed9319f1171c
+  md5: a8b41eb97c8a9d618243a79ba78fdc3c
   depends:
   - libcxx
   - libllvm16 >=16.0.6,<16.1.0a0
   - sigtool
   - tapi >=1100.0.11,<1101.0a0
   constrains:
-  - cctools_osx-64 973.0.1.*
-  - cctools 973.0.1.*
   - clang >=16.0.6,<17.0a0
-  - ld 609.*
+  - cctools 986.*
+  - ld 711.*
+  - cctools_osx-64 986.*
   license: APSL-2.0
   license_family: Other
-  size: 1055029
-  timestamp: 1706798033425
+  size: 1075550
+  timestamp: 1710466354788
 - kind: conda
   name: ld64_osx-arm64
-  version: '609'
-  build: ha4bd21c_16
-  build_number: 16
+  version: '711'
+  build: ha4bd21c_0
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ld64_osx-arm64-609-ha4bd21c_16.conda
-  sha256: 08acf7129ec9298d78943ecc913d09d500608ae7b3920fb88ec3aa4a052759c6
-  md5: 538b338b3a9f8712915ef9149606687b
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ld64_osx-arm64-711-ha4bd21c_0.conda
+  sha256: f27b661fa4cac5b351ed4ee0ec8c8baf27c2f982309a453968418438c8197450
+  md5: 38abda2ba1128fdde7b7108cc36a9d99
   depends:
   - libcxx
   - libllvm16 >=16.0.6,<16.1.0a0
   - sigtool
   - tapi >=1100.0.11,<1101.0a0
   constrains:
-  - cctools 973.0.1.*
-  - ld 609.*
+  - ld 711.*
   - clang >=16.0.6,<17.0a0
-  - cctools_osx-arm64 973.0.1.*
+  - cctools 986.*
+  - cctools_osx-arm64 986.*
   license: APSL-2.0
   license_family: Other
-  size: 1047208
-  timestamp: 1706798110129
+  size: 1066358
+  timestamp: 1710466668466
 - kind: conda
   name: ld_impl_linux-64
   version: '2.40'
@@ -5379,173 +5440,173 @@ packages:
   timestamp: 1657977526749
 - kind: conda
   name: libabseil
-  version: '20230802.1'
-  build: cxx17_h048a20a_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libabseil-20230802.1-cxx17_h048a20a_0.conda
-  sha256: 05431a6adb376a865e10d4ae673399d7890083c06f61cf18edb7c6629e75f39e
-  md5: 6554f5fb47c025273268bcdb7bf3cd48
+  version: '20240116.1'
+  build: cxx17_h2f0025b_2
+  build_number: 2
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libabseil-20240116.1-cxx17_h2f0025b_2.conda
+  sha256: bf8d5c1ee76960840d6a0e8eac4fd4111712a4745fffb1e6f9466feb3f11c1c6
+  md5: 85dff948e5ec41a2eba9eb8fb001d01e
   depends:
-  - libcxx >=15.0.7
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
   constrains:
+  - abseil-cpp =20240116.1
+  - libabseil-static =20240116.1=cxx17*
+  license: Apache-2.0
+  license_family: Apache
+  size: 1286200
+  timestamp: 1709159884574
+- kind: conda
+  name: libabseil
+  version: '20240116.1'
+  build: cxx17_h59595ed_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20240116.1-cxx17_h59595ed_2.conda
+  sha256: 9951421311285dd4335ad3aceffb223a4d3bc90fb804245508cd27aceb184a29
+  md5: 75648bc5dd3b8eab22406876c24d81ec
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  constrains:
+  - libabseil-static =20240116.1=cxx17*
+  - abseil-cpp =20240116.1
+  license: Apache-2.0
+  license_family: Apache
+  size: 1266503
+  timestamp: 1709159756788
+- kind: conda
+  name: libabseil
+  version: '20240116.1'
+  build: cxx17_h63175ca_2
+  build_number: 2
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libabseil-20240116.1-cxx17_h63175ca_2.conda
+  sha256: 565071112e6339051b037bb9c5dae3f4bbc3b45c6f7b8ee598d0ec9056346c93
+  md5: bda6bc65300c4188933d8c68abc97923
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - libabseil-static =20240116.1=cxx17*
+  - abseil-cpp =20240116.1
+  license: Apache-2.0
+  license_family: Apache
+  size: 1737645
+  timestamp: 1709160246325
+- kind: conda
+  name: libabseil
+  version: '20240116.1'
+  build: cxx17_hc1bcbd7_2
+  build_number: 2
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libabseil-20240116.1-cxx17_hc1bcbd7_2.conda
+  sha256: 30c0f569949a2fa0c5fd9aae3416e3f6623b9dd6fccdaa8d3437f143b67cca2a
+  md5: 819934a15bc13a0d30778bf18446ada6
+  depends:
+  - libcxx >=16
+  constrains:
+  - libabseil-static =20240116.1=cxx17*
   - __osx >=10.13
-  - libabseil-static =20230802.1=cxx17*
-  - abseil-cpp =20230802.1
+  - abseil-cpp =20240116.1
   license: Apache-2.0
   license_family: Apache
-  size: 1148356
-  timestamp: 1695064289396
+  size: 1133225
+  timestamp: 1709160179404
 - kind: conda
   name: libabseil
-  version: '20230802.1'
-  build: cxx17_h13dd4ca_0
+  version: '20240116.1'
+  build: cxx17_hebf3989_2
+  build_number: 2
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20230802.1-cxx17_h13dd4ca_0.conda
-  sha256: 459a58f36607246b4483d7a370c2d9a03e7f824e79da2c6e3e9d62abf80393e7
-  md5: fb6dfadc1898666616dfda242d8aea10
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20240116.1-cxx17_hebf3989_2.conda
+  sha256: 3e87e8da8e40c71f6107386f6e87aeadc8c7b42e2736f6ac894abe50c763d642
+  md5: 0b85aac2fab429166f76940791de071a
   depends:
-  - libcxx >=15.0.7
+  - libcxx >=16
   constrains:
-  - libabseil-static =20230802.1=cxx17*
-  - abseil-cpp =20230802.1
+  - abseil-cpp =20240116.1
+  - libabseil-static =20240116.1=cxx17*
   license: Apache-2.0
   license_family: Apache
-  size: 1173407
-  timestamp: 1695064439482
+  size: 1144666
+  timestamp: 1709160261245
 - kind: conda
-  name: libabseil
-  version: '20230802.1'
-  build: cxx17_h2f0025b_0
+  name: libaec
+  version: 1.1.3
+  build: h2f0025b_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libabseil-20230802.1-cxx17_h2f0025b_0.conda
-  sha256: 7890ac8c806e63d2acf8b6917151ad80a17c63b832bf0926723a890d9861b856
-  md5: d1d7afab9c131b52ffe11aed370d06cd
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libaec-1.1.3-h2f0025b_0.conda
+  sha256: 9c366233b4f4bf11e64ce886055aaac34445205a178061923300872e0564a4f2
+  md5: e52c4a30901a90354855e40992af907d
   depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  constrains:
-  - libabseil-static =20230802.1=cxx17*
-  - abseil-cpp =20230802.1
-  license: Apache-2.0
-  license_family: Apache
-  size: 1280284
-  timestamp: 1695064063958
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 35339
+  timestamp: 1711021162162
 - kind: conda
-  name: libabseil
-  version: '20230802.1'
-  build: cxx17_h59595ed_0
+  name: libaec
+  version: 1.1.3
+  build: h59595ed_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20230802.1-cxx17_h59595ed_0.conda
-  sha256: 8729021a93e67bb93b4e73ef0a132499db516accfea11561b667635bcd0507e7
-  md5: 2785ddf4cb0e7e743477991d64353947
+  url: https://conda.anaconda.org/conda-forge/linux-64/libaec-1.1.3-h59595ed_0.conda
+  sha256: 2ef420a655528bca9d269086cf33b7e90d2f54ad941b437fb1ed5eca87cee017
+  md5: 5e97e271911b8b2001a8b71860c32faa
   depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  constrains:
-  - abseil-cpp =20230802.1
-  - libabseil-static =20230802.1=cxx17*
-  license: Apache-2.0
-  license_family: Apache
-  size: 1263396
-  timestamp: 1695063868515
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 35446
+  timestamp: 1711021212685
 - kind: conda
-  name: libabseil
-  version: '20230802.1'
-  build: cxx17_h63175ca_0
+  name: libaec
+  version: 1.1.3
+  build: h63175ca_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libabseil-20230802.1-cxx17_h63175ca_0.conda
-  sha256: 8a016d49fad3d4216ce5ae4a60869b5384d31b2009e1ed9f445b6551ce7ef9e8
-  md5: 02674c18394394ee4f76cdbd1012f526
-  depends:
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  constrains:
-  - abseil-cpp =20230802.1
-  - libabseil-static =20230802.1=cxx17*
-  license: Apache-2.0
-  license_family: Apache
-  size: 1733638
-  timestamp: 1695064265262
-- kind: conda
-  name: libaec
-  version: 1.1.2
-  build: h13dd4ca_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libaec-1.1.2-h13dd4ca_1.conda
-  sha256: c9d6f01d511bd3686ce590addf829f34031b95e3feb34418496cbb45924c5d17
-  md5: b7962cdc2cedcc9f8d12928824c11fbd
-  depends:
-  - libcxx >=15.0.7
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 29002
-  timestamp: 1696474168895
-- kind: conda
-  name: libaec
-  version: 1.1.2
-  build: h2f0025b_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libaec-1.1.2-h2f0025b_1.conda
-  sha256: faf1c20e0a0f823c01913ae0243a3fc5ebe822689c95896d24f80492903b497a
-  md5: 35cdc41045e1041d7f3bf29081b3d3cb
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 35153
-  timestamp: 1696474043418
-- kind: conda
-  name: libaec
-  version: 1.1.2
-  build: h59595ed_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libaec-1.1.2-h59595ed_1.conda
-  sha256: fdde15e74dc099ab1083823ec0f615958e53d9a8fae10405af977de251668bea
-  md5: 127b0be54c1c90760d7fe02ea7a56426
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 35228
-  timestamp: 1696474021700
-- kind: conda
-  name: libaec
-  version: 1.1.2
-  build: h63175ca_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libaec-1.1.2-h63175ca_1.conda
-  sha256: 731dc77bce7d6425e2113b902023fba146e827cfe301bac565f92cc4e749588a
-  md5: 0b252d2bf460364bccb1523bcdbe4af6
+  url: https://conda.anaconda.org/conda-forge/win-64/libaec-1.1.3-h63175ca_0.conda
+  sha256: f5c293d3cfc00f71dfdb64bd65ab53625565f8778fc2d5790575bef238976ebf
+  md5: 8723000f6ffdbdaef16025f0a01b64c5
   depends:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: BSD-2-Clause
   license_family: BSD
-  size: 33554
-  timestamp: 1696474526588
+  size: 32567
+  timestamp: 1711021603471
 - kind: conda
   name: libaec
-  version: 1.1.2
-  build: he965462_1
-  build_number: 1
+  version: 1.1.3
+  build: h73e2aa4_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libaec-1.1.2-he965462_1.conda
-  sha256: 1b0a0b9b67e8f155ebdc7205a7421c7aff4850a740fc9f88b3fa23282c98ed72
-  md5: faa179050abc6af1385e0fe9dd074f91
+  url: https://conda.anaconda.org/conda-forge/osx-64/libaec-1.1.3-h73e2aa4_0.conda
+  sha256: dae5921339c5d89f4bf58a95fd4e9c76270dbf7f6a94f3c5081b574905fcccf8
+  md5: 66d3c1f6dd4636216b4fca7a748d50eb
   depends:
-  - libcxx >=15.0.7
+  - libcxx >=16
   license: BSD-2-Clause
   license_family: BSD
-  size: 29027
-  timestamp: 1696474151758
+  size: 28602
+  timestamp: 1711021419744
+- kind: conda
+  name: libaec
+  version: 1.1.3
+  build: hebf3989_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libaec-1.1.3-hebf3989_0.conda
+  sha256: 896189b7b48a194c46a3556ea04943ef81cbe0498521231f8eb25816a68bc8ed
+  md5: 6f0b8e56d2e7bae12a18fc5b2cd9f310
+  depends:
+  - libcxx >=16
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 28451
+  timestamp: 1711021498493
 - kind: conda
   name: libass
   version: 0.17.1
@@ -5975,56 +6036,77 @@ packages:
 - kind: conda
   name: libclang
   version: 15.0.7
-  build: default_h65c9d4d_4
-  build_number: 4
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang-15.0.7-default_h65c9d4d_4.conda
-  sha256: 5c5494f7ccc2f06cbf3ae2169f8a9f1fb523d38ecbb1041db5468dd8c5c8a1c7
-  md5: 857fa5cd2d4920120f0d413457ed28e8
+  build: default_h127d8a8_5
+  build_number: 5
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libclang-15.0.7-default_h127d8a8_5.conda
+  sha256: 606b79c8a4a926334191d79f4a1447aac1d82c43344e3a603cbba31ace859b8f
+  md5: 09b94dd3a7e304df5b83176239347920
   depends:
-  - libclang13 15.0.7 default_hf5d3afd_4
+  - libclang13 15.0.7 default_h5d6823c_5
   - libgcc-ng >=12
   - libllvm15 >=15.0.7,<15.1.0a0
   - libstdcxx-ng >=12
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 133451
-  timestamp: 1701414768968
+  size: 133467
+  timestamp: 1711064002817
 - kind: conda
   name: libclang
   version: 15.0.7
-  build: default_h6b1ee41_4
-  build_number: 4
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libclang-15.0.7-default_h6b1ee41_4.conda
-  sha256: 7ff11065d4706777ff18041e200715e512ea7313d424b1e04204e9291f836326
-  md5: 054a23b7162cadf8c7d7d54f90948c82
+  build: default_h3a3e6c3_5
+  build_number: 5
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libclang-15.0.7-default_h3a3e6c3_5.conda
+  sha256: 562dea76c17c30ed6d78734a9e40008f45cdab15611439d7d4e8250e0040f3ef
+  md5: 26e1a5a4ff7f8e3f5fb89be829818a75
   depends:
-  - libclang13 15.0.7 default_h89cd682_4
+  - libclang13 15.0.7 default_hf64faad_5
+  - libxml2 >=2.12.6,<3.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zstd >=1.5.5,<1.6.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 148436
+  timestamp: 1711068015076
+- kind: conda
+  name: libclang
+  version: 15.0.7
+  build: default_h7151d67_5
+  build_number: 5
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libclang-15.0.7-default_h7151d67_5.conda
+  sha256: ea3c840b7e931228007f1dc21c1cfe8e3e833990da9e92fff9c23c98d035b89a
+  md5: 2e7eb31c1431630f111be17f7f0cb948
+  depends:
+  - libclang13 15.0.7 default_h0edc4dd_5
   - libcxx >=16.0.6
   - libllvm15 >=15.0.7,<15.1.0a0
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 133689
-  timestamp: 1701415540597
+  size: 133819
+  timestamp: 1711067667338
 - kind: conda
   name: libclang
   version: 15.0.7
-  build: default_hb11cfb5_4
-  build_number: 4
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libclang-15.0.7-default_hb11cfb5_4.conda
-  sha256: 0b80441f222a91074d0e5edb0fbc3b1ce16ca2cdf6ab899721afdcc3a3ff6302
-  md5: c90f4cbb57839c98fef8f830e4b9972f
+  build: default_hb368394_5
+  build_number: 5
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang-15.0.7-default_hb368394_5.conda
+  sha256: d1434b409bfb07b32e0ec11c84885b5bff6dbd5a56639a8a3fe221f409b64c90
+  md5: 9c12c3c12f5dab6ec1b6421149cbd09c
   depends:
-  - libclang13 15.0.7 default_ha2b6cf4_4
+  - libclang13 15.0.7 default_hf9b4efe_5
   - libgcc-ng >=12
   - libllvm15 >=15.0.7,<15.1.0a0
   - libstdcxx-ng >=12
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 133384
-  timestamp: 1701412265788
+  size: 134146
+  timestamp: 1711066878589
 - kind: conda
   name: libclang
   version: 15.0.7
@@ -6043,110 +6125,70 @@ packages:
   size: 133641
   timestamp: 1701414923949
 - kind: conda
-  name: libclang
-  version: 15.0.7
-  build: default_hde6756a_4
-  build_number: 4
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libclang-15.0.7-default_hde6756a_4.conda
-  sha256: 1083e53f51b35c7a6769fafa2e7ab5bb85f953eb288eb4a62cddd8200db7c46d
-  md5: a621ea4ac3f826d02441369e73e53800
-  depends:
-  - libclang13 15.0.7 default_h85b4d89_4
-  - libxml2 >=2.12.1,<3.0.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - zstd >=1.5.5,<1.6.0a0
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 148080
-  timestamp: 1701415503085
-- kind: conda
   name: libclang-cpp16
   version: 16.0.6
-  build: default_h7151d67_5
-  build_number: 5
+  build: default_h7151d67_6
+  build_number: 6
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libclang-cpp16-16.0.6-default_h7151d67_5.conda
-  sha256: b308b6faee84c4646dca87221d8a0d1e293a8b9a2a1b83a4500abcd4dd6c8eca
-  md5: 3189f83f21974fa2a9204f949d2aff18
+  url: https://conda.anaconda.org/conda-forge/osx-64/libclang-cpp16-16.0.6-default_h7151d67_6.conda
+  sha256: 8d77bf8bb12e4dff0bdc0d6dbc9ec674a46470c4e51a1fc8ffec16ed7da3365f
+  md5: 7eaad118ab797d1427f8745c861d1925
   depends:
   - libcxx >=16.0.6
   - libllvm16 >=16.0.6,<16.1.0a0
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 12713468
-  timestamp: 1706894023056
+  size: 12714864
+  timestamp: 1711067666274
 - kind: conda
   name: libclang-cpp16
   version: 16.0.6
-  build: default_he012953_5
-  build_number: 5
+  build: default_he012953_6
+  build_number: 6
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libclang-cpp16-16.0.6-default_he012953_5.conda
-  sha256: a6b4c11571e3c20dc0e977d9a7b1670d991ef0cf807595b857405548706853eb
-  md5: 77908ba1789d35c808eeaae28b4c9dd4
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libclang-cpp16-16.0.6-default_he012953_6.conda
+  sha256: 83ebaab5779a592de1b349d29a0f633ec0d7ed2722746c616f89ecf43c7a6675
+  md5: 4562ed88b0429ac497603df91cdd4f5c
   depends:
   - libcxx >=16.0.6
   - libllvm16 >=16.0.6,<16.1.0a0
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 11813500
-  timestamp: 1706893965706
+  size: 11762505
+  timestamp: 1711066876125
 - kind: conda
   name: libclang13
   version: 15.0.7
-  build: default_h85b4d89_4
-  build_number: 4
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libclang13-15.0.7-default_h85b4d89_4.conda
-  sha256: 37917f88ea5beb660a86b2325b727a03db125e25182d8186921a7cc53966df9d
-  md5: c6b0181860717a08469a324c4180ff2d
-  depends:
-  - libzlib >=1.2.13,<1.3.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - zstd >=1.5.5,<1.6.0a0
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 21902269
-  timestamp: 1701415323912
-- kind: conda
-  name: libclang13
-  version: 15.0.7
-  build: default_h89cd682_4
-  build_number: 4
+  build: default_h0edc4dd_5
+  build_number: 5
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libclang13-15.0.7-default_h89cd682_4.conda
-  sha256: bb710896ffcda1f3233e94a62c84f0c31ac062e17a723b7fa034449010c5d085
-  md5: 974a771460156182b1871585cf534532
+  url: https://conda.anaconda.org/conda-forge/osx-64/libclang13-15.0.7-default_h0edc4dd_5.conda
+  sha256: fec1ff1ae4a49f96eefeae9dd14ea8d9e591fc29995861ad49e92104ae6bb8e6
+  md5: 3bfcf640ab0956a9db86335e917100e3
   depends:
   - libcxx >=16.0.6
   - libllvm15 >=15.0.7,<15.1.0a0
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 6952807
-  timestamp: 1701415435112
+  size: 6952364
+  timestamp: 1711067548768
 - kind: conda
   name: libclang13
   version: 15.0.7
-  build: default_ha2b6cf4_4
-  build_number: 4
+  build: default_h5d6823c_5
+  build_number: 5
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libclang13-15.0.7-default_ha2b6cf4_4.conda
-  sha256: e1d34d415160b69a401dc0662bf1b5378655193ed1364bf7dd14f055e76e4b60
-  md5: 898e0dd993afbed0d871b60c2eb33b83
+  url: https://conda.anaconda.org/conda-forge/linux-64/libclang13-15.0.7-default_h5d6823c_5.conda
+  sha256: 91ecfcf545a5d4588e9fad5db2b5b04eeef18cae1c03b790829ef8b978f06ccd
+  md5: 2d694a9ffdcc30e89dea34a8dcdab6ae
   depends:
   - libgcc-ng >=12
   - libllvm15 >=15.0.7,<15.1.0a0
   - libstdcxx-ng >=12
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 9581845
-  timestamp: 1701412208888
+  size: 9583734
+  timestamp: 1711063939856
 - kind: conda
   name: libclang13
   version: 15.0.7
@@ -6166,20 +6208,39 @@ packages:
 - kind: conda
   name: libclang13
   version: 15.0.7
-  build: default_hf5d3afd_4
-  build_number: 4
+  build: default_hf64faad_5
+  build_number: 5
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libclang13-15.0.7-default_hf64faad_5.conda
+  sha256: b952b85a6124442be3fe8af23d56f123548f7b28067f60615f7233197469a02d
+  md5: 2f96c58f89abccb04bbc8cd57961111f
+  depends:
+  - libzlib >=1.2.13,<1.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zstd >=1.5.5,<1.6.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 21892425
+  timestamp: 1711067804682
+- kind: conda
+  name: libclang13
+  version: 15.0.7
+  build: default_hf9b4efe_5
+  build_number: 5
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang13-15.0.7-default_hf5d3afd_4.conda
-  sha256: 788dcd2591009a217bf9533ede002ff3bc18a23966c17e3cc7332abdb44bf795
-  md5: 9c06f18affb9c9b011b367274116b364
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang13-15.0.7-default_hf9b4efe_5.conda
+  sha256: a274eac14210ad07fab66aaf611251b4e0f46260dd52d39b035ef5991837f448
+  md5: 873ad4ee72c905267ac4334456608985
   depends:
   - libgcc-ng >=12
   - libllvm15 >=15.0.7,<15.1.0a0
   - libstdcxx-ng >=12
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 9440025
-  timestamp: 1701414702096
+  size: 9429799
+  timestamp: 1711066800274
 - kind: conda
   name: libcups
   version: 2.3.3
@@ -6218,90 +6279,90 @@ packages:
   timestamp: 1689195353551
 - kind: conda
   name: libcurl
-  version: 8.5.0
+  version: 8.6.0
   build: h2d989ff_0
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.5.0-h2d989ff_0.conda
-  sha256: f1c04be217aaf161ce3c99a8d618871295b5dc1eae2f7ff7b32078af50303f5b
-  md5: f1211ed00947a84e15a964a8f459f620
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.6.0-h2d989ff_0.conda
+  sha256: 85d2cbba4b0435a6fbf22963a50d2fd8cf2124eb76118e62d616ef355003c5a5
+  md5: 3c0b1d8a9c8952e97c240fe0133dd27e
   depends:
   - krb5 >=1.21.2,<1.22.0a0
   - libnghttp2 >=1.58.0,<2.0a0
   - libssh2 >=1.11.0,<2.0a0
   - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.2.0,<4.0a0
+  - openssl >=3.2.1,<4.0a0
   - zstd >=1.5.5,<1.6.0a0
   license: curl
   license_family: MIT
-  size: 350298
-  timestamp: 1701860532373
+  size: 351423
+  timestamp: 1710591296327
 - kind: conda
   name: libcurl
-  version: 8.5.0
+  version: 8.6.0
   build: h4e8248e_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurl-8.5.0-h4e8248e_0.conda
-  sha256: 4f4f8b884927d0c6fad4a8f5d7afaf789fe4f6554448ac8b416231f2f3dc7490
-  md5: fa0f5edc06ffc25a01eed005c6dc3d8c
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurl-8.6.0-h4e8248e_0.conda
+  sha256: bb39e3b0209f14409ebb305d2485332c8a8ed492fd095ce997d92936f3e7d425
+  md5: 45c9c275ebb236102844300c6988ebb1
   depends:
   - krb5 >=1.21.2,<1.22.0a0
   - libgcc-ng >=12
   - libnghttp2 >=1.58.0,<2.0a0
   - libssh2 >=1.11.0,<2.0a0
   - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.2.0,<4.0a0
+  - openssl >=3.2.1,<4.0a0
   - zstd >=1.5.5,<1.6.0a0
   license: curl
   license_family: MIT
-  size: 399469
-  timestamp: 1701860213311
+  size: 400378
+  timestamp: 1710591072656
 - kind: conda
   name: libcurl
-  version: 8.5.0
+  version: 8.6.0
   build: h726d00d_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.5.0-h726d00d_0.conda
-  sha256: 7ec7e026be90da0965dfa6b92bbc905c852c13b27f3f83c47156db66ed0668f0
-  md5: 86d749e27fe00fa6b7d790a6feaa22a2
+  url: https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.6.0-h726d00d_0.conda
+  sha256: 2381d1d91e61b7521a6fb084bdcfbd0e9219c1294d8a89d36016240f3dad70fc
+  md5: 09569d6e3dc8bef57841f1fc69ea3ea6
   depends:
   - krb5 >=1.21.2,<1.22.0a0
   - libnghttp2 >=1.58.0,<2.0a0
   - libssh2 >=1.11.0,<2.0a0
   - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.2.0,<4.0a0
+  - openssl >=3.2.1,<4.0a0
   - zstd >=1.5.5,<1.6.0a0
   license: curl
   license_family: MIT
-  size: 367821
-  timestamp: 1701860630644
+  size: 371183
+  timestamp: 1710591172599
 - kind: conda
   name: libcurl
-  version: 8.5.0
+  version: 8.6.0
   build: hca28451_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.5.0-hca28451_0.conda
-  sha256: 00a6bea5ff90ca58eeb15ebc98e08ffb88bddaff27396bb62640064f59d29cf0
-  md5: 7144d5a828e2cae218e0e3c98d8a0aeb
+  url: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.6.0-hca28451_0.conda
+  sha256: 357ce806adf1818dc8dccdcd64627758e1858eb0d8a9c91aae4a0eeee2a44608
+  md5: 704739398d858872cb91610f49f0ef29
   depends:
   - krb5 >=1.21.2,<1.22.0a0
   - libgcc-ng >=12
   - libnghttp2 >=1.58.0,<2.0a0
   - libssh2 >=1.11.0,<2.0a0
   - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.2.0,<4.0a0
+  - openssl >=3.2.1,<4.0a0
   - zstd >=1.5.5,<1.6.0a0
   license: curl
   license_family: MIT
-  size: 389164
-  timestamp: 1701860147844
+  size: 391187
+  timestamp: 1710590979402
 - kind: conda
   name: libcurl
-  version: 8.5.0
+  version: 8.6.0
   build: hd5e4a3a_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.5.0-hd5e4a3a_0.conda
-  sha256: 8c933416c61445ab51515a5ca8c32ddc4f83180d5dc43684e4a80915022ffe1f
-  md5: c95eb3d60266dd47b8eb864e10d6bcf3
+  url: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.6.0-hd5e4a3a_0.conda
+  sha256: 49904a3c1ede193cf9044e8379067bf56850fb03f64abbf57ca45f7e6d2d3888
+  md5: 9cc8dea844a89245dfe8618521ef8d6a
   depends:
   - krb5 >=1.21.2,<1.22.0a0
   - libssh2 >=1.11.0,<2.0a0
@@ -6311,8 +6372,8 @@ packages:
   - vc14_runtime >=14.29.30139
   license: curl
   license_family: MIT
-  size: 323619
-  timestamp: 1701860670113
+  size: 325841
+  timestamp: 1710591351093
 - kind: conda
   name: libcxx
   version: 16.0.6
@@ -6407,19 +6468,19 @@ packages:
   timestamp: 1694922285678
 - kind: conda
   name: libdrm
-  version: 2.4.114
-  build: h166bdaf_0
+  version: 2.4.120
+  build: hd590300_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.114-h166bdaf_0.tar.bz2
-  sha256: 9316075084ad66f9f96d31836e83303a8199eec93c12d68661e41c44eed101e3
-  md5: efb58e80f5d0179a783c4e76c3df3b9c
+  url: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.120-hd590300_0.conda
+  sha256: 8622f52e517418ae7234081fac14a3caa8aec5d1ee5f881ca1f3b194d81c3150
+  md5: 7c3071bdf1d28b331a06bda6e85ab607
   depends:
   - libgcc-ng >=12
-  - libpciaccess >=0.17,<0.18.0a0
+  - libpciaccess >=0.18,<0.19.0a0
   license: MIT
   license_family: MIT
-  size: 305197
-  timestamp: 1667566354412
+  size: 303067
+  timestamp: 1708374304366
 - kind: conda
   name: libedit
   version: 3.1.20191231
@@ -6572,83 +6633,78 @@ packages:
   timestamp: 1685725977222
 - kind: conda
   name: libexpat
-  version: 2.5.0
-  build: h63175ca_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.5.0-h63175ca_1.conda
-  sha256: 794b2a9be72f176a2767c299574d330ffb76b2ed75d7fd20bee3bbadce5886cf
-  md5: 636cc3cbbd2e28bcfd2f73b2044aac2c
-  constrains:
-  - expat 2.5.0.*
-  license: MIT
-  license_family: MIT
-  size: 138689
-  timestamp: 1680190844101
-- kind: conda
-  name: libexpat
-  version: 2.5.0
-  build: hb7217d7_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.5.0-hb7217d7_1.conda
-  sha256: 7d143a9c991579ad4207f84c632650a571c66329090daa32b3c87cf7311c3381
-  md5: 5a097ad3d17e42c148c9566280481317
-  constrains:
-  - expat 2.5.0.*
-  license: MIT
-  license_family: MIT
-  size: 63442
-  timestamp: 1680190916539
-- kind: conda
-  name: libexpat
-  version: 2.5.0
-  build: hcb278e6_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.5.0-hcb278e6_1.conda
-  sha256: 74c98a563777ae2ad71f1f74d458a8ab043cee4a513467c159ccf159d0e461f3
-  md5: 6305a3dd2752c76335295da4e581f2fd
-  depends:
-  - libgcc-ng >=12
-  constrains:
-  - expat 2.5.0.*
-  license: MIT
-  license_family: MIT
-  size: 77980
-  timestamp: 1680190528313
-- kind: conda
-  name: libexpat
-  version: 2.5.0
-  build: hd600fc2_1
-  build_number: 1
+  version: 2.6.2
+  build: h2f0025b_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libexpat-2.5.0-hd600fc2_1.conda
-  sha256: b4651d196d5adb0637c678d874160a318078d963caec264bda7ac07ff6a1cbc7
-  md5: 6cd3d0a28437b3845c260f9d71d434d7
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libexpat-2.6.2-h2f0025b_0.conda
+  sha256: 07453df3232a649f39fb4d1e68cfe1c78c3457764f85225f6f3ccd1bdd9818a4
+  md5: 1b9f46b804a2c3c5d7fd6a80b77c35f9
   depends:
   - libgcc-ng >=12
   constrains:
-  - expat 2.5.0.*
+  - expat 2.6.2.*
   license: MIT
   license_family: MIT
-  size: 77194
-  timestamp: 1680190675750
+  size: 72544
+  timestamp: 1710362309065
 - kind: conda
   name: libexpat
-  version: 2.5.0
-  build: hf0c8a7f_1
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.5.0-hf0c8a7f_1.conda
-  sha256: 80024bd9f44d096c4cc07fb2bac76b5f1f7553390112dab3ad6acb16a05f0b96
-  md5: 6c81cb022780ee33435cca0127dd43c9
+  version: 2.6.2
+  build: h59595ed_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.6.2-h59595ed_0.conda
+  sha256: 331bb7c7c05025343ebd79f86ae612b9e1e74d2687b8f3179faec234f986ce19
+  md5: e7ba12deb7020dd080c6c70e7b6f6a3d
+  depends:
+  - libgcc-ng >=12
   constrains:
-  - expat 2.5.0.*
+  - expat 2.6.2.*
   license: MIT
   license_family: MIT
-  size: 69602
-  timestamp: 1680191040160
+  size: 73730
+  timestamp: 1710362120304
+- kind: conda
+  name: libexpat
+  version: 2.6.2
+  build: h63175ca_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.6.2-h63175ca_0.conda
+  sha256: 79f612f75108f3e16bbdc127d4885bb74729cf66a8702fca0373dad89d40c4b7
+  md5: bc592d03f62779511d392c175dcece64
+  constrains:
+  - expat 2.6.2.*
+  license: MIT
+  license_family: MIT
+  size: 139224
+  timestamp: 1710362609641
+- kind: conda
+  name: libexpat
+  version: 2.6.2
+  build: h73e2aa4_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.6.2-h73e2aa4_0.conda
+  sha256: a188a77b275d61159a32ab547f7d17892226e7dac4518d2c6ac3ac8fc8dfde92
+  md5: 3d1d51c8f716d97c864d12f7af329526
+  constrains:
+  - expat 2.6.2.*
+  license: MIT
+  license_family: MIT
+  size: 69246
+  timestamp: 1710362566073
+- kind: conda
+  name: libexpat
+  version: 2.6.2
+  build: hebf3989_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.6.2-hebf3989_0.conda
+  sha256: ba7173ac30064ea901a4c9fb5a51846dcc25512ceb565759be7d18cbf3e5415e
+  md5: e3cde7cfa87f82f7cb13d482d5e0ad09
+  constrains:
+  - expat 2.6.2.*
+  license: MIT
+  license_family: MIT
+  size: 63655
+  timestamp: 1710362424980
 - kind: conda
   name: libffi
   version: 3.4.2
@@ -6999,110 +7055,106 @@ packages:
   timestamp: 1707330687590
 - kind: conda
   name: libglib
-  version: 2.78.3
-  build: h16e383f_0
+  version: 2.80.0
+  build: h39d0aa6_1
+  build_number: 1
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libglib-2.78.3-h16e383f_0.conda
-  sha256: 33527a11321609064c649682e709ebede86e24f1264dac1d018aaa00fb3b90bf
-  md5: c295badd19494ac8476b36e9e9e47ace
+  url: https://conda.anaconda.org/conda-forge/win-64/libglib-2.80.0-h39d0aa6_1.conda
+  sha256: 326fb2d1c8789660cec01eda3eec2fa15dd816d291126df13f1c34d80ffda6aa
+  md5: 6160439f169ec670951460024751b2ae
   depends:
-  - gettext >=0.21.1,<1.0a0
   - libffi >=3.4,<4.0a0
   - libiconv >=1.17,<2.0a0
   - libzlib >=1.2.13,<1.3.0a0
-  - pcre2 >=10.42,<10.43.0a0
+  - pcre2 >=10.43,<10.44.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   constrains:
-  - glib 2.78.3 *_0
+  - glib 2.80.0 *_1
   license: LGPL-2.1-or-later
-  size: 2620918
-  timestamp: 1702003409384
+  size: 2805065
+  timestamp: 1710939443433
 - kind: conda
   name: libglib
-  version: 2.78.3
-  build: h198397b_0
+  version: 2.80.0
+  build: h81c1438_1
+  build_number: 1
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libglib-2.78.3-h198397b_0.conda
-  sha256: 90e58879873b05617e0678ecfbf47bc740c1a2ed7840b8f7cd1241813b9037db
-  md5: e18624e441743b0d744116885b70f092
+  url: https://conda.anaconda.org/conda-forge/osx-64/libglib-2.80.0-h81c1438_1.conda
+  sha256: 5bc911f8c29878252f14dfc08fcf72cf550038a7102f9c03612fee9f7ccf6234
+  md5: e1c7ad2617b7ebe7589e87024d90ddda
   depends:
-  - __osx >=10.9
   - gettext >=0.21.1,<1.0a0
-  - libcxx >=16.0.6
   - libffi >=3.4,<4.0a0
   - libiconv >=1.17,<2.0a0
   - libzlib >=1.2.13,<1.3.0a0
-  - pcre2 >=10.42,<10.43.0a0
+  - pcre2 >=10.43,<10.44.0a0
   constrains:
-  - glib 2.78.3 *_0
+  - glib 2.80.0 *_1
   license: LGPL-2.1-or-later
-  size: 2489079
-  timestamp: 1702003188907
+  size: 2641391
+  timestamp: 1710939600553
 - kind: conda
   name: libglib
-  version: 2.78.3
-  build: h311d5f7_0
+  version: 2.80.0
+  build: h9d8fbc1_1
+  build_number: 1
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libglib-2.78.3-h311d5f7_0.conda
-  sha256: 4e400e259c42abf2850c660d2f484630f60d71be1aa66f4c6e43effed68d6961
-  md5: 09e44253dee99895f02cfad44dd8fea4
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libglib-2.80.0-h9d8fbc1_1.conda
+  sha256: 6f472f2bb3d4beda02668ec5d13ad29ab742dab6426f8204febb069d3ffa2a61
+  md5: 6dcce63f13ac16ab5ff26e00b2b92a12
   depends:
-  - gettext >=0.21.1,<1.0a0
   - libffi >=3.4,<4.0a0
   - libgcc-ng >=12
   - libiconv >=1.17,<2.0a0
-  - libstdcxx-ng >=12
   - libzlib >=1.2.13,<1.3.0a0
-  - pcre2 >=10.42,<10.43.0a0
+  - pcre2 >=10.43,<10.44.0a0
   constrains:
-  - glib 2.78.3 *_0
+  - glib 2.80.0 *_1
   license: LGPL-2.1-or-later
-  size: 2780828
-  timestamp: 1702002826554
+  size: 2995380
+  timestamp: 1710938796473
 - kind: conda
   name: libglib
-  version: 2.78.3
-  build: h783c2da_0
+  version: 2.80.0
+  build: hf2295e7_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.78.3-h783c2da_0.conda
-  sha256: b1b594294a0fe4c9a51596ef027efed9268d60827e8ae61fb7545c521a631e33
-  md5: 9bd06b12bbfa6fd1740fd23af4b0f0c7
+  url: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.80.0-hf2295e7_1.conda
+  sha256: 636d984568a1e5d915098a5020712f82bb3988635015765c3caf70f1a91340c5
+  md5: 0725f6081030c29b109088639824ff90
   depends:
-  - gettext >=0.21.1,<1.0a0
   - libffi >=3.4,<4.0a0
   - libgcc-ng >=12
   - libiconv >=1.17,<2.0a0
-  - libstdcxx-ng >=12
   - libzlib >=1.2.13,<1.3.0a0
-  - pcre2 >=10.42,<10.43.0a0
+  - pcre2 >=10.43,<10.44.0a0
   constrains:
-  - glib 2.78.3 *_0
+  - glib 2.80.0 *_1
   license: LGPL-2.1-or-later
-  size: 2696351
-  timestamp: 1702003069863
+  size: 2888982
+  timestamp: 1710939100254
 - kind: conda
   name: libglib
-  version: 2.78.3
-  build: hb438215_0
+  version: 2.80.0
+  build: hfc324ee_1
+  build_number: 1
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libglib-2.78.3-hb438215_0.conda
-  sha256: f26afb1003e810e768138b0c849e9408c0ae8635062aeaf7abae381903a84e53
-  md5: 8c98b7018b434236e2c0f14d7cf3c113
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libglib-2.80.0-hfc324ee_1.conda
+  sha256: b7411c3b19681fea1a33c093364cb2d8a021a408133399b23c947231aac157d9
+  md5: 3d8a5773a6ba1be1db8dc23ea9f44a0a
   depends:
-  - __osx >=10.9
   - gettext >=0.21.1,<1.0a0
-  - libcxx >=16.0.6
   - libffi >=3.4,<4.0a0
   - libiconv >=1.17,<2.0a0
   - libzlib >=1.2.13,<1.3.0a0
-  - pcre2 >=10.42,<10.43.0a0
+  - pcre2 >=10.43,<10.44.0a0
   constrains:
-  - glib 2.78.3 *_0
+  - glib 2.80.0 *_1
   license: LGPL-2.1-or-later
-  size: 2452441
-  timestamp: 1702003179895
+  size: 2630397
+  timestamp: 1710939388253
 - kind: conda
   name: libglu
   version: 9.0.0
@@ -7172,36 +7224,36 @@ packages:
   timestamp: 1706820564165
 - kind: conda
   name: libgpg-error
-  version: '1.47'
+  version: '1.48'
   build: h5ce24db_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgpg-error-1.47-h5ce24db_0.conda
-  sha256: 9cd58f2dc22bbcf485384f751369f6354b66e99d41daa3806cec1353fa321c31
-  md5: 95141e9738caf37c637ed073e79840f9
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgpg-error-1.48-h5ce24db_0.conda
+  sha256: c559389a67d3102410671b5ad8d9457e671dcb719aaedf151c2a9e8c13443ccd
+  md5: b4139dba81278589ea67408962cf8cdf
   depends:
   - gettext >=0.21.1,<1.0a0
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   license: GPL-2.0-only
   license_family: GPL
-  size: 272783
-  timestamp: 1686979747950
+  size: 278143
+  timestamp: 1708702398068
 - kind: conda
   name: libgpg-error
-  version: '1.47'
+  version: '1.48'
   build: h71f35ed_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgpg-error-1.47-h71f35ed_0.conda
-  sha256: 0306b3c2d65863048983a50bd8b86f6f26e457ef55d1da745a5796af25093f5a
-  md5: c2097d0b46367996f09b4e8e4920384a
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgpg-error-1.48-h71f35ed_0.conda
+  sha256: c448c6d86d27e10b9e844172000540e9cbfe9c28f968db87f949ba05add9bd50
+  md5: 4d18d86916705d352d5f4adfb7f0edd3
   depends:
   - gettext >=0.21.1,<1.0a0
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   license: GPL-2.0-only
   license_family: GPL
-  size: 260794
-  timestamp: 1686979818648
+  size: 266447
+  timestamp: 1708702470365
 - kind: conda
   name: libhwloc
   version: 2.9.3
@@ -8080,1094 +8132,1160 @@ packages:
 - kind: conda
   name: libopencv
   version: 4.9.0
-  build: py310ha3ab171_7
-  build_number: 7
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libopencv-4.9.0-py310ha3ab171_7.conda
-  sha256: f2703b20a2aa03a9a13b98928e78c1e4f1f3b16c804bfcf7d8c0b06af9c1e819
-  md5: 8f03be3b70b58a1ebe3ef46cc8a3fd35
+  build: headless_py311h18d748c_12
+  build_number: 12
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopencv-4.9.0-headless_py311h18d748c_12.conda
+  sha256: a22d8e66baedcff42595ed57129278369e8b4eaf4110e3380239a4c736a69073
+  md5: 2ab98d54fd67690cdc8cc3265ade46ba
   depends:
-  - __osx >=10.13
   - ffmpeg >=6.1.1,<7.0a0
   - freetype >=2.12.1,<3.0a0
+  - gettext >=0.21.1,<1.0a0
   - harfbuzz >=8.3.0,<9.0a0
   - hdf5 >=1.14.3,<1.14.4.0a0
-  - jasper >=4.1.2,<5.0a0
+  - jasper >=4.2.2,<5.0a0
   - libcblas >=3.9.0,<4.0a0
-  - libcxx >=15
-  - libglib >=2.78.3,<3.0a0
+  - libcxx >=16
+  - libglib >=2.80.0,<3.0a0
   - libiconv >=1.17,<2.0a0
   - libjpeg-turbo >=3.0.0,<4.0a0
   - liblapack >=3.9.0,<4.0a0
   - liblapacke >=3.9.0,<4.0a0
-  - libopenvino >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-auto-batch-plugin >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-auto-plugin >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-hetero-plugin >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-intel-cpu-plugin >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-ir-frontend >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-onnx-frontend >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-paddle-frontend >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-pytorch-frontend >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-tensorflow-frontend >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-tensorflow-lite-frontend >=2023.3.0,<2023.3.1.0a0
-  - libpng >=1.6.39,<1.7.0a0
-  - libprotobuf >=4.25.1,<4.25.2.0a0
+  - libopenvino >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-arm-cpu-plugin >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-auto-batch-plugin >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-auto-plugin >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-hetero-plugin >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-ir-frontend >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-onnx-frontend >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-paddle-frontend >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-pytorch-frontend >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-tensorflow-frontend >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-tensorflow-lite-frontend >=2024.0.0,<2024.0.1.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libprotobuf >=4.25.3,<4.25.4.0a0
   - libtiff >=4.6.0,<4.7.0a0
   - libwebp-base >=1.3.2,<2.0a0
   - libzlib >=1.2.13,<1.3.0a0
-  - numpy >=1.22.4,<2.0a0
+  - numpy >=1.23.5,<2.0a0
+  - openexr >=3.2.2,<3.3.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
   license: Apache-2.0
   license_family: Apache
-  size: 27391293
-  timestamp: 1706397604033
+  size: 16793743
+  timestamp: 1711065818771
 - kind: conda
   name: libopencv
   version: 4.9.0
-  build: py311h5435783_7
-  build_number: 7
+  build: headless_py311h773aa8a_12
+  build_number: 12
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopencv-4.9.0-py311h5435783_7.conda
-  sha256: bf57201c92ce99fc399744ac58f63f2563a794a8b0d920ec0f3b674959273308
-  md5: d9a6dc8d0c90694c488dfdeb7fed8c68
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopencv-4.9.0-headless_py311h773aa8a_12.conda
+  sha256: e646d24c1f242eb40713c0a937abaac4e45d1f776192216bf384192723b1a129
+  md5: dc856edd85270b00eda3c33c48cfa336
   depends:
   - _openmp_mutex >=4.5
   - ffmpeg >=6.1.1,<7.0a0
   - freetype >=2.12.1,<3.0a0
+  - gettext >=0.21.1,<1.0a0
   - harfbuzz >=8.3.0,<9.0a0
   - hdf5 >=1.14.3,<1.14.4.0a0
-  - jasper >=4.1.2,<5.0a0
+  - jasper >=4.2.2,<5.0a0
   - libcblas >=3.9.0,<4.0a0
   - libgcc-ng >=12
-  - libglib >=2.78.3,<3.0a0
+  - libglib >=2.80.0,<3.0a0
   - libiconv >=1.17,<2.0a0
   - libjpeg-turbo >=3.0.0,<4.0a0
   - liblapack >=3.9.0,<4.0a0
   - liblapacke >=3.9.0,<4.0a0
-  - libopenvino >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-arm-cpu-plugin >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-auto-batch-plugin >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-auto-plugin >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-hetero-plugin >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-ir-frontend >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-onnx-frontend >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-paddle-frontend >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-pytorch-frontend >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-tensorflow-frontend >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-tensorflow-lite-frontend >=2023.3.0,<2023.3.1.0a0
-  - libpng >=1.6.39,<1.7.0a0
-  - libprotobuf >=4.25.1,<4.25.2.0a0
+  - libopenvino >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-arm-cpu-plugin >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-auto-batch-plugin >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-auto-plugin >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-hetero-plugin >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-ir-frontend >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-onnx-frontend >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-paddle-frontend >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-pytorch-frontend >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-tensorflow-frontend >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-tensorflow-lite-frontend >=2024.0.0,<2024.0.1.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libprotobuf >=4.25.3,<4.25.4.0a0
   - libstdcxx-ng >=12
   - libtiff >=4.6.0,<4.7.0a0
   - libwebp-base >=1.3.2,<2.0a0
   - libzlib >=1.2.13,<1.3.0a0
   - numpy >=1.23.5,<2.0a0
+  - openexr >=3.2.2,<3.3.0a0
   - python >=3.11,<3.12.0a0 *_cpython
-  - qt-main >=5.15.8,<5.16.0a0
   license: Apache-2.0
   license_family: Apache
-  size: 20400937
-  timestamp: 1706396912816
+  size: 19540131
+  timestamp: 1711057888539
 - kind: conda
   name: libopencv
   version: 4.9.0
-  build: py311haea74c2_7
-  build_number: 7
+  build: headless_py39h1cbcdfd_12
+  build_number: 12
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libopencv-4.9.0-headless_py39h1cbcdfd_12.conda
+  sha256: 51956f3e06a7ceb1abceaa5fdd97ca13434e0e3d0afe8c75b358707fa818355e
+  md5: ffc389f68f36373c0f01be5834504ad1
+  depends:
+  - __osx >=10.13
+  - ffmpeg >=6.1.1,<7.0a0
+  - freetype >=2.12.1,<3.0a0
+  - gettext >=0.21.1,<1.0a0
+  - harfbuzz >=8.3.0,<9.0a0
+  - hdf5 >=1.14.3,<1.14.4.0a0
+  - jasper >=4.2.2,<5.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=16
+  - libglib >=2.80.0,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - liblapacke >=3.9.0,<4.0a0
+  - libopenvino >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-auto-batch-plugin >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-auto-plugin >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-hetero-plugin >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-intel-cpu-plugin >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-ir-frontend >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-onnx-frontend >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-paddle-frontend >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-pytorch-frontend >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-tensorflow-frontend >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-tensorflow-lite-frontend >=2024.0.0,<2024.0.1.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - libtiff >=4.6.0,<4.7.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - numpy >=1.22.4,<2.0a0
+  - openexr >=3.2.2,<3.3.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 27163393
+  timestamp: 1711060417560
+- kind: conda
+  name: libopencv
+  version: 4.9.0
+  build: qt5_py312h563a59f_512
+  build_number: 512
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libopencv-4.9.0-qt5_py312h563a59f_512.conda
+  sha256: d9b29fc09e5a14e2b0a9e60c9430a87db2c6cffc36863c6ce28d9ce95ded05f2
+  md5: f9729809174ca6017856c5543913f21d
+  depends:
+  - ffmpeg >=6.1.1,<7.0a0
+  - freetype >=2.12.1,<3.0a0
+  - gettext >=0.21.1,<1.0a0
+  - harfbuzz >=8.3.0,<9.0a0
+  - hdf5 >=1.14.3,<1.14.4.0a0
+  - jasper >=4.2.2,<5.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libglib >=2.80.0,<3.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - liblapacke >=3.9.0,<4.0a0
+  - libopenvino >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-auto-batch-plugin >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-auto-plugin >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-hetero-plugin >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-intel-cpu-plugin >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-intel-gpu-plugin >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-ir-frontend >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-onnx-frontend >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-paddle-frontend >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-pytorch-frontend >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-tensorflow-frontend >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-tensorflow-lite-frontend >=2024.0.0,<2024.0.1.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - libtiff >=4.6.0,<4.7.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - numpy >=1.26.4,<2.0a0
+  - openexr >=3.2.2,<3.3.0a0
+  - qt-main >=5.15.8,<5.16.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 32895170
+  timestamp: 1711064934347
+- kind: conda
+  name: libopencv
+  version: 4.9.0
+  build: qt5_py38h03d32d8_512
+  build_number: 512
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopencv-4.9.0-py311haea74c2_7.conda
-  sha256: 479107680fe980f41ff9f7e3f3457099126ca5aff537eee3ce2c4a31ae4643a2
-  md5: 4e3ad778805793f14107592be0e710a5
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopencv-4.9.0-qt5_py38h03d32d8_512.conda
+  sha256: 5d7491756b9e8d6fe78fe224a95f4225d837f0893fa803dbcbb7ea3e51ea1fef
+  md5: 27a7eb833d93b79a02ad6ec0f2680604
   depends:
   - __glibc >=2.17,<3.0.a0
   - _openmp_mutex >=4.5
   - ffmpeg >=6.1.1,<7.0a0
   - freetype >=2.12.1,<3.0a0
+  - gettext >=0.21.1,<1.0a0
   - harfbuzz >=8.3.0,<9.0a0
   - hdf5 >=1.14.3,<1.14.4.0a0
-  - jasper >=4.1.2,<5.0a0
+  - jasper >=4.2.2,<5.0a0
   - libcblas >=3.9.0,<4.0a0
   - libgcc-ng >=12
-  - libglib >=2.78.3,<3.0a0
+  - libglib >=2.80.0,<3.0a0
   - libiconv >=1.17,<2.0a0
   - libjpeg-turbo >=3.0.0,<4.0a0
   - liblapack >=3.9.0,<4.0a0
   - liblapacke >=3.9.0,<4.0a0
-  - libopenvino >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-auto-batch-plugin >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-auto-plugin >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-hetero-plugin >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-intel-cpu-plugin >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-intel-gpu-plugin >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-ir-frontend >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-onnx-frontend >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-paddle-frontend >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-pytorch-frontend >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-tensorflow-frontend >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-tensorflow-lite-frontend >=2023.3.0,<2023.3.1.0a0
-  - libpng >=1.6.39,<1.7.0a0
-  - libprotobuf >=4.25.1,<4.25.2.0a0
+  - libopenvino >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-auto-batch-plugin >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-auto-plugin >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-hetero-plugin >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-intel-cpu-plugin >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-intel-gpu-plugin >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-ir-frontend >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-onnx-frontend >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-paddle-frontend >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-pytorch-frontend >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-tensorflow-frontend >=2024.0.0,<2024.0.1.0a0
+  - libopenvino-tensorflow-lite-frontend >=2024.0.0,<2024.0.1.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libprotobuf >=4.25.3,<4.25.4.0a0
   - libstdcxx-ng >=12
   - libtiff >=4.6.0,<4.7.0a0
   - libwebp-base >=1.3.2,<2.0a0
   - libzlib >=1.2.13,<1.3.0a0
-  - numpy >=1.23.5,<2.0a0
+  - numpy >=1.22.4,<2.0a0
+  - openexr >=3.2.2,<3.3.0a0
   - qt-main >=5.15.8,<5.16.0a0
   license: Apache-2.0
   license_family: Apache
-  size: 30804850
-  timestamp: 1706397265285
-- kind: conda
-  name: libopencv
-  version: 4.9.0
-  build: py311hdccf81a_7
-  build_number: 7
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopencv-4.9.0-py311hdccf81a_7.conda
-  sha256: c2e197325e3e017d0426ead900d5ac1bb1249ff7bbb10f234e8ebeae67bf5eea
-  md5: 1249d406db539eec581152f8c0ad21f7
-  depends:
-  - ffmpeg >=6.1.1,<7.0a0
-  - freetype >=2.12.1,<3.0a0
-  - harfbuzz >=8.3.0,<9.0a0
-  - hdf5 >=1.14.3,<1.14.4.0a0
-  - jasper >=4.1.2,<5.0a0
-  - libcblas >=3.9.0,<4.0a0
-  - libcxx >=15
-  - libglib >=2.78.3,<3.0a0
-  - libiconv >=1.17,<2.0a0
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - liblapack >=3.9.0,<4.0a0
-  - liblapacke >=3.9.0,<4.0a0
-  - libopenvino >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-arm-cpu-plugin >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-auto-batch-plugin >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-auto-plugin >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-hetero-plugin >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-ir-frontend >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-onnx-frontend >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-paddle-frontend >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-pytorch-frontend >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-tensorflow-frontend >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-tensorflow-lite-frontend >=2023.3.0,<2023.3.1.0a0
-  - libpng >=1.6.39,<1.7.0a0
-  - libprotobuf >=4.25.1,<4.25.2.0a0
-  - libtiff >=4.6.0,<4.7.0a0
-  - libwebp-base >=1.3.2,<2.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - numpy >=1.23.5,<2.0a0
-  - python >=3.11,<3.12.0a0 *_cpython
-  license: Apache-2.0
-  license_family: Apache
-  size: 17202313
-  timestamp: 1706400635073
-- kind: conda
-  name: libopencv
-  version: 4.9.0
-  build: py312h766d233_7
-  build_number: 7
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libopencv-4.9.0-py312h766d233_7.conda
-  sha256: 5bca0ab39f5219d4c028918ca5cb0190b1ebee6acac7b58c64a997bdf275633a
-  md5: 41bbd33d4d69b2dd5200bfd86bd5f5fe
-  depends:
-  - ffmpeg >=6.1.1,<7.0a0
-  - freetype >=2.12.1,<3.0a0
-  - harfbuzz >=8.3.0,<9.0a0
-  - hdf5 >=1.14.3,<1.14.4.0a0
-  - jasper >=4.1.2,<5.0a0
-  - libcblas >=3.9.0,<4.0a0
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - liblapack >=3.9.0,<4.0a0
-  - liblapacke >=3.9.0,<4.0a0
-  - libopenvino >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-auto-batch-plugin >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-auto-plugin >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-hetero-plugin >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-intel-cpu-plugin >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-intel-gpu-plugin >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-ir-frontend >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-onnx-frontend >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-paddle-frontend >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-pytorch-frontend >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-tensorflow-frontend >=2023.3.0,<2023.3.1.0a0
-  - libopenvino-tensorflow-lite-frontend >=2023.3.0,<2023.3.1.0a0
-  - libpng >=1.6.39,<1.7.0a0
-  - libprotobuf >=4.25.1,<4.25.2.0a0
-  - libtiff >=4.6.0,<4.7.0a0
-  - libwebp-base >=1.3.2,<2.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - numpy >=1.26.3,<2.0a0
-  - qt-main >=5.15.8,<5.16.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: Apache
-  size: 33383534
-  timestamp: 1706398847318
+  size: 30320065
+  timestamp: 1711059044144
 - kind: conda
   name: libopenvino
-  version: 2023.3.0
-  build: h113ac47_0
+  version: 2024.0.0
+  build: h113ac47_4
+  build_number: 4
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-2023.3.0-h113ac47_0.conda
-  sha256: eed5300bb5ff993f35ba57c5f589c13e5d1e1204536f707cee5b08d41cfde5fe
-  md5: 1ef3c484b1ab71894b1fc34ebacdd43d
+  url: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-2024.0.0-h113ac47_4.conda
+  sha256: 18359d9a5d343a89fd9fb8d0dc7890b290c52fbfc51fc2fdc7e639246ddccc60
+  md5: 9d8a53bb2dbc55cee97d7c5093164e5b
   depends:
-  - libcxx >=15
+  - libcxx >=16
   - pugixml >=1.14,<1.15.0a0
   - tbb >=2021.11.0
-  size: 4740618
-  timestamp: 1706098076272
+  size: 3978821
+  timestamp: 1711026119791
 - kind: conda
   name: libopenvino
-  version: 2023.3.0
-  build: h2e90f83_0
+  version: 2024.0.0
+  build: h2e90f83_4
+  build_number: 4
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-2023.3.0-h2e90f83_0.conda
-  sha256: 0cf752211e89e534b7ca2b5faa2f1e696b436bcedee78f1200a59ee02920f04f
-  md5: 1cd43b2caa22f51118294978876502f7
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-2024.0.0-h2e90f83_4.conda
+  sha256: 901d6a974cf86c96f5ec29e7ef0e3a3bcf128ad9f48ee65d244d796512c2c8f5
+  md5: 126a2a61d276c4268f71adeef25bfc33
   depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   - pugixml >=1.14,<1.15.0a0
   - tbb >=2021.11.0
-  size: 5932555
-  timestamp: 1706095513626
+  size: 5111555
+  timestamp: 1711027178467
 - kind: conda
   name: libopenvino
-  version: 2023.3.0
-  build: h3e0449b_0
+  version: 2024.0.0
+  build: h3e0449b_4
+  build_number: 4
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-2023.3.0-h3e0449b_0.conda
-  sha256: 9cc473727e91301c45419ca75b92a7dfba5a871e26d2703cf63ae1ef179417ec
-  md5: dc8efb968fdca4aefb1f96de4cdea22c
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-2024.0.0-h3e0449b_4.conda
+  sha256: f0b6a9a5ba4c9f1792c20d91789dbc3ae50ba81a45d10470c2965aefc6bd227f
+  md5: d99b3eaf761f16a28397eb539b890547
   depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   - pugixml >=1.14,<1.15.0a0
   - tbb >=2021.11.0
-  size: 5316412
-  timestamp: 1706093593445
+  size: 4591172
+  timestamp: 1711021267498
 - kind: conda
   name: libopenvino
-  version: 2023.3.0
-  build: hc2557fa_0
+  version: 2024.0.0
+  build: hc2557fa_4
+  build_number: 4
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-2023.3.0-hc2557fa_0.conda
-  sha256: d4e27af57d18763172c9b899f4f23e85abb4584a22868f6dd93749b159cd13fd
-  md5: 7b5f4e3ecc0c7eeaf5d66629a822e87f
+  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-2024.0.0-hc2557fa_4.conda
+  sha256: d82e141f2e821d5f15995dff5873cd1c9ce0b3c892751442f840ec14518d766a
+  md5: 6471a7c178d58242f856b9ae89ea4a92
   depends:
   - pugixml >=1.14,<1.15.0a0
   - tbb >=2021.11.0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  size: 4150455
-  timestamp: 1706100273686
+  size: 3116652
+  timestamp: 1711027954881
 - kind: conda
   name: libopenvino
-  version: 2023.3.0
-  build: he6dadac_0
+  version: 2024.0.0
+  build: he6dadac_4
+  build_number: 4
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-2023.3.0-he6dadac_0.conda
-  sha256: c2dba5092411a76e168ae0beadfbfceb33c9a696a5e0adfa0293d61e8dc242f6
-  md5: 64b41dbbfc0a08866016bece25c76753
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-2024.0.0-he6dadac_4.conda
+  sha256: fc4c9e19a5314c6a50205f226062e0bcc6899749371fd6bf6399eafdff4b4adc
+  md5: 48783d76d1cff4a85dada8fc8de4106b
   depends:
-  - libcxx >=15
+  - libcxx >=16
   - pugixml >=1.14,<1.15.0a0
   - tbb >=2021.11.0
-  size: 4317458
-  timestamp: 1706096927739
+  size: 3667126
+  timestamp: 1711025235569
 - kind: conda
   name: libopenvino-arm-cpu-plugin
-  version: 2023.3.0
-  build: h3e0449b_0
+  version: 2024.0.0
+  build: h3e0449b_4
+  build_number: 4
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-arm-cpu-plugin-2023.3.0-h3e0449b_0.conda
-  sha256: 5a4b3581fd2a24dd0357431214f43423d9fb56ba93627474a0da5855c1a00d4d
-  md5: 64c7b64c5cfd3d2064f5efd92bf33c69
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-arm-cpu-plugin-2024.0.0-h3e0449b_4.conda
+  sha256: 5090bf7282e29f5f7322d4e6b4d838357da558ed6696b0e4558f56fbc96758b6
+  md5: 7af51baa5c9f8de6d8937ad1ad63054c
   depends:
   - libgcc-ng >=12
-  - libopenvino 2023.3.0 h3e0449b_0
+  - libopenvino 2024.0.0 h3e0449b_4
   - libstdcxx-ng >=12
   - pugixml >=1.14,<1.15.0a0
   - tbb >=2021.11.0
-  size: 5884633
-  timestamp: 1706093620063
+  size: 6193823
+  timestamp: 1711021298834
 - kind: conda
   name: libopenvino-arm-cpu-plugin
-  version: 2023.3.0
-  build: he6dadac_0
+  version: 2024.0.0
+  build: he6dadac_4
+  build_number: 4
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-arm-cpu-plugin-2023.3.0-he6dadac_0.conda
-  sha256: f73216881199749215e71b4627287b38d2b14a8702a3ebfde73095eb0fb530db
-  md5: c60046d907690ae42c0ef55e3bf9a2b6
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-arm-cpu-plugin-2024.0.0-he6dadac_4.conda
+  sha256: 129eea1691443392ffe6887ae8b704774164a21d7a40b6677f1ce099865c9c08
+  md5: 15808ae7cc119a909c2ef41e58a72c20
   depends:
-  - libcxx >=15
-  - libopenvino 2023.3.0 he6dadac_0
+  - libcxx >=16
+  - libopenvino 2024.0.0 he6dadac_4
   - pugixml >=1.14,<1.15.0a0
   - tbb >=2021.11.0
-  size: 5707756
-  timestamp: 1706096983291
+  size: 5910778
+  timestamp: 1711025307421
 - kind: conda
   name: libopenvino-auto-batch-plugin
-  version: 2023.3.0
-  build: h002f227_0
+  version: 2024.0.0
+  build: h002f227_4
+  build_number: 4
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-auto-batch-plugin-2023.3.0-h002f227_0.conda
-  sha256: d4b6e02ee94a60992d571809486627dfe538591da89a52573a516fb280144cda
-  md5: 7c93c18b73c7a3b2411a30b4a6479a95
+  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-auto-batch-plugin-2024.0.0-h002f227_4.conda
+  sha256: 445181150f4c89dc9b9d652ed7dbf80a63bea91ee0ae1565ca73542278355bef
+  md5: 1e220626bc704d43cb690b6479866bae
   depends:
-  - libopenvino 2023.3.0 hc2557fa_0
+  - libopenvino 2024.0.0 hc2557fa_4
   - tbb >=2021.11.0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  size: 102785
-  timestamp: 1706100336403
+  size: 98587
+  timestamp: 1711028047720
 - kind: conda
   name: libopenvino-auto-batch-plugin
-  version: 2023.3.0
-  build: h9adb129_0
+  version: 2024.0.0
+  build: h9adb129_4
+  build_number: 4
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-auto-batch-plugin-2023.3.0-h9adb129_0.conda
-  sha256: 725e19359a52d7883b75b5e30490546ba0ddc3bbb9d13726439cdc910e3de02d
-  md5: 1674861af8450baa042c9ec5ec5fb259
+  url: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-auto-batch-plugin-2024.0.0-h9adb129_4.conda
+  sha256: 735797a48790d2317ca18d081ae3fa96cede63bd7c1d749d95aabebd946e4b1b
+  md5: bc0a89ad1ab1fdc0ac29434109086c86
   depends:
-  - libcxx >=15
-  - libopenvino 2023.3.0 h113ac47_0
+  - libcxx >=16
+  - libopenvino 2024.0.0 h113ac47_4
   - tbb >=2021.11.0
-  size: 110495
-  timestamp: 1706098126610
+  size: 103483
+  timestamp: 1711026194169
 - kind: conda
   name: libopenvino-auto-batch-plugin
-  version: 2023.3.0
-  build: hc9f00d9_0
+  version: 2024.0.0
+  build: hc9f00d9_4
+  build_number: 4
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-auto-batch-plugin-2023.3.0-hc9f00d9_0.conda
-  sha256: bfdf1b76d4b89a6a612e0b675220881e07ccf28379bf6ad0713659b2709690a6
-  md5: 58741ce7d3318ccf685a2d6d50a86e59
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-auto-batch-plugin-2024.0.0-hc9f00d9_4.conda
+  sha256: c3cf9f7543eef2c3924b23b80f40bae51348d37e876959a6217c6543aa3db965
+  md5: 83a4a7cf4b07bd8cd9def70bbbc1f6b8
   depends:
-  - libcxx >=15
-  - libopenvino 2023.3.0 he6dadac_0
+  - libcxx >=16
+  - libopenvino 2024.0.0 he6dadac_4
   - tbb >=2021.11.0
-  size: 108058
-  timestamp: 1706097052472
+  size: 101644
+  timestamp: 1711025395864
 - kind: conda
   name: libopenvino-auto-batch-plugin
-  version: 2023.3.0
-  build: hd429f41_0
+  version: 2024.0.0
+  build: hd429f41_4
+  build_number: 4
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-auto-batch-plugin-2023.3.0-hd429f41_0.conda
-  sha256: d9f133140e9eff3b597791f30e03f310d64a71ae7800935f2ecb0a26830f348c
-  md5: 1511c331f949c2f1cdc27ddca841e65c
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-auto-batch-plugin-2024.0.0-hd429f41_4.conda
+  sha256: 364c62a3ccc819e3b0647b94933ca83b5d59c8dd35e9d16dca8478557fcc1faf
+  md5: 891f5b643aa3842cf82493c884d7d2dd
   depends:
   - libgcc-ng >=12
-  - libopenvino 2023.3.0 h3e0449b_0
+  - libopenvino 2024.0.0 h3e0449b_4
   - libstdcxx-ng >=12
   - tbb >=2021.11.0
-  size: 109577
-  timestamp: 1706093647899
+  size: 104627
+  timestamp: 1711021334086
 - kind: conda
   name: libopenvino-auto-batch-plugin
-  version: 2023.3.0
-  build: hd5fc58b_0
+  version: 2024.0.0
+  build: hd5fc58b_4
+  build_number: 4
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-batch-plugin-2023.3.0-hd5fc58b_0.conda
-  sha256: 7cae505b43001f8097c932fb791cf84450d406b3f8ecce1a775469c59194aa8a
-  md5: c246b3ce9b6976d3b31ebc0a107c4486
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-batch-plugin-2024.0.0-hd5fc58b_4.conda
+  sha256: 7997f2e1e24d79dbecbc7a275a0aef495cdb25018b19ab982b23147cfe80f659
+  md5: de9c380fea8634540db5fc8422888df1
   depends:
   - libgcc-ng >=12
-  - libopenvino 2023.3.0 h2e90f83_0
+  - libopenvino 2024.0.0 h2e90f83_4
   - libstdcxx-ng >=12
   - tbb >=2021.11.0
-  size: 115304
-  timestamp: 1706095539905
+  size: 110186
+  timestamp: 1711027220662
 - kind: conda
   name: libopenvino-auto-plugin
-  version: 2023.3.0
-  build: h002f227_0
+  version: 2024.0.0
+  build: h002f227_4
+  build_number: 4
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-auto-plugin-2023.3.0-h002f227_0.conda
-  sha256: 82c050c3fcd3dc030f3cdff04da6b54376a5abc7bcc9a4e62fd20eadaf3f1fe7
-  md5: fa0859641deb58647147b8c9c993d4e6
+  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-auto-plugin-2024.0.0-h002f227_4.conda
+  sha256: cda1e01e446eebb2d41833890dab03d1ea3c4c13bfbe4110a92f0bcc275941bf
+  md5: 540e607b26c81910275f5b2c25bcc6ff
   depends:
-  - libopenvino 2023.3.0 hc2557fa_0
+  - libopenvino 2024.0.0 hc2557fa_4
   - tbb >=2021.11.0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  size: 193732
-  timestamp: 1706100383207
+  size: 186806
+  timestamp: 1711028111911
 - kind: conda
   name: libopenvino-auto-plugin
-  version: 2023.3.0
-  build: h9adb129_0
+  version: 2024.0.0
+  build: h9adb129_4
+  build_number: 4
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-auto-plugin-2023.3.0-h9adb129_0.conda
-  sha256: b1ceb32c3d8c2a99fdf883b55d53c3097dcf5e94450292b1434fd62eb7dc1afa
-  md5: 10900b86dcad9ce1dd2b8ae208854339
+  url: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-auto-plugin-2024.0.0-h9adb129_4.conda
+  sha256: d417139fa5501b8765085443e811e91c90c4a45350378f34dc0fa2121edc4f3b
+  md5: 99efdc8defbec695d3b5c02359dc2c92
   depends:
-  - libcxx >=15
-  - libopenvino 2023.3.0 h113ac47_0
+  - libcxx >=16
+  - libopenvino 2024.0.0 h113ac47_4
   - tbb >=2021.11.0
-  size: 213888
-  timestamp: 1706098165163
+  size: 204632
+  timestamp: 1711026258627
 - kind: conda
   name: libopenvino-auto-plugin
-  version: 2023.3.0
-  build: hc9f00d9_0
+  version: 2024.0.0
+  build: hc9f00d9_4
+  build_number: 4
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-auto-plugin-2023.3.0-hc9f00d9_0.conda
-  sha256: ec1afea9273cdd4c1f77bd6786dfc56a2af5989c92d27a3d7e9ea5e16afbbdb5
-  md5: 896dc7a361e0082c7570b7865d7deff6
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-auto-plugin-2024.0.0-hc9f00d9_4.conda
+  sha256: 7a2cd693494c5a5cd5bd09727db88fe9e78a9fad8047269bf07be4ec61f40ace
+  md5: c05237e0d9572b6bacc316d32f4e746d
   depends:
-  - libcxx >=15
-  - libopenvino 2023.3.0 he6dadac_0
+  - libcxx >=16
+  - libopenvino 2024.0.0 he6dadac_4
   - tbb >=2021.11.0
-  size: 207024
-  timestamp: 1706097093752
+  size: 198650
+  timestamp: 1711025449439
 - kind: conda
   name: libopenvino-auto-plugin
-  version: 2023.3.0
-  build: hd429f41_0
+  version: 2024.0.0
+  build: hd429f41_4
+  build_number: 4
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-auto-plugin-2023.3.0-hd429f41_0.conda
-  sha256: 52b7dfebd749348efd8686ae505a02742464699d0c498701bb864c60901e5d8e
-  md5: a456a02824e3cfed081efb907f95e993
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-auto-plugin-2024.0.0-hd429f41_4.conda
+  sha256: 250ac7d2eedbdb13ecf18d303aa4bbae9f5c1b440a9b6dda929446b2a8cc8ac0
+  md5: 94131818c623c83ece60c2fca1c68a0b
   depends:
   - libgcc-ng >=12
-  - libopenvino 2023.3.0 h3e0449b_0
+  - libopenvino 2024.0.0 h3e0449b_4
   - libstdcxx-ng >=12
   - tbb >=2021.11.0
-  size: 218748
-  timestamp: 1706093665867
+  size: 211325
+  timestamp: 1711021356485
 - kind: conda
   name: libopenvino-auto-plugin
-  version: 2023.3.0
-  build: hd5fc58b_0
+  version: 2024.0.0
+  build: hd5fc58b_4
+  build_number: 4
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-plugin-2023.3.0-hd5fc58b_0.conda
-  sha256: dd41e78515edc6497d9a12258fead3a3fe55c36b1c420dc45754697a021a3a1c
-  md5: bbdfe24aec88f9cded013e24da5a3cec
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-plugin-2024.0.0-hd5fc58b_4.conda
+  sha256: 1ec1dc0cf9aa4e1879145f0d8645d6132d19e7f8ea0a678b500ee96a110527e7
+  md5: de1cbf145ecdc1d29af18e14eb267bca
   depends:
   - libgcc-ng >=12
-  - libopenvino 2023.3.0 h2e90f83_0
+  - libopenvino 2024.0.0 h2e90f83_4
   - libstdcxx-ng >=12
   - tbb >=2021.11.0
-  size: 238546
-  timestamp: 1706095555063
+  size: 229461
+  timestamp: 1711027252355
 - kind: conda
   name: libopenvino-hetero-plugin
-  version: 2023.3.0
-  build: h3ecfda7_0
+  version: 2024.0.0
+  build: h3ecfda7_4
+  build_number: 4
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-hetero-plugin-2023.3.0-h3ecfda7_0.conda
-  sha256: 8a9cd139d5680093fcdf9e3c30db6983a0d2702d0fb848741bd8ccf2656fe00a
-  md5: 93068e7b80a145689dfdd4b182957020
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-hetero-plugin-2024.0.0-h3ecfda7_4.conda
+  sha256: 6b530d036bf3a608c6cae2de4ab8f7e9471b53603c63b10d0a04c211e3325b1f
+  md5: 016b763e4776b4c2c536420a7e6a2349
   depends:
   - libgcc-ng >=12
-  - libopenvino 2023.3.0 h2e90f83_0
+  - libopenvino 2024.0.0 h2e90f83_4
   - libstdcxx-ng >=12
   - pugixml >=1.14,<1.15.0a0
-  size: 181775
-  timestamp: 1706095570201
+  size: 180199
+  timestamp: 1711027285756
 - kind: conda
   name: libopenvino-hetero-plugin
-  version: 2023.3.0
-  build: h7e3b17c_0
+  version: 2024.0.0
+  build: h7e3b17c_4
+  build_number: 4
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-hetero-plugin-2023.3.0-h7e3b17c_0.conda
-  sha256: 349aa190e4cc6690ff992f2ed44ac1ee77c8107d81e810940cc3b518f823825f
-  md5: 936abcc23c58dbab1a94c98e607c3ed0
+  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-hetero-plugin-2024.0.0-h7e3b17c_4.conda
+  sha256: 0ecd1693764ce97d01512c614e030ca745bb9e9dd09977e36fd943cb76b316ed
+  md5: 71df158a1f05a9ba4d27938a767ee899
   depends:
-  - libopenvino 2023.3.0 hc2557fa_0
+  - libopenvino 2024.0.0 hc2557fa_4
   - pugixml >=1.14,<1.15.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  size: 150827
-  timestamp: 1706100429322
+  size: 150628
+  timestamp: 1711028175536
 - kind: conda
   name: libopenvino-hetero-plugin
-  version: 2023.3.0
-  build: hc6dd956_0
+  version: 2024.0.0
+  build: hc6dd956_4
+  build_number: 4
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-hetero-plugin-2023.3.0-hc6dd956_0.conda
-  sha256: 5d4f26a39fb7506aab81d97fe1559c8638469b36f279d93437d222c3c5332966
-  md5: 0b36cf3dfe0cfd0570043d02500888e9
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-hetero-plugin-2024.0.0-hc6dd956_4.conda
+  sha256: b8d9d4a8c1cf43408d713883381f1f0c98af0b4bf6383c98b6b6b85c13b9fe4a
+  md5: d7f48666882d053dcdb9da3c39422936
   depends:
   - libgcc-ng >=12
-  - libopenvino 2023.3.0 h3e0449b_0
+  - libopenvino 2024.0.0 h3e0449b_4
   - libstdcxx-ng >=12
   - pugixml >=1.14,<1.15.0a0
-  size: 170271
-  timestamp: 1706093683826
+  size: 168072
+  timestamp: 1711021380636
 - kind: conda
   name: libopenvino-hetero-plugin
-  version: 2023.3.0
-  build: hf483cef_0
+  version: 2024.0.0
+  build: hf483cef_4
+  build_number: 4
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-hetero-plugin-2023.3.0-hf483cef_0.conda
-  sha256: 3e7d5548f662ebf15f17fb777ed07ce158e39fdd2d939f00b08c869867efe4df
-  md5: 0131f1038f2cee5e5589c046aa8476f4
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-hetero-plugin-2024.0.0-hf483cef_4.conda
+  sha256: 1e670b5ed9c7f81c9512ad08912e0a8ff15316b7ce95da75e4e8e58796a1de06
+  md5: 18b7390ccce7e83d0d36a1131ea6cb84
   depends:
-  - libcxx >=15
-  - libopenvino 2023.3.0 he6dadac_0
+  - libcxx >=16
+  - libopenvino 2024.0.0 he6dadac_4
   - pugixml >=1.14,<1.15.0a0
-  size: 161036
-  timestamp: 1706097137423
+  size: 159686
+  timestamp: 1711025501657
 - kind: conda
   name: libopenvino-hetero-plugin
-  version: 2023.3.0
-  build: hfe2fe54_0
+  version: 2024.0.0
+  build: hfe2fe54_4
+  build_number: 4
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-hetero-plugin-2023.3.0-hfe2fe54_0.conda
-  sha256: 2c909ff017f3d1a6f47da215e3c753b0630812b69a69613a0b7d261a0249be1c
-  md5: 937cc0b9c147f091e8de503fd9f87b76
+  url: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-hetero-plugin-2024.0.0-hfe2fe54_4.conda
+  sha256: 37bc25f92b6803d7d4a1e5424c780a75ad1eda4974ca6dbcc4cbb573e240a377
+  md5: cece1c44db441905aa3caaa79b1c8a86
   depends:
-  - libcxx >=15
-  - libopenvino 2023.3.0 h113ac47_0
+  - libcxx >=16
+  - libopenvino 2024.0.0 h113ac47_4
   - pugixml >=1.14,<1.15.0a0
-  size: 168632
-  timestamp: 1706098201368
+  size: 167431
+  timestamp: 1711026321577
 - kind: conda
   name: libopenvino-intel-cpu-plugin
-  version: 2023.3.0
-  build: h113ac47_0
+  version: 2024.0.0
+  build: h113ac47_4
+  build_number: 4
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-intel-cpu-plugin-2023.3.0-h113ac47_0.conda
-  sha256: a91bc764f25d540155ec751e4857a42dd2c3dcbf0e1beece618a8674f0f37d08
-  md5: 68e1bdc75b56222b6212e521813c6b11
+  url: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-intel-cpu-plugin-2024.0.0-h113ac47_4.conda
+  sha256: eb5985f740ee97b8a30efd7ff6a48c36e3eb33678bf7a3f6fb53d5fc4bcc9cc7
+  md5: 0714af035978be750d5e1f9adc8ee4cb
   depends:
-  - libcxx >=15
-  - libopenvino 2023.3.0 h113ac47_0
+  - libcxx >=16
+  - libopenvino 2024.0.0 h113ac47_4
   - pugixml >=1.14,<1.15.0a0
   - tbb >=2021.11.0
-  size: 9583651
-  timestamp: 1706098242445
+  size: 9930944
+  timestamp: 1711026387156
 - kind: conda
   name: libopenvino-intel-cpu-plugin
-  version: 2023.3.0
-  build: h2e90f83_0
+  version: 2024.0.0
+  build: h2e90f83_4
+  build_number: 4
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-cpu-plugin-2023.3.0-h2e90f83_0.conda
-  sha256: e2ed3d21349c9e6c8de576e7401396c76de5d004a8d8523ef78fa747a4117c87
-  md5: 2c2735c63288953e2108dc804fe52adf
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-cpu-plugin-2024.0.0-h2e90f83_4.conda
+  sha256: 2daa2f6fc584674adee84b036a9a267a6bcae731c912326efda155f2328586d8
+  md5: d866cc8dc37f101505e65a4372794631
   depends:
   - libgcc-ng >=12
-  - libopenvino 2023.3.0 h2e90f83_0
+  - libopenvino 2024.0.0 h2e90f83_4
   - libstdcxx-ng >=12
   - pugixml >=1.14,<1.15.0a0
   - tbb >=2021.11.0
-  size: 10201476
-  timestamp: 1706095585804
+  size: 10618695
+  timestamp: 1711027317641
 - kind: conda
   name: libopenvino-intel-cpu-plugin
-  version: 2023.3.0
-  build: hc2557fa_0
+  version: 2024.0.0
+  build: hc2557fa_4
+  build_number: 4
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-intel-cpu-plugin-2023.3.0-hc2557fa_0.conda
-  sha256: 1192cc95b6785372ebd9b13e4fca3db778208dbefd80171538379b967afc9106
-  md5: c000572da97636f5015116b8de0144fd
+  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-intel-cpu-plugin-2024.0.0-hc2557fa_4.conda
+  sha256: 264eb4dee7695a60d37b6eecbab4967db3c76a62f1b910c4d0ada4c076bbef3f
+  md5: 99906c0b41251d08acedd963214f080c
   depends:
-  - libopenvino 2023.3.0 hc2557fa_0
+  - libopenvino 2024.0.0 hc2557fa_4
   - pugixml >=1.14,<1.15.0a0
   - tbb >=2021.11.0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  size: 7048158
-  timestamp: 1706100492731
+  size: 7223389
+  timestamp: 1711028247831
 - kind: conda
   name: libopenvino-intel-gpu-plugin
-  version: 2023.3.0
-  build: h2e90f83_0
+  version: 2024.0.0
+  build: h2e90f83_4
+  build_number: 4
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-gpu-plugin-2023.3.0-h2e90f83_0.conda
-  sha256: 1bc8193fcf33072e2078a4dbbd86c5ebcc7cae5258b7a9d1ade0d5742e4efb06
-  md5: ee3930030324235a2e3ec5171b418481
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-gpu-plugin-2024.0.0-h2e90f83_4.conda
+  sha256: 15f0ad9ea10829d8964253b08667af015dfa4befa0afd2e6f3a44110f6efcb96
+  md5: 6ebefdc74cb700ec82cd6702125cc422
   depends:
   - libgcc-ng >=12
-  - libopenvino 2023.3.0 h2e90f83_0
+  - libopenvino 2024.0.0 h2e90f83_4
   - libstdcxx-ng >=12
-  - ocl-icd >=2.3.1,<3.0a0
-  - ocl-icd-system
+  - ocl-icd >=2.3.2,<3.0a0
   - pugixml >=1.14,<1.15.0a0
   - tbb >=2021.11.0
-  size: 8210562
-  timestamp: 1706095622466
+  size: 8353160
+  timestamp: 1711027380449
 - kind: conda
   name: libopenvino-intel-gpu-plugin
-  version: 2023.3.0
-  build: hc2557fa_0
+  version: 2024.0.0
+  build: hc2557fa_4
+  build_number: 4
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-intel-gpu-plugin-2023.3.0-hc2557fa_0.conda
-  sha256: 77acef2554a38d7a2c572dd7f1d778f689d6f34c3558bd4cc9c4521b1be737a8
-  md5: cddcf24ede63c8d6483a0442ca2e578b
+  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-intel-gpu-plugin-2024.0.0-hc2557fa_4.conda
+  sha256: 9db806c981d14942dd2f2a46f7d58003a267d28fe9b2afb14fcc3c144daec922
+  md5: 47f49ccca5334fc44dddaf9a8ad1dd84
   depends:
   - khronos-opencl-icd-loader >=2023.4.17
-  - libopenvino 2023.3.0 hc2557fa_0
+  - libopenvino 2024.0.0 hc2557fa_4
   - pugixml >=1.14,<1.15.0a0
   - tbb >=2021.11.0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  size: 7076471
-  timestamp: 1706100563024
+  size: 7151374
+  timestamp: 1711028339128
 - kind: conda
   name: libopenvino-ir-frontend
-  version: 2023.3.0
-  build: h3ecfda7_0
+  version: 2024.0.0
+  build: h3ecfda7_4
+  build_number: 4
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-ir-frontend-2023.3.0-h3ecfda7_0.conda
-  sha256: 59a40ec23729ec8c23592246caf24ce72d7497fca2721a5434591e258fb50594
-  md5: a3e2922d58b4cd9ee51ba8dbb80dfcc6
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-ir-frontend-2024.0.0-h3ecfda7_4.conda
+  sha256: 09c91b8701764154b41a2c82d0412939e5625c712edfe965496930cdad6c822e
+  md5: 6397395a4677d59bbd32c4f05bb8fa63
   depends:
   - libgcc-ng >=12
-  - libopenvino 2023.3.0 h2e90f83_0
+  - libopenvino 2024.0.0 h2e90f83_4
   - libstdcxx-ng >=12
   - pugixml >=1.14,<1.15.0a0
-  size: 199008
-  timestamp: 1706095653420
+  size: 201195
+  timestamp: 1711027432846
 - kind: conda
   name: libopenvino-ir-frontend
-  version: 2023.3.0
-  build: h7e3b17c_0
+  version: 2024.0.0
+  build: h7e3b17c_4
+  build_number: 4
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-ir-frontend-2023.3.0-h7e3b17c_0.conda
-  sha256: 7865a129bad4ded35f24ab510a02aa8a1914ddc71087103b928012076530b6dc
-  md5: 2cb21bc1584658d2896ce31efdfb57f6
+  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-ir-frontend-2024.0.0-h7e3b17c_4.conda
+  sha256: 77bc36d1501bc6c1b0b6fcd8589f7cfbc7e1ebe14dc1a0d4b25b208d9fe9ba1a
+  md5: 9a45a5589d14166671ae5463f9cf48cc
   depends:
-  - libopenvino 2023.3.0 hc2557fa_0
+  - libopenvino 2024.0.0 hc2557fa_4
   - pugixml >=1.14,<1.15.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  size: 157357
-  timestamp: 1706100624978
+  size: 157968
+  timestamp: 1711028420821
 - kind: conda
   name: libopenvino-ir-frontend
-  version: 2023.3.0
-  build: hc6dd956_0
+  version: 2024.0.0
+  build: hc6dd956_4
+  build_number: 4
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-ir-frontend-2023.3.0-hc6dd956_0.conda
-  sha256: 5172f715fbc38a22a837277c1205ab61489f5cfd6db72583cd07ba43399559ea
-  md5: 9c421cbe7ae8b91e67f50a0536a70a25
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-ir-frontend-2024.0.0-hc6dd956_4.conda
+  sha256: 57a97848d64d2f95b0f5ed1209da9f55965af4cbe1011700cd7e22a97addef6e
+  md5: 44041135feefb1a23b74484d4e28b7ad
   depends:
   - libgcc-ng >=12
-  - libopenvino 2023.3.0 h3e0449b_0
+  - libopenvino 2024.0.0 h3e0449b_4
   - libstdcxx-ng >=12
   - pugixml >=1.14,<1.15.0a0
-  size: 185300
-  timestamp: 1706093704008
+  size: 186649
+  timestamp: 1711021402947
 - kind: conda
   name: libopenvino-ir-frontend
-  version: 2023.3.0
-  build: hf483cef_0
+  version: 2024.0.0
+  build: hf483cef_4
+  build_number: 4
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-ir-frontend-2023.3.0-hf483cef_0.conda
-  sha256: 6457872a91895efecadccbd22e11a7498f353fa036349d93f2930b58d4d0fc4a
-  md5: '05097639405108128773486888481e00'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-ir-frontend-2024.0.0-hf483cef_4.conda
+  sha256: 90c6b63568d705aecd213f2de63cc0b8b0afafd30e61f72e76ab4302fd4cb863
+  md5: 77654f9ad0a6c38fb90d069ac7792d98
   depends:
-  - libcxx >=15
-  - libopenvino 2023.3.0 he6dadac_0
+  - libcxx >=16
+  - libopenvino 2024.0.0 he6dadac_4
   - pugixml >=1.14,<1.15.0a0
-  size: 168367
-  timestamp: 1706097179506
+  size: 170057
+  timestamp: 1711025552719
 - kind: conda
   name: libopenvino-ir-frontend
-  version: 2023.3.0
-  build: hfe2fe54_0
+  version: 2024.0.0
+  build: hfe2fe54_4
+  build_number: 4
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-ir-frontend-2023.3.0-hfe2fe54_0.conda
-  sha256: 5d12548a64a8606f3240e014f188cd42e540f91cade3f5561bb24fd41efef8f0
-  md5: 6ca936beb0a1675e1431c875432da7d7
+  url: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-ir-frontend-2024.0.0-hfe2fe54_4.conda
+  sha256: 64b45b4df151b80988d13f72cec3145ab3773f255e089d21cdb6a7ab7b2dc852
+  md5: c3f40e2622af41f0e597733266a0ec09
   depends:
-  - libcxx >=15
-  - libopenvino 2023.3.0 h113ac47_0
+  - libcxx >=16
+  - libopenvino 2024.0.0 h113ac47_4
   - pugixml >=1.14,<1.15.0a0
-  size: 176467
-  timestamp: 1706098326344
+  size: 178232
+  timestamp: 1711026493930
 - kind: conda
   name: libopenvino-onnx-frontend
-  version: 2023.3.0
-  build: h8f0bfdc_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-onnx-frontend-2023.3.0-h8f0bfdc_0.conda
-  sha256: 7b600d8bc35f4c3f627a9585c05f7e7fb921135c1be6600aab2d19f8798b6560
-  md5: ff4b819d7d69ddfe92199b5212470865
-  depends:
-  - libopenvino 2023.3.0 hc2557fa_0
-  - libprotobuf >=4.25.1,<4.25.2.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  size: 997950
-  timestamp: 1706100679612
-- kind: conda
-  name: libopenvino-onnx-frontend
-  version: 2023.3.0
-  build: h98f6304_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-onnx-frontend-2023.3.0-h98f6304_0.conda
-  sha256: 3ef80a0e9f216a244dbdfdefc55e02f8898bec34c38abc44237d2b022b03f2c5
-  md5: 197ea4d75d03fb4948d616850511f502
-  depends:
-  - libcxx >=15
-  - libopenvino 2023.3.0 he6dadac_0
-  - libprotobuf >=4.25.1,<4.25.2.0a0
-  size: 1198274
-  timestamp: 1706097221621
-- kind: conda
-  name: libopenvino-onnx-frontend
-  version: 2023.3.0
-  build: hb0b24c1_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-onnx-frontend-2023.3.0-hb0b24c1_0.conda
-  sha256: b460a6361a0c6a2fbd1a2aa59b15875c6f2d110bd1b217a57c0e64f8e0e7e967
-  md5: ba7e384a8b055243ae0293362b13ffa8
-  depends:
-  - libgcc-ng >=12
-  - libopenvino 2023.3.0 h3e0449b_0
-  - libprotobuf >=4.25.1,<4.25.2.0a0
-  - libstdcxx-ng >=12
-  size: 1375405
-  timestamp: 1706093722570
-- kind: conda
-  name: libopenvino-onnx-frontend
-  version: 2023.3.0
-  build: hd0b7f58_0
+  version: 2024.0.0
+  build: h1a3ed6a_4
+  build_number: 4
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-onnx-frontend-2023.3.0-hd0b7f58_0.conda
-  sha256: 621c32065ed8fc38dd0777b9a04d8d039c1a6220f0ce29509619867b97441923
-  md5: 9583b4293844c3500c9718f06fad8b63
+  url: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-onnx-frontend-2024.0.0-h1a3ed6a_4.conda
+  sha256: 16da5c3b4526a340145e074b32253221059f60389bc6c048cec8dc2767ad357e
+  md5: 543a343c411d307d3076e021f4eec355
   depends:
   - __osx >=10.13
-  - libcxx >=15
-  - libopenvino 2023.3.0 h113ac47_0
-  - libprotobuf >=4.25.1,<4.25.2.0a0
-  size: 1264771
-  timestamp: 1706098366523
+  - libcxx >=16
+  - libopenvino 2024.0.0 h113ac47_4
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  size: 1264777
+  timestamp: 1711026558792
 - kind: conda
   name: libopenvino-onnx-frontend
-  version: 2023.3.0
-  build: hfbc7f12_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-onnx-frontend-2023.3.0-hfbc7f12_0.conda
-  sha256: 7fa26c36f4bb3a636af8923ff1313061845b1b0e1bc03a206017e4bcd3f00c23
-  md5: da9b47d41e0357f66af895327a8ac72d
+  version: 2024.0.0
+  build: h298fcef_4
+  build_number: 4
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-onnx-frontend-2024.0.0-h298fcef_4.conda
+  sha256: 4b8a7777d10b327fce52d8bab324d94ff12d5c3a008a40ddcd86699f5cebfa7c
+  md5: d3d7b3d5d7b9e59fdcf68bbbdbb571cc
   depends:
-  - libgcc-ng >=12
-  - libopenvino 2023.3.0 h2e90f83_0
-  - libprotobuf >=4.25.1,<4.25.2.0a0
-  - libstdcxx-ng >=12
-  size: 1543070
-  timestamp: 1706095670120
+  - libcxx >=16
+  - libopenvino 2024.0.0 he6dadac_4
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  size: 1198233
+  timestamp: 1711025605707
 - kind: conda
-  name: libopenvino-paddle-frontend
-  version: 2023.3.0
-  build: h8f0bfdc_0
+  name: libopenvino-onnx-frontend
+  version: 2024.0.0
+  build: h55b4db4_4
+  build_number: 4
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-paddle-frontend-2023.3.0-h8f0bfdc_0.conda
-  sha256: 6116aef26283f27ec6c8937e09e71b9c8ba3bc666799585420bd3c80ea0767d9
-  md5: 9f5751793f2023ff946f8f6bb6053c0f
+  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-onnx-frontend-2024.0.0-h55b4db4_4.conda
+  sha256: d5fb8ea4a2eb7d27cb29171f9c84bf63ca9f6473852c8b2b9d8a87e0901ba297
+  md5: 5b603ddb74d306d4e9a1871a46e232c4
   depends:
-  - libopenvino 2023.3.0 hc2557fa_0
-  - libprotobuf >=4.25.1,<4.25.2.0a0
+  - libopenvino 2024.0.0 hc2557fa_4
+  - libprotobuf >=4.25.3,<4.25.4.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  size: 410988
-  timestamp: 1706100731323
+  size: 987441
+  timestamp: 1711028489373
 - kind: conda
-  name: libopenvino-paddle-frontend
-  version: 2023.3.0
-  build: h98f6304_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-paddle-frontend-2023.3.0-h98f6304_0.conda
-  sha256: 4012373cd35caaa3fdf36e4f67a9793e0f1f7fedf3e27e15c9fe8598b0d56d04
-  md5: edf222dbe2a2718760db3d8cc851b63a
-  depends:
-  - libcxx >=15
-  - libopenvino 2023.3.0 he6dadac_0
-  - libprotobuf >=4.25.1,<4.25.2.0a0
-  size: 405107
-  timestamp: 1706097264140
-- kind: conda
-  name: libopenvino-paddle-frontend
-  version: 2023.3.0
-  build: hb0b24c1_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-paddle-frontend-2023.3.0-hb0b24c1_0.conda
-  sha256: e9587d1265fab8ef64ec029b653e28543cebe70eade4e6964dd7ed647d1661ff
-  md5: 2716736ca82bc23b7dea0ee950388b7d
+  name: libopenvino-onnx-frontend
+  version: 2024.0.0
+  build: h757c851_4
+  build_number: 4
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-onnx-frontend-2024.0.0-h757c851_4.conda
+  sha256: c29f5bead57bfb14cca7bd89e20f13eb18ec9a4624dcff1d56834454deb3be9c
+  md5: 24c9cf1dd8f6d6189102a136a731758c
   depends:
   - libgcc-ng >=12
-  - libopenvino 2023.3.0 h3e0449b_0
-  - libprotobuf >=4.25.1,<4.25.2.0a0
+  - libopenvino 2024.0.0 h2e90f83_4
+  - libprotobuf >=4.25.3,<4.25.4.0a0
   - libstdcxx-ng >=12
-  size: 604273
-  timestamp: 1706093742456
+  size: 1586430
+  timestamp: 1711027467156
+- kind: conda
+  name: libopenvino-onnx-frontend
+  version: 2024.0.0
+  build: h81208d3_4
+  build_number: 4
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-onnx-frontend-2024.0.0-h81208d3_4.conda
+  sha256: 766e78e6400a2be23cb23c33428873df87943f33b2afddf22124fe706b20c867
+  md5: bd078064c35012e2c28e58d2d39069f8
+  depends:
+  - libgcc-ng >=12
+  - libopenvino 2024.0.0 h3e0449b_4
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - libstdcxx-ng >=12
+  size: 1403136
+  timestamp: 1711021425932
 - kind: conda
   name: libopenvino-paddle-frontend
-  version: 2023.3.0
-  build: hd0b7f58_0
+  version: 2024.0.0
+  build: h1a3ed6a_4
+  build_number: 4
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-paddle-frontend-2023.3.0-hd0b7f58_0.conda
-  sha256: 804f203f5ce5d34a4994e26af13ef511391807c4720015dc3df0049e8d856aef
-  md5: 4a6d3b571cc6826e6a0432a677ab7749
+  url: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-paddle-frontend-2024.0.0-h1a3ed6a_4.conda
+  sha256: 37de5299f8f9c790f073bf7b5dd2d1c21ee148302fc8087a31291e72f49c0c52
+  md5: f52039a0882dad166cbc55e1d41c05a4
   depends:
   - __osx >=10.13
-  - libcxx >=15
-  - libopenvino 2023.3.0 h113ac47_0
-  - libprotobuf >=4.25.1,<4.25.2.0a0
-  size: 416094
-  timestamp: 1706098409186
+  - libcxx >=16
+  - libopenvino 2024.0.0 h113ac47_4
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  size: 426912
+  timestamp: 1711026626668
 - kind: conda
   name: libopenvino-paddle-frontend
-  version: 2023.3.0
-  build: hfbc7f12_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-paddle-frontend-2023.3.0-hfbc7f12_0.conda
-  sha256: 2eed3087da14d60d6d81df7c89239e16bf2b123daa9d8b6947ab82d5f792d553
-  md5: 6860072c5ee02bb11f287416b73a0ff8
+  version: 2024.0.0
+  build: h298fcef_4
+  build_number: 4
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-paddle-frontend-2024.0.0-h298fcef_4.conda
+  sha256: 8e9336faddf8191486b127986344d0b7500182c584f7cd8f806768bd79f8c606
+  md5: 08c0bba5af5c86b7e20eac7f9567756f
   depends:
-  - libgcc-ng >=12
-  - libopenvino 2023.3.0 h2e90f83_0
-  - libprotobuf >=4.25.1,<4.25.2.0a0
-  - libstdcxx-ng >=12
-  size: 659697
-  timestamp: 1706095687275
+  - libcxx >=16
+  - libopenvino 2024.0.0 he6dadac_4
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  size: 415162
+  timestamp: 1711025663174
 - kind: conda
-  name: libopenvino-pytorch-frontend
-  version: 2023.3.0
-  build: h2f0025b_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-pytorch-frontend-2023.3.0-h2f0025b_0.conda
-  sha256: ae8854f7ed7d7b702a27f8587cda110a5a38921c4e3c299d7ba9e6b12ebc2f09
-  md5: 00f03d9aa56a6471683e0247280bc7e8
-  depends:
-  - libgcc-ng >=12
-  - libopenvino 2023.3.0 h3e0449b_0
-  - libstdcxx-ng >=12
-  size: 874762
-  timestamp: 1706093760950
-- kind: conda
-  name: libopenvino-pytorch-frontend
-  version: 2023.3.0
-  build: h59595ed_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-pytorch-frontend-2023.3.0-h59595ed_0.conda
-  sha256: d8be2b27aca1772af542c7842e8f2b9f2de07d3d54ae3d59a4207645b0954882
-  md5: 69676390abdff86e57c0d50b82ee72ad
-  depends:
-  - libgcc-ng >=12
-  - libopenvino 2023.3.0 h2e90f83_0
-  - libstdcxx-ng >=12
-  size: 960370
-  timestamp: 1706095703121
-- kind: conda
-  name: libopenvino-pytorch-frontend
-  version: 2023.3.0
-  build: h63175ca_0
+  name: libopenvino-paddle-frontend
+  version: 2024.0.0
+  build: h55b4db4_4
+  build_number: 4
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-pytorch-frontend-2023.3.0-h63175ca_0.conda
-  sha256: 446c000a2041c08752c4388630759a6129ec2773f869f2a021a197ab747c6b71
-  md5: a85cb5c01026e9c67ea41a8a619b062d
+  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-paddle-frontend-2024.0.0-h55b4db4_4.conda
+  sha256: 91fed61727c82d22b058d0378665f3baeb11133a50a237501f80e07fc5136059
+  md5: 4d52bd422679701b6640ae3d2cf28c07
   depends:
-  - libopenvino 2023.3.0 hc2557fa_0
+  - libopenvino 2024.0.0 hc2557fa_4
+  - libprotobuf >=4.25.3,<4.25.4.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  size: 604900
-  timestamp: 1706100778676
+  size: 417982
+  timestamp: 1711028557850
+- kind: conda
+  name: libopenvino-paddle-frontend
+  version: 2024.0.0
+  build: h757c851_4
+  build_number: 4
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-paddle-frontend-2024.0.0-h757c851_4.conda
+  sha256: cc16cf9103d57d14a4f65b0148ae6197ced75063bebb07533744a1f0675ef294
+  md5: 259bd0c788f447fe78aab69895365528
+  depends:
+  - libgcc-ng >=12
+  - libopenvino 2024.0.0 h2e90f83_4
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - libstdcxx-ng >=12
+  size: 695625
+  timestamp: 1711027501848
+- kind: conda
+  name: libopenvino-paddle-frontend
+  version: 2024.0.0
+  build: h81208d3_4
+  build_number: 4
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-paddle-frontend-2024.0.0-h81208d3_4.conda
+  sha256: c7dd82dab0bf4661973e5ee61655b4ecf606e9a02c0a737e3f84115bba54d8d2
+  md5: f93fa34d7545a46a08836d97c1eb3145
+  depends:
+  - libgcc-ng >=12
+  - libopenvino 2024.0.0 h3e0449b_4
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - libstdcxx-ng >=12
+  size: 630686
+  timestamp: 1711021452310
 - kind: conda
   name: libopenvino-pytorch-frontend
-  version: 2023.3.0
-  build: hd427752_0
+  version: 2024.0.0
+  build: h2f0025b_4
+  build_number: 4
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-pytorch-frontend-2024.0.0-h2f0025b_4.conda
+  sha256: 7678b94bd34b41782d620b6ecbc9c1a2cc56d4904105088af6a6820c855cab09
+  md5: c37b2c39a1324b009be45794a5f44f10
+  depends:
+  - libgcc-ng >=12
+  - libopenvino 2024.0.0 h3e0449b_4
+  - libstdcxx-ng >=12
+  size: 959260
+  timestamp: 1711021475330
+- kind: conda
+  name: libopenvino-pytorch-frontend
+  version: 2024.0.0
+  build: h59595ed_4
+  build_number: 4
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-pytorch-frontend-2024.0.0-h59595ed_4.conda
+  sha256: 2f032e4cec7d24f80ea932c99b0fea896fbf1e4a202453b71b50bc6980d0cfae
+  md5: ec121a4195acadad086f84719cc91430
+  depends:
+  - libgcc-ng >=12
+  - libopenvino 2024.0.0 h2e90f83_4
+  - libstdcxx-ng >=12
+  size: 1062658
+  timestamp: 1711027534033
+- kind: conda
+  name: libopenvino-pytorch-frontend
+  version: 2024.0.0
+  build: h63175ca_4
+  build_number: 4
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-pytorch-frontend-2024.0.0-h63175ca_4.conda
+  sha256: 0167c1620028884f0a6a6f37d7841981117bb795a8babe8f53eb416293a16424
+  md5: a0f1a943347cebd2ce7db39faa1d8ddf
+  depends:
+  - libopenvino 2024.0.0 hc2557fa_4
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  size: 647043
+  timestamp: 1711028623161
+- kind: conda
+  name: libopenvino-pytorch-frontend
+  version: 2024.0.0
+  build: hd427752_4
+  build_number: 4
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-pytorch-frontend-2023.3.0-hd427752_0.conda
-  sha256: 0f529e073945e3cbe8220248de25f5bb45c29c6512495dfe28c759333833148e
-  md5: 521c6bef6f50deab4278fcda50480dbd
+  url: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-pytorch-frontend-2024.0.0-hd427752_4.conda
+  sha256: a78255491cc455d1b8ac8436996e8112d59f49e6994013a3184f93cf55c6cd0d
+  md5: 7489363c2aa4d7a29c2b6f2c505099a4
   depends:
-  - libcxx >=15
-  - libopenvino 2023.3.0 h113ac47_0
-  size: 703094
-  timestamp: 1706098450272
+  - libcxx >=16
+  - libopenvino 2024.0.0 h113ac47_4
+  size: 760887
+  timestamp: 1711026691193
 - kind: conda
   name: libopenvino-pytorch-frontend
-  version: 2023.3.0
-  build: hebf3989_0
+  version: 2024.0.0
+  build: hebf3989_4
+  build_number: 4
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-pytorch-frontend-2023.3.0-hebf3989_0.conda
-  sha256: 8662e1ada217c18742f435df07d7170d52fd1d2d3d555173ae3b965de443891c
-  md5: d3b0f4df56099d925542c338418023e3
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-pytorch-frontend-2024.0.0-hebf3989_4.conda
+  sha256: 2bf917984a213800cca75e3c2d5ebeb23a1704b85be4bc17b07f336f4ec77ba7
+  md5: 19fa1a81ca49a5f3cb357fe6c3a57b40
   depends:
-  - libcxx >=15
-  - libopenvino 2023.3.0 he6dadac_0
-  size: 677798
-  timestamp: 1706097305598
+  - libcxx >=16
+  - libopenvino 2024.0.0 he6dadac_4
+  size: 730406
+  timestamp: 1711025718854
 - kind: conda
   name: libopenvino-tensorflow-frontend
-  version: 2023.3.0
-  build: h0bff32c_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-frontend-2023.3.0-h0bff32c_0.conda
-  sha256: 4692a237546819b040e269bfbf87b57503905cba38d091e96322fd7abccdf3fd
-  md5: 9d3772f3ae8e4dfa31287bde490238de
+  version: 2024.0.0
+  build: h356fca3_4
+  build_number: 4
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-tensorflow-frontend-2024.0.0-h356fca3_4.conda
+  sha256: eb63037c898e133130bb52d243301cfbfa91301f02dd932d91475e16b64b174d
+  md5: cb5593445e5ac05a3c7682c88e80de17
   depends:
   - libabseil * cxx17*
-  - libabseil >=20230802.1,<20230803.0a0
-  - libgcc-ng >=12
-  - libopenvino 2023.3.0 h2e90f83_0
-  - libprotobuf >=4.25.1,<4.25.2.0a0
-  - libstdcxx-ng >=12
+  - libabseil >=20240116.1,<20240117.0a0
+  - libcxx >=16
+  - libopenvino 2024.0.0 he6dadac_4
+  - libprotobuf >=4.25.3,<4.25.4.0a0
   - snappy >=1.1.10,<2.0a0
-  size: 1192939
-  timestamp: 1706095719842
+  size: 881831
+  timestamp: 1711025780162
 - kind: conda
   name: libopenvino-tensorflow-frontend
-  version: 2023.3.0
-  build: h35b5a9d_0
+  version: 2024.0.0
+  build: h5177828_4
+  build_number: 4
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-tensorflow-frontend-2024.0.0-h5177828_4.conda
+  sha256: 48979c422bd2df5eb374c4cc3c28c69fdc200791b35fd91689c5b9c3e11ee3e0
+  md5: 43a29ea76c5072b69f75495141623112
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20240116.1,<20240117.0a0
+  - libgcc-ng >=12
+  - libopenvino 2024.0.0 h3e0449b_4
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - libstdcxx-ng >=12
+  - snappy >=1.1.10,<2.0a0
+  size: 1174002
+  timestamp: 1711021499528
+- kind: conda
+  name: libopenvino-tensorflow-frontend
+  version: 2024.0.0
+  build: h7d3639a_4
+  build_number: 4
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-tensorflow-frontend-2023.3.0-h35b5a9d_0.conda
-  sha256: aca81a3fa98c27b62443a7d0dc3b5d6d606c7052116e7895bb3b713d6a65a871
-  md5: cc379db1bd5be47167514f4a3b987a89
+  url: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-tensorflow-frontend-2024.0.0-h7d3639a_4.conda
+  sha256: 077a86295e5b30c8c9f9a140486f6d3b2eff32a9ff7e1c462a28f4e95bd60c66
+  md5: 426d2097dd8f8c129351ab6d0158dde6
   depends:
   - __osx >=10.13
   - libabseil * cxx17*
-  - libabseil >=20230802.1,<20230803.0a0
-  - libcxx >=15
-  - libopenvino 2023.3.0 h113ac47_0
-  - libprotobuf >=4.25.1,<4.25.2.0a0
+  - libabseil >=20240116.1,<20240117.0a0
+  - libcxx >=16
+  - libopenvino 2024.0.0 h113ac47_4
+  - libprotobuf >=4.25.3,<4.25.4.0a0
   - snappy >=1.1.10,<2.0a0
-  size: 893375
-  timestamp: 1706098490465
+  size: 935944
+  timestamp: 1711026766564
 - kind: conda
   name: libopenvino-tensorflow-frontend
-  version: 2023.3.0
-  build: h5dc61ae_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-tensorflow-frontend-2023.3.0-h5dc61ae_0.conda
-  sha256: 5654ad3e3ee34a64f6dbf51e8f0ef20f351133514b08e22f3426d619be847b8e
-  md5: 12a0bb0a1a4de97a762b8e46a8b4114b
-  depends:
-  - libabseil * cxx17*
-  - libabseil >=20230802.1,<20230803.0a0
-  - libgcc-ng >=12
-  - libopenvino 2023.3.0 h3e0449b_0
-  - libprotobuf >=4.25.1,<4.25.2.0a0
-  - libstdcxx-ng >=12
-  - snappy >=1.1.10,<2.0a0
-  size: 1106336
-  timestamp: 1706093780445
-- kind: conda
-  name: libopenvino-tensorflow-frontend
-  version: 2023.3.0
-  build: h815df86_0
+  version: 2024.0.0
+  build: ha362bc9_4
+  build_number: 4
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-tensorflow-frontend-2023.3.0-h815df86_0.conda
-  sha256: 6af901c8e8bf0bfe925d15444f04ea772bae150ecbcebef678764080007500de
-  md5: f12c31bcaf8b7830b6a4dd8b8929a37e
+  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-tensorflow-frontend-2024.0.0-ha362bc9_4.conda
+  sha256: 0b2def68d9bfa021ed066f56cbbbeb304d749dc7e3f6a8b2aa6ab606ed9e6a42
+  md5: 06e6366a721b528d48d0190287c3d619
   depends:
   - libabseil * cxx17*
-  - libabseil >=20230802.1,<20230803.0a0
-  - libopenvino 2023.3.0 hc2557fa_0
-  - libprotobuf >=4.25.1,<4.25.2.0a0
+  - libabseil >=20240116.1,<20240117.0a0
+  - libopenvino 2024.0.0 hc2557fa_4
+  - libprotobuf >=4.25.3,<4.25.4.0a0
   - snappy >=1.1.10,<2.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  size: 807202
-  timestamp: 1706100834430
+  size: 841512
+  timestamp: 1711028696316
 - kind: conda
   name: libopenvino-tensorflow-frontend
-  version: 2023.3.0
-  build: hb5ee477_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-tensorflow-frontend-2023.3.0-hb5ee477_0.conda
-  sha256: 2a44ee24f1c4ce3f31689ba506736b41324e6e422ad19d35025fe1d45a0c9722
-  md5: 5ba9b522b7ce160a27f7baad0e063013
-  depends:
-  - libabseil * cxx17*
-  - libabseil >=20230802.1,<20230803.0a0
-  - libcxx >=15
-  - libopenvino 2023.3.0 he6dadac_0
-  - libprotobuf >=4.25.1,<4.25.2.0a0
-  - snappy >=1.1.10,<2.0a0
-  size: 844788
-  timestamp: 1706097348161
-- kind: conda
-  name: libopenvino-tensorflow-lite-frontend
-  version: 2023.3.0
-  build: h2f0025b_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-tensorflow-lite-frontend-2023.3.0-h2f0025b_0.conda
-  sha256: 0610b710ef93a723bea0ca1ba9fb80d5afe2d5d2590844e5868a435959a19a0d
-  md5: 2f9a22c836a0deae69cd5cd0ee6b1173
-  depends:
-  - libgcc-ng >=12
-  - libopenvino 2023.3.0 h3e0449b_0
-  - libstdcxx-ng >=12
-  size: 420513
-  timestamp: 1706093799611
-- kind: conda
-  name: libopenvino-tensorflow-lite-frontend
-  version: 2023.3.0
-  build: h59595ed_0
+  version: 2024.0.0
+  build: hca94c1a_4
+  build_number: 4
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-lite-frontend-2023.3.0-h59595ed_0.conda
-  sha256: 66d7a1481979a834d0707fdb6a41ecf76595f443614902414876ebaaf8dcf050
-  md5: c1cec95aa4db6e625e2659c0ab31a9c5
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-frontend-2024.0.0-hca94c1a_4.conda
+  sha256: 3037418cbf5e14964e4c4909ac4f15729db29e990b57d3b2d0b7cf6b0186a3d7
+  md5: bdbf11f760f1a3b35d766e03cebd9c42
   depends:
+  - libabseil * cxx17*
+  - libabseil >=20240116.1,<20240117.0a0
   - libgcc-ng >=12
-  - libopenvino 2023.3.0 h2e90f83_0
+  - libopenvino 2024.0.0 h2e90f83_4
+  - libprotobuf >=4.25.3,<4.25.4.0a0
   - libstdcxx-ng >=12
-  size: 456367
-  timestamp: 1706095736363
+  - snappy >=1.1.10,<2.0a0
+  size: 1270397
+  timestamp: 1711027568199
 - kind: conda
   name: libopenvino-tensorflow-lite-frontend
-  version: 2023.3.0
-  build: h63175ca_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-tensorflow-lite-frontend-2023.3.0-h63175ca_0.conda
-  sha256: 69f7f4886d7edd39a35c0d549a4fed7e4a22e707207caedfbdec978b3b9bca7d
-  md5: ef6ecc61c4bfd7997a3f647351a1d018
+  version: 2024.0.0
+  build: h2f0025b_4
+  build_number: 4
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-tensorflow-lite-frontend-2024.0.0-h2f0025b_4.conda
+  sha256: c2157867b42ad952bf707e04f98eb571ce39d47259b290ff296a1b4a7e4370b4
+  md5: 53c065cfdf622b4ba309b34615e6c31a
   depends:
-  - libopenvino 2023.3.0 hc2557fa_0
+  - libgcc-ng >=12
+  - libopenvino 2024.0.0 h3e0449b_4
+  - libstdcxx-ng >=12
+  size: 437346
+  timestamp: 1711021525232
+- kind: conda
+  name: libopenvino-tensorflow-lite-frontend
+  version: 2024.0.0
+  build: h59595ed_4
+  build_number: 4
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-lite-frontend-2024.0.0-h59595ed_4.conda
+  sha256: 792f3a7de81b92a85339082008281dc03359c64ab10d9a93c71856fbefac8333
+  md5: 4354ea9f30a8c5111403fa4b24a2ad66
+  depends:
+  - libgcc-ng >=12
+  - libopenvino 2024.0.0 h2e90f83_4
+  - libstdcxx-ng >=12
+  size: 477431
+  timestamp: 1711027605659
+- kind: conda
+  name: libopenvino-tensorflow-lite-frontend
+  version: 2024.0.0
+  build: h63175ca_4
+  build_number: 4
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-tensorflow-lite-frontend-2024.0.0-h63175ca_4.conda
+  sha256: 652d3d74f013f0800a8c461bcb0123a7984b4c5a2f62bc7a10cada6d18b8048f
+  md5: 7c7e927452dfb65150bf447ac9ee789a
+  depends:
+  - libopenvino 2024.0.0 hc2557fa_4
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  size: 323258
-  timestamp: 1706100881832
+  size: 329890
+  timestamp: 1711028761582
 - kind: conda
   name: libopenvino-tensorflow-lite-frontend
-  version: 2023.3.0
-  build: hd427752_0
+  version: 2024.0.0
+  build: hd427752_4
+  build_number: 4
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-tensorflow-lite-frontend-2023.3.0-hd427752_0.conda
-  sha256: 0c2a9e2c13ffe49444060073a4d124d6ec401aa67389ce45a4b729ae24fc0083
-  md5: 97edd4f94d7f32eb811b4a880e16831e
+  url: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-tensorflow-lite-frontend-2024.0.0-hd427752_4.conda
+  sha256: 7458435a72afd7648cdce5da233407750f14c11e78cb4219b6d30a4a57a7a741
+  md5: ab2a53b0b8a50397a71b58ad4792c615
   depends:
-  - libcxx >=15
-  - libopenvino 2023.3.0 h113ac47_0
-  size: 367556
-  timestamp: 1706098529605
+  - libcxx >=16
+  - libopenvino 2024.0.0 h113ac47_4
+  size: 377031
+  timestamp: 1711026835681
 - kind: conda
   name: libopenvino-tensorflow-lite-frontend
-  version: 2023.3.0
-  build: hebf3989_0
+  version: 2024.0.0
+  build: hebf3989_4
+  build_number: 4
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-tensorflow-lite-frontend-2023.3.0-hebf3989_0.conda
-  sha256: c842fd83ea2b003d4d09f811e149c59468b2db96d3b2dfb21cb627c274ea86b5
-  md5: 540f0272a0f13bda3964ac450694a5d8
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-tensorflow-lite-frontend-2024.0.0-hebf3989_4.conda
+  sha256: de941d13292bb24caf0a906818058257b042668e53f7399a1dd7b858d6ef9a24
+  md5: 46de308a60f4d3361fa07c9ff23e3f08
   depends:
-  - libcxx >=15
-  - libopenvino 2023.3.0 he6dadac_0
-  size: 365463
-  timestamp: 1706097391896
+  - libcxx >=16
+  - libopenvino 2024.0.0 he6dadac_4
+  size: 374273
+  timestamp: 1711025833025
 - kind: conda
   name: libopus
   version: 1.3.1
@@ -9321,241 +9439,240 @@ packages:
   timestamp: 1685065544324
 - kind: conda
   name: libpciaccess
-  version: '0.17'
-  build: h166bdaf_0
+  version: '0.18'
+  build: hd590300_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.17-h166bdaf_0.tar.bz2
-  sha256: 9fe4aaf5629b4848d9407b9ed4da941ba7e5cebada63ee0becb9aa82259dc6e2
-  md5: b7463391cf284065294e2941dd41ab95
+  url: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.18-hd590300_0.conda
+  sha256: c0a30ac74eba66ea76a4f0a39acc7833f5ed783a632ca3bb6665b2d81aabd2fb
+  md5: 48f4330bfcd959c3cfb704d424903c82
   depends:
   - libgcc-ng >=12
   license: MIT
   license_family: MIT
-  size: 39750
-  timestamp: 1666091838440
+  size: 28361
+  timestamp: 1707101388552
 - kind: conda
   name: libpng
-  version: 1.6.42
+  version: 1.6.43
   build: h091b4b1_0
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.42-h091b4b1_0.conda
-  sha256: 6df48b05868437377a0717b486d9f57396a45cb6e3a044453944c8e597b03370
-  md5: 308b6746e691265c21cb013960c74ae6
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.43-h091b4b1_0.conda
+  sha256: 66c4713b07408398f2221229a1c1d5df57d65dc0902258113f2d9ecac4772495
+  md5: 77e684ca58d82cae9deebafb95b1a2b8
   depends:
   - libzlib >=1.2.13,<1.3.0a0
   license: zlib-acknowledgement
-  size: 263699
-  timestamp: 1706789057076
+  size: 264177
+  timestamp: 1708780447187
 - kind: conda
   name: libpng
-  version: 1.6.42
+  version: 1.6.43
   build: h194ca79_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libpng-1.6.42-h194ca79_0.conda
-  sha256: 035ab9c6a38dedd8ffc28f7c1ca0bed4196f7f8631e9ac74695a3630d2bb527b
-  md5: b8ff00cc9a5184726baea61244f8bec3
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libpng-1.6.43-h194ca79_0.conda
+  sha256: 6f408f3d6854f86e223289f0dda12562b047c7a1fdf3636c67ec39afcd141f43
+  md5: 1123e504d9254dd9494267ab9aba95f0
   depends:
   - libgcc-ng >=12
   - libzlib >=1.2.13,<1.3.0a0
   license: zlib-acknowledgement
-  size: 296479
-  timestamp: 1706791406271
+  size: 294380
+  timestamp: 1708782876525
 - kind: conda
   name: libpng
-  version: 1.6.42
+  version: 1.6.43
   build: h19919ed_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.42-h19919ed_0.conda
-  sha256: 92a7f54585bac3b5f90e89bb674be1bd2e66e281206ec056a125eec7e32bb85f
-  md5: 9d97d0e6a5d51a7fd03c3398bc752890
+  url: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.43-h19919ed_0.conda
+  sha256: 6ad31bf262a114de5bbe0c6ba73b29ed25239d0f46f9d59700310d2ea0b3c142
+  md5: 77e398acc32617a0384553aea29e866b
   depends:
   - libzlib >=1.2.13,<1.3.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: zlib-acknowledgement
-  size: 346387
-  timestamp: 1706789602418
+  size: 347514
+  timestamp: 1708780763195
 - kind: conda
   name: libpng
-  version: 1.6.42
+  version: 1.6.43
   build: h2797004_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.42-h2797004_0.conda
-  sha256: 1a0c3a4b7fd1e101cb37dd6d2f8b5ec93409c8cae422f04470fe39a01ef59024
-  md5: d67729828dc6ff7ba44a61062ad79880
+  url: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.43-h2797004_0.conda
+  sha256: 502f6ff148ac2777cc55ae4ade01a8fc3543b4ffab25c4e0eaa15f94e90dd997
+  md5: 009981dd9cfcaa4dbfa25ffaed86bcae
   depends:
   - libgcc-ng >=12
   - libzlib >=1.2.13,<1.3.0a0
   license: zlib-acknowledgement
-  size: 289100
-  timestamp: 1706788935660
+  size: 288221
+  timestamp: 1708780443939
 - kind: conda
   name: libpng
-  version: 1.6.42
+  version: 1.6.43
   build: h92b6c6a_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.42-h92b6c6a_0.conda
-  sha256: 57c816e3b8cd0aaca7b85e79c0cc2211789ce0729a581d006faf8daeebf51f8d
-  md5: 7654da21e9d7ca6a8c87fbc77448588e
+  url: https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.43-h92b6c6a_0.conda
+  sha256: 13e646d24b5179e6b0a5ece4451a587d759f55d9a360b7015f8f96eff4524b8f
+  md5: 65dcddb15965c9de2c0365cb14910532
   depends:
   - libzlib >=1.2.13,<1.3.0a0
   license: zlib-acknowledgement
-  size: 268963
-  timestamp: 1706789121898
+  size: 268524
+  timestamp: 1708780496420
 - kind: conda
   name: libpq
   version: '16.2'
-  build: h0f8b458_0
+  build: h0f8b458_1
+  build_number: 1
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libpq-16.2-h0f8b458_0.conda
-  sha256: 0ad2265131a6d79fcfe8c5b7a04884f7377f981d18af775ebb71bc61b0c938b6
-  md5: fea5d30234a7158f4eaa915b5a6e0c9c
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libpq-16.2-h0f8b458_1.conda
+  sha256: 7a6a195d37f6fe2f2d608033755f6e9522c9a2b7b07e52529159105f635c6cae
+  md5: e236a8e95b82a454e333f22418b9c879
   depends:
   - krb5 >=1.21.2,<1.22.0a0
   - openssl >=3.2.1,<4.0a0
   license: PostgreSQL
-  size: 2408453
-  timestamp: 1707416268983
+  size: 2452312
+  timestamp: 1710864761131
 - kind: conda
   name: libpq
   version: '16.2'
-  build: h33b98f1_0
+  build: h33b98f1_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libpq-16.2-h33b98f1_0.conda
-  sha256: 352748b0499a22e2a8e103f071b8d9357e1fb710c0aec0f79895d3ba03dccb03
-  md5: fe0e297faf462ee579c95071a5211665
+  url: https://conda.anaconda.org/conda-forge/linux-64/libpq-16.2-h33b98f1_1.conda
+  sha256: e03a8439b79e013840c44c957d37dbce10316888b2b5dc7dcfcfc0cfe3a3b128
+  md5: 9e49ec2a61d02623b379dc332eb6889d
   depends:
   - krb5 >=1.21.2,<1.22.0a0
   - libgcc-ng >=12
   - openssl >=3.2.1,<4.0a0
   license: PostgreSQL
-  size: 2474825
-  timestamp: 1707415138154
+  size: 2601973
+  timestamp: 1710863646063
 - kind: conda
   name: libpq
   version: '16.2'
-  build: h58720eb_0
+  build: h58720eb_1
+  build_number: 1
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libpq-16.2-h58720eb_0.conda
-  sha256: 439633fee193ad250d97da135a7fb1c497b4f496ec6baabcb73bdba554926943
-  md5: ca0572c11209701741812f657ebeef82
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libpq-16.2-h58720eb_1.conda
+  sha256: 41013bae4c01518394ed366de29d1d1b6851efee9f41b7fd4cd8c53bd74c1ba7
+  md5: 08197815d955b96d6ad5ac18e2c8f322
   depends:
   - krb5 >=1.21.2,<1.22.0a0
   - libgcc-ng >=12
   - openssl >=3.2.1,<4.0a0
   license: PostgreSQL
-  size: 2528613
-  timestamp: 1707415354953
+  size: 2507128
+  timestamp: 1710863715662
 - kind: conda
   name: libpq
   version: '16.2'
-  build: ha925e61_0
+  build: ha925e61_1
+  build_number: 1
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libpq-16.2-ha925e61_0.conda
-  sha256: 537b3816ac66f12c56fc62a67d896703b68f7588a5d83ab98009731de82eb742
-  md5: 8b81f4feaa3744271fcf2822ad1489f1
+  url: https://conda.anaconda.org/conda-forge/osx-64/libpq-16.2-ha925e61_1.conda
+  sha256: bfb252cb14b88a75ba4af930c16dccae265dce0afdf5abde7de1718181aa2cea
+  md5: a10ef466bbc68a8e74112a8e26028d66
   depends:
   - krb5 >=1.21.2,<1.22.0a0
   - openssl >=3.2.1,<4.0a0
   license: PostgreSQL
-  size: 2336821
-  timestamp: 1707415890165
+  size: 2333894
+  timestamp: 1710864725862
 - kind: conda
   name: libprotobuf
-  version: 4.25.1
-  build: h810fc01_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-4.25.1-h810fc01_1.conda
-  sha256: bdaff15489c9a64ae150ba9fba29c2f019c86c36fc2828aa6edfffdd32313830
-  md5: 3e1535cfcf9d0f8e1141e021248c721e
+  version: 4.25.3
+  build: h08a7969_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-4.25.3-h08a7969_0.conda
+  sha256: 70e0eef046033af2e8d21251a785563ad738ed5281c74e21c31c457780845dcd
+  md5: 6945825cebd2aeb16af4c69d97c32c13
   depends:
   - libabseil * cxx17*
-  - libabseil >=20230802.1,<20230803.0a0
-  - libcxx >=16
-  - libzlib >=1.2.13,<1.3.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 2159882
-  timestamp: 1706891704812
-- kind: conda
-  name: libprotobuf
-  version: 4.25.1
-  build: h87e877f_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libprotobuf-4.25.1-h87e877f_1.conda
-  sha256: 826bee292ebf91b1cb3e809683d9b6bdbc2398d0a41a1b4d3e64d98f3db14d75
-  md5: c129f45da1472e472c28304046a92d9d
-  depends:
-  - libabseil * cxx17*
-  - libabseil >=20230802.1,<20230803.0a0
+  - libabseil >=20240116.1,<20240117.0a0
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   - libzlib >=1.2.13,<1.3.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 2582348
-  timestamp: 1706890811006
+  size: 2811207
+  timestamp: 1709514552541
 - kind: conda
   name: libprotobuf
-  version: 4.25.1
-  build: hb8276f3_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libprotobuf-4.25.1-hb8276f3_1.conda
-  sha256: 980d7736424a5750fbec3ca454fc5654096eb93fc4cc5f44598919ce3710b951
-  md5: 6fac1decbb9591b391c124dc7bc39905
-  depends:
-  - libabseil * cxx17*
-  - libabseil >=20230802.1,<20230803.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 5548805
-  timestamp: 1707169970392
-- kind: conda
-  name: libprotobuf
-  version: 4.25.1
-  build: hc4f2305_1
-  build_number: 1
+  version: 4.25.3
+  build: h4e4d658_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libprotobuf-4.25.1-hc4f2305_1.conda
-  sha256: 9f0eccde6aabded86225d60166c93544f138aa0fad7478e4811879dbd61bffbc
-  md5: e75c3761805ceb70bbc28b8109f67d85
+  url: https://conda.anaconda.org/conda-forge/osx-64/libprotobuf-4.25.3-h4e4d658_0.conda
+  sha256: 3f126769fb5820387d436370ad48600e05d038a28689fdf9988b64e1059947a8
+  md5: 57b7ee4f1fd8573781cfdabaec4a7782
   depends:
   - __osx >=10.13
   - libabseil * cxx17*
-  - libabseil >=20230802.1,<20230803.0a0
+  - libabseil >=20240116.1,<20240117.0a0
   - libcxx >=16
   - libzlib >=1.2.13,<1.3.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 2225893
-  timestamp: 1706891832837
+  size: 2216001
+  timestamp: 1709514908146
 - kind: conda
   name: libprotobuf
-  version: 4.25.1
-  build: hf27288f_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-4.25.1-hf27288f_1.conda
-  sha256: 4f3f6db5fb502ae1392d3f8d66639154b8ba7bf5c0547be988ec9236a5a784b2
-  md5: 78ad06185133494138cd5e922ed73ac7
+  version: 4.25.3
+  build: h503648d_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libprotobuf-4.25.3-h503648d_0.conda
+  sha256: 5d4c5592be3994657ebf47e52f26b734cc50b0ea9db007d920e2e31762aac216
+  md5: 4da7de0ba35777742edf67bf7a1075df
   depends:
   - libabseil * cxx17*
-  - libabseil >=20230802.1,<20230803.0a0
+  - libabseil >=20240116.1,<20240117.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5650604
+  timestamp: 1709514804631
+- kind: conda
+  name: libprotobuf
+  version: 4.25.3
+  build: h648ac29_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libprotobuf-4.25.3-h648ac29_0.conda
+  sha256: 76775a1457b2d4de1097bec2fda16b8e6e80f761d11aa7a525fa215bff4ab87c
+  md5: a239d63913ec9e008bdbe35899f677f4
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20240116.1,<20240117.0a0
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   - libzlib >=1.2.13,<1.3.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 2735654
-  timestamp: 1706891328749
+  size: 2576197
+  timestamp: 1709513627963
+- kind: conda
+  name: libprotobuf
+  version: 4.25.3
+  build: hbfab5d5_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-4.25.3-hbfab5d5_0.conda
+  sha256: d754519abc3ddbdedab2a38d0639170f5347c1573eef80c707f3a8dc5dff706a
+  md5: 5f70b2b945a9741cba7e6dfe735a02a7
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20240116.1,<20240117.0a0
+  - libcxx >=16
+  - libzlib >=1.2.13,<1.3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2154402
+  timestamp: 1709514097574
 - kind: conda
   name: libqdldl
   version: 0.1.5
@@ -9841,73 +9958,73 @@ packages:
   timestamp: 1706177768929
 - kind: conda
   name: libsqlite
-  version: 3.45.1
+  version: 3.45.2
   build: h091b4b1_0
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.45.1-h091b4b1_0.conda
-  sha256: 64befc456a38907d1334fb58eb604a96625d3a23a2f34fbd203e0b307a4a141e
-  md5: a153a40a253962373b5330eb9d182da9
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.45.2-h091b4b1_0.conda
+  sha256: 7c234320a1a2132b9cc972aaa06bb215bb220a5b1addb0bed7a5a321c805920e
+  md5: 9d07427ee5bd9afd1e11ce14368a48d6
   depends:
   - libzlib >=1.2.13,<1.3.0a0
   license: Unlicense
-  size: 824677
-  timestamp: 1707495428497
+  size: 825300
+  timestamp: 1710255078823
 - kind: conda
   name: libsqlite
-  version: 3.45.1
+  version: 3.45.2
   build: h194ca79_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libsqlite-3.45.1-h194ca79_0.conda
-  sha256: 2aeb33230d074c9c91605def8296475dc0c064c23bd50ccfacb8336ec4bfc422
-  md5: 4190198deb1ed253eb938f6a6d92ff4f
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libsqlite-3.45.2-h194ca79_0.conda
+  sha256: 0ce6de6369c04386cfc8696b1f795f425843789609ae2e04e7a1eb7deae62a8b
+  md5: bf4c96a21fbfc6a6ef6a7781a534a4e0
   depends:
   - libgcc-ng >=12
   - libzlib >=1.2.13,<1.3.0a0
   license: Unlicense
-  size: 1034865
-  timestamp: 1707495102245
+  size: 1038462
+  timestamp: 1710253998432
 - kind: conda
   name: libsqlite
-  version: 3.45.1
+  version: 3.45.2
   build: h2797004_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.45.1-h2797004_0.conda
-  sha256: 1b379d1c652b25d0540251d422ef767472e768fd36b77261045e97f9ba6d3faa
-  md5: fc4ccadfbf6d4784de88c41704792562
+  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.45.2-h2797004_0.conda
+  sha256: 8cdbeb7902729e319510a82d7c642402981818702b58812af265ef55d1315473
+  md5: 866983a220e27a80cb75e85cb30466a1
   depends:
   - libgcc-ng >=12
   - libzlib >=1.2.13,<1.3.0a0
   license: Unlicense
-  size: 859346
-  timestamp: 1707495156652
+  size: 857489
+  timestamp: 1710254744982
 - kind: conda
   name: libsqlite
-  version: 3.45.1
+  version: 3.45.2
   build: h92b6c6a_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.45.1-h92b6c6a_0.conda
-  sha256: d65ce7093ecf5884b241a5ca8d26f80d21eaebf14ca67923b50c249f47a84cf9
-  md5: e451d14a5412cdc68be50493df251f55
+  url: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.45.2-h92b6c6a_0.conda
+  sha256: 320ec73a4e3dd377757a2595770b8137ec4583df4d7782472d76377cdbdc4543
+  md5: 086f56e13a96a6cfb1bf640505ae6b70
   depends:
   - libzlib >=1.2.13,<1.3.0a0
   license: Unlicense
-  size: 902313
-  timestamp: 1707495366004
+  size: 902355
+  timestamp: 1710254991672
 - kind: conda
   name: libsqlite
-  version: 3.45.1
+  version: 3.45.2
   build: hcfcfb64_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.45.1-hcfcfb64_0.conda
-  sha256: e1010f4ac7b056d85d91e6cb6137ef118f920eba88059261689e543780b230df
-  md5: c583c1d6999b7aa148eff3089e13c44b
+  url: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.45.2-hcfcfb64_0.conda
+  sha256: 4bb24b986550275a6d02835150d943c4c675808d05c0efc5c2a22154d007a69f
+  md5: f95359f8dc5abf7da7776ece9ef10bc5
   depends:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: Unlicense
-  size: 870045
-  timestamp: 1707495642340
+  size: 869606
+  timestamp: 1710255095740
 - kind: conda
   name: libssh2
   version: 1.11.0
@@ -10045,11 +10162,12 @@ packages:
 - kind: conda
   name: libsystemd0
   version: '255'
-  build: h3516f8a_0
+  build: h3516f8a_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-255-h3516f8a_0.conda
-  sha256: 9306eafe761a758e0c2efa92025bfc0684c66ef500efdea4fbe4687b59e8099e
-  md5: 24e2649ebd432e652aa72cfd05f23a8e
+  url: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-255-h3516f8a_1.conda
+  sha256: af27b0d225435d03f378a119f8eab6b280c53557a3c84cdb3bb8fd3167615aed
+  md5: 3366af27f0b593544a6cd453c7932ac5
   depends:
   - __glibc >=2.17,<3.0.a0
   - libcap >=2.69,<2.70.0a0
@@ -10059,16 +10177,17 @@ packages:
   - xz >=5.2.6,<6.0a0
   - zstd >=1.5.5,<1.6.0a0
   license: LGPL-2.1-or-later
-  size: 404326
-  timestamp: 1701982703751
+  size: 402592
+  timestamp: 1709568499820
 - kind: conda
   name: libsystemd0
   version: '255'
-  build: h91e93f8_0
+  build: h91e93f8_1
+  build_number: 1
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libsystemd0-255-h91e93f8_0.conda
-  sha256: c49c1dad8881cb518412f8e56fa251afbde1887e82d197cbb27ab39afafd39af
-  md5: 7834e7d37b2e4b65b96a75634e45c304
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libsystemd0-255-h91e93f8_1.conda
+  sha256: ff2fb8af038371bce24930d0913a90ac525be39f947c93099bdda88da80559b1
+  md5: afcd3dddcdc93fee67fb67fc950f6099
   depends:
   - libcap >=2.69,<2.70.0a0
   - libgcc-ng >=12
@@ -10077,8 +10196,8 @@ packages:
   - xz >=5.2.6,<6.0a0
   - zstd >=1.5.5,<1.6.0a0
   license: LGPL-2.1-or-later
-  size: 423120
-  timestamp: 1701982603040
+  size: 420184
+  timestamp: 1709568302419
 - kind: conda
   name: libtasn1
   version: 4.19.0
@@ -10317,22 +10436,21 @@ packages:
   timestamp: 1680113474501
 - kind: conda
   name: libva
-  version: 2.20.0
+  version: 2.21.0
   build: hd590300_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libva-2.20.0-hd590300_0.conda
-  sha256: 972d6f67d854d0f0fc2593f8bddc8d411859437ace7248c374e1a85a9ea9d410
-  md5: 933bcea637569c6cea6084957028cb53
+  url: https://conda.anaconda.org/conda-forge/linux-64/libva-2.21.0-hd590300_0.conda
+  sha256: b4e3a3fa523a5ddd1eca7981c9d6a9b831a182950116cc5bda18c94a040b63bc
+  md5: e50a2609159a3e336fe4092738c00687
   depends:
-  - libdrm >=2.4.114,<2.5.0a0
-  - libgcc-ng >=12
-  - xorg-libx11 >=1.8.6,<2.0a0
+  - libdrm >=2.4.120,<2.5.0a0
+  - xorg-libx11 >=1.8.7,<2.0a0
   - xorg-libxext >=1.3.4,<2.0a0
   - xorg-libxfixes
   license: MIT
   license_family: MIT
-  size: 188151
-  timestamp: 1694689905260
+  size: 189313
+  timestamp: 1710242676665
 - kind: conda
   name: libvorbis
   version: 1.3.7
@@ -10413,62 +10531,62 @@ packages:
   timestamp: 1610609991029
 - kind: conda
   name: libvpx
-  version: 1.13.1
+  version: 1.14.0
+  build: h078ce10_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libvpx-1.14.0-h078ce10_0.conda
+  sha256: e202f23fca763d88ad8170f90fa380510c65f29b86cfe6fb29706843462cee4f
+  md5: 8a515c7875e4d61734f4ac964851f4a5
+  depends:
+  - libcxx >=16
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1174097
+  timestamp: 1707175717608
+- kind: conda
+  name: libvpx
+  version: 1.14.0
   build: h2f0025b_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libvpx-1.13.1-h2f0025b_0.conda
-  sha256: c403cd479dc5acd86d9b62ddb2fb4756d7775e6c2f25db79c9efa187b759af4f
-  md5: 9a6ce789667dfdbea886b5d9e7f268a0
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libvpx-1.14.0-h2f0025b_0.conda
+  sha256: 8f89f9183df7ab6bb45fa16443b6d4de123b2aa5e7149d1b0d39b97f1f50bf2c
+  md5: a4fe92babed93075982b95096ce13136
   depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   license: BSD-3-Clause
   license_family: BSD
-  size: 1193429
-  timestamp: 1696342120210
+  size: 1208251
+  timestamp: 1707175363916
 - kind: conda
   name: libvpx
-  version: 1.13.1
+  version: 1.14.0
   build: h59595ed_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libvpx-1.13.1-h59595ed_0.conda
-  sha256: 8067e73d6e4f82eae158cb86acdc2d1cf18dd7f13807f0b93e13a07ee4c04b79
-  md5: 0974a6d3432e10bae02bcab0cce1b308
+  url: https://conda.anaconda.org/conda-forge/linux-64/libvpx-1.14.0-h59595ed_0.conda
+  sha256: b0e0500fc92f626baaa2cf926dece5ce7571c42a2db2d993a250d4c5da4d68ca
+  md5: 01c76c6d71097a0f3bd8683a8f255123
   depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   license: BSD-3-Clause
   license_family: BSD
-  size: 1006029
-  timestamp: 1696342275863
+  size: 1019593
+  timestamp: 1707175376125
 - kind: conda
   name: libvpx
-  version: 1.13.1
-  build: hb765f3a_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libvpx-1.13.1-hb765f3a_0.conda
-  sha256: 3a9c5e903cc212f426bb4515293b45c84cb6173fd9ecc5bdba144e07c817d84c
-  md5: d62a0d3d8c01bd9fad3fd17d720d0cf5
-  depends:
-  - libcxx >=15.0.7
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 1134986
-  timestamp: 1696342737036
-- kind: conda
-  name: libvpx
-  version: 1.13.1
-  build: he965462_0
+  version: 1.14.0
+  build: h73e2aa4_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libvpx-1.13.1-he965462_0.conda
-  sha256: cc3d921861e4ac760b1f54caef0fae7ce2e94faca51bcb438696bfbf16e42b54
-  md5: 217e20148014ce0118f7d10852ac2fec
+  url: https://conda.anaconda.org/conda-forge/osx-64/libvpx-1.14.0-h73e2aa4_0.conda
+  sha256: d3980ecf1e65bfbf7e1c57d6f41a66ab4f33c4fe6b71bf9414bb823e2db186fb
+  md5: 2c087711228029c8eab3301ddff1c386
   depends:
-  - libcxx >=15.0.7
+  - libcxx >=16
   license: BSD-3-Clause
   license_family: BSD
-  size: 1285936
-  timestamp: 1696342600631
+  size: 1294811
+  timestamp: 1707175761017
 - kind: conda
   name: libwebp-base
   version: 1.3.2
@@ -10683,12 +10801,12 @@ packages:
   timestamp: 1701352639132
 - kind: conda
   name: libxml2
-  version: 2.12.5
+  version: 2.12.6
   build: h0d0cfa8_0
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.12.5-h0d0cfa8_0.conda
-  sha256: 34daea04dc08af703effe424527505789f8a50fa71b447c7cac6f0d36a02cce3
-  md5: 6aef67f18bef799926bc05948a1239e3
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.12.6-h0d0cfa8_0.conda
+  sha256: 38a5e25e1fd3b59fd31301f39a0f02ca28925d7d102348921b9366e580cd810c
+  md5: 4713f0d8bb1e50cc4757c118b6fe20d5
   depends:
   - icu >=73.2,<74.0a0
   - libiconv >=1.17,<2.0a0
@@ -10696,16 +10814,16 @@ packages:
   - xz >=5.2.6,<6.0a0
   license: MIT
   license_family: MIT
-  size: 587894
-  timestamp: 1707084537489
+  size: 588221
+  timestamp: 1710715191381
 - kind: conda
   name: libxml2
-  version: 2.12.5
+  version: 2.12.6
   build: h232c23b_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.12.5-h232c23b_0.conda
-  sha256: db9bf97e9e367985204331b58a059ebd5a4e0cb9e1c8754e9ecb23046b7b7bc1
-  md5: c442ebfda7a475f5e78f1c8e45f1e919
+  url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.12.6-h232c23b_0.conda
+  sha256: 4646ae14fb226080d2bfeb89510147abebd603bab1c80bb6b3c02a01c10c6ee5
+  md5: d86653ff5ccb88bf7f13833fdd8789e0
   depends:
   - icu >=73.2,<74.0a0
   - libgcc-ng >=12
@@ -10714,16 +10832,16 @@ packages:
   - xz >=5.2.6,<6.0a0
   license: MIT
   license_family: MIT
-  size: 704829
-  timestamp: 1707084502281
+  size: 704019
+  timestamp: 1710715057008
 - kind: conda
   name: libxml2
-  version: 2.12.5
+  version: 2.12.6
   build: h3091e33_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libxml2-2.12.5-h3091e33_0.conda
-  sha256: 34f7a007fa23b70c56358738d7ba801df9a923422f2dcd23f3b2ca790ea2460a
-  md5: 2fcb5d64474a337f2a4213ec1dd40ce2
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libxml2-2.12.6-h3091e33_0.conda
+  sha256: d805fd3420450a7f2378b23e04538dbe3ac50f0829063c18e047d36e6f0284ee
+  md5: 61792398a68011c12d1b19a325802589
   depends:
   - icu >=73.2,<74.0a0
   - libgcc-ng >=12
@@ -10732,16 +10850,16 @@ packages:
   - xz >=5.2.6,<6.0a0
   license: MIT
   license_family: MIT
-  size: 752149
-  timestamp: 1707084726972
+  size: 750967
+  timestamp: 1710715173960
 - kind: conda
   name: libxml2
-  version: 2.12.5
+  version: 2.12.6
   build: hc0ae0f7_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.12.5-hc0ae0f7_0.conda
-  sha256: a84f355dcf9039ae54e21bf8833c16200f848fd333a5e68c143e142cc55dc07d
-  md5: abe27e7ab68b95e8d0e41cd5018ec8ae
+  url: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.12.6-hc0ae0f7_0.conda
+  sha256: 4b6e6c4616a3a46f64416fed97901496e8f46d0a771572fe9f8cc3b9701e78c2
+  md5: 913ce3dbfa8677fba65c44647ef88594
   depends:
   - icu >=73.2,<74.0a0
   - libiconv >=1.17,<2.0a0
@@ -10749,16 +10867,16 @@ packages:
   - xz >=5.2.6,<6.0a0
   license: MIT
   license_family: MIT
-  size: 619351
-  timestamp: 1707084558935
+  size: 619163
+  timestamp: 1710717459458
 - kind: conda
   name: libxml2
-  version: 2.12.5
+  version: 2.12.6
   build: hc3477c8_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.12.5-hc3477c8_0.conda
-  sha256: 15696b049911b3ea5d37672408e500fb27e375d865f8cceac9cb02f9349e6804
-  md5: d8c3c1c8242db352f38cd1dc0bf44f77
+  url: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.12.6-hc3477c8_0.conda
+  sha256: 1840ebacace4e8439b1cafbf8df004cd75f7647afc6d37812b86c035e4311fbf
+  md5: 3c32fe752618a88e83f515a1fdd0e9a1
   depends:
   - libiconv >=1.17,<2.0a0
   - libzlib >=1.2.13,<1.3.0a0
@@ -10767,8 +10885,8 @@ packages:
   - vc14_runtime >=14.29.30139
   license: MIT
   license_family: MIT
-  size: 1567894
-  timestamp: 1707084720091
+  size: 1641927
+  timestamp: 1710715561316
 - kind: conda
   name: libxslt
   version: 1.1.39
@@ -10847,12 +10965,12 @@ packages:
 - kind: conda
   name: libyarp
   version: 3.9.0
-  build: h6d2be9b_1
-  build_number: 1
+  build: h6d2be9b_2
+  build_number: 2
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libyarp-3.9.0-h6d2be9b_1.conda
-  sha256: 05db9ab7b0109a8276a90655328192c3cca8e2325662754f2378f95d5f99ac48
-  md5: 340e8d819db339d5b13f0799f4073bfb
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libyarp-3.9.0-h6d2be9b_2.conda
+  sha256: 2a96712e6d762671735ad32003a565118215b0060923491abdf3fa8d8c44a3b1
+  md5: 10784ba3d7d4d12722ba41148e494080
   depends:
   - ace >=7.1.3,<7.1.4.0a0
   - eigen
@@ -10862,8 +10980,8 @@ packages:
   - libi2c >=4.3,<5.0a0
   - libjpeg-turbo >=3.0.0,<4.0a0
   - libopencv >=4.9.0,<4.9.1.0a0
-  - libpng >=1.6.39,<1.7.0a0
-  - libsqlite >=3.44.2,<4.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libsqlite >=3.45.2,<4.0a0
   - libstdcxx-ng >=12
   - libzlib >=1.2.13,<1.3.0a0
   - portaudio >=19.6.0,<19.7.0a0
@@ -10874,27 +10992,27 @@ packages:
   - tinyxml
   - ycm-cmake-modules
   license: BSD-3-Clause AND MIT AND GPL-3.0-or-later
-  size: 10700707
-  timestamp: 1706034748012
+  size: 10728595
+  timestamp: 1711027867844
 - kind: conda
   name: libyarp
   version: 3.9.0
-  build: h9c0c770_1
-  build_number: 1
+  build: h9c0c770_2
+  build_number: 2
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libyarp-3.9.0-h9c0c770_1.conda
-  sha256: 156cb9750ba2fc4b145f401cfaf5144c51188dc7e72c283d1f627693cd080b3c
-  md5: 952b04298dc0bf83604e9cdd9be491c2
+  url: https://conda.anaconda.org/conda-forge/osx-64/libyarp-3.9.0-h9c0c770_2.conda
+  sha256: 4650c1f3d6df8aa9fddb7bb68386690ee344bddb829c215b60ad4ce08b6c14f3
+  md5: 540a665d37a2ef57ae2d73b761b2f26c
   depends:
   - ace >=7.1.3,<7.1.4.0a0
   - eigen
   - ffmpeg >=6.1.1,<7.0a0
-  - libcxx >=15
+  - libcxx >=16
   - libedit >=3.1.20191231,<3.2.0a0
   - libjpeg-turbo >=3.0.0,<4.0a0
   - libopencv >=4.9.0,<4.9.1.0a0
-  - libpng >=1.6.39,<1.7.0a0
-  - libsqlite >=3.44.2,<4.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libsqlite >=3.45.2,<4.0a0
   - libzlib >=1.2.13,<1.3.0a0
   - portaudio >=19.6.0,<19.7.0a0
   - qt-main >=5.15.8,<5.16.0a0
@@ -10904,25 +11022,25 @@ packages:
   - tinyxml
   - ycm-cmake-modules
   license: BSD-3-Clause AND MIT AND GPL-3.0-or-later
-  size: 7620958
-  timestamp: 1706034947951
+  size: 7633482
+  timestamp: 1711028877959
 - kind: conda
   name: libyarp
   version: 3.9.0
-  build: ha0ae21b_1
-  build_number: 1
+  build: ha0ae21b_2
+  build_number: 2
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libyarp-3.9.0-ha0ae21b_1.conda
-  sha256: 94d50ef201d8d7c401031af6421584e9e0262eb98301071956cdd91be0ac671f
-  md5: 0e33a632f0577b35a30965c5cee6a8fc
+  url: https://conda.anaconda.org/conda-forge/win-64/libyarp-3.9.0-ha0ae21b_2.conda
+  sha256: d3fb5f802579655b0951b15ac9c569bc012309d83eb05545552b2869d3af7f0f
+  md5: 05494ca8d0446dc269cdf6f862b80dfc
   depends:
   - ace >=7.1.3,<7.1.4.0a0
   - eigen
   - ffmpeg >=6.1.1,<7.0a0
   - libjpeg-turbo >=3.0.0,<4.0a0
   - libopencv >=4.9.0,<4.9.1.0a0
-  - libpng >=1.6.39,<1.7.0a0
-  - libsqlite >=3.44.2,<4.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libsqlite >=3.45.2,<4.0a0
   - libzlib >=1.2.13,<1.3.0a0
   - portaudio >=19.6.0,<19.7.0a0
   - qt-main >=5.15.8,<5.16.0a0
@@ -10935,17 +11053,17 @@ packages:
   - vc14_runtime >=14.29.30139
   - ycm-cmake-modules
   license: BSD-3-Clause AND MIT AND GPL-3.0-or-later
-  size: 9242887
-  timestamp: 1706035547672
+  size: 9297114
+  timestamp: 1711029347523
 - kind: conda
   name: libyarp
   version: 3.9.0
-  build: ha614a09_1
-  build_number: 1
+  build: ha614a09_2
+  build_number: 2
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libyarp-3.9.0-ha614a09_1.conda
-  sha256: 40e4ffb64d5964951576795559121a8da363c139b522b16c1540412d5024f320
-  md5: 77bab65488a974247a640ec1d1b8ab7e
+  url: https://conda.anaconda.org/conda-forge/linux-64/libyarp-3.9.0-ha614a09_2.conda
+  sha256: e65ed048ca864c1caca7d84856f8376299aea2a361f3d2ad2c4b1599970c1a7b
+  md5: 91311b595caa11b3de437ed4919ff6d6
   depends:
   - ace >=7.1.3,<7.1.4.0a0
   - eigen
@@ -10955,8 +11073,8 @@ packages:
   - libi2c >=4.3,<5.0a0
   - libjpeg-turbo >=3.0.0,<4.0a0
   - libopencv >=4.9.0,<4.9.1.0a0
-  - libpng >=1.6.39,<1.7.0a0
-  - libsqlite >=3.44.2,<4.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libsqlite >=3.45.2,<4.0a0
   - libstdcxx-ng >=12
   - libzlib >=1.2.13,<1.3.0a0
   - portaudio >=19.6.0,<19.7.0a0
@@ -10967,26 +11085,26 @@ packages:
   - tinyxml
   - ycm-cmake-modules
   license: BSD-3-Clause AND MIT AND GPL-3.0-or-later
-  size: 10150570
-  timestamp: 1706034146006
+  size: 10090055
+  timestamp: 1711027782866
 - kind: conda
   name: libyarp
   version: 3.9.0
-  build: hff4382b_1
-  build_number: 1
+  build: hff4382b_2
+  build_number: 2
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libyarp-3.9.0-hff4382b_1.conda
-  sha256: b7015046d5fae7c5c555be09b24b4805b454d162c27a845eee04ac9e41d08549
-  md5: 7aad3a8158920c3f16dcb4e49d401149
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libyarp-3.9.0-hff4382b_2.conda
+  sha256: 31f8bfbb019bf2d136e463250cd42d09ce15bf606ed7b5004a8a848a33f8b009
+  md5: 29efca2ccae313f55c70adedee4b0600
   depends:
   - eigen
   - ffmpeg >=6.1.1,<7.0a0
-  - libcxx >=15
+  - libcxx >=16
   - libedit >=3.1.20191231,<3.2.0a0
   - libjpeg-turbo >=3.0.0,<4.0a0
   - libopencv >=4.9.0,<4.9.1.0a0
-  - libpng >=1.6.39,<1.7.0a0
-  - libsqlite >=3.44.2,<4.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libsqlite >=3.45.2,<4.0a0
   - libzlib >=1.2.13,<1.3.0a0
   - portaudio >=19.6.0,<19.7.0a0
   - qt-main >=5.15.8,<5.16.0a0
@@ -10996,8 +11114,8 @@ packages:
   - tinyxml
   - ycm-cmake-modules
   license: BSD-3-Clause AND MIT AND GPL-3.0-or-later
-  size: 7452384
-  timestamp: 1706035278536
+  size: 7177892
+  timestamp: 1711029042235
 - kind: conda
   name: libzlib
   version: 1.2.13
@@ -11095,32 +11213,32 @@ packages:
   size: 2667
 - kind: conda
   name: llvm-openmp
-  version: 17.0.6
+  version: 18.1.2
   build: hb6ac08f_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-17.0.6-hb6ac08f_0.conda
-  sha256: 9ea2f7018f335fdc55bc9b21a388eb94ea47a243d9cbf6ec3d8862d4df9fb49b
-  md5: f260ab897df05f729fc3e65dbb0850ef
+  url: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-18.1.2-hb6ac08f_0.conda
+  sha256: dc40b678f5be2caf4e89ee3dc9037399d0bcd46543bc258dc46e1b92d241c6a6
+  md5: e7f7e91cfabd8c7172c9ae405214dd68
   constrains:
-  - openmp 17.0.6|17.0.6.*
+  - openmp 18.1.2|18.1.2.*
   license: Apache-2.0 WITH LLVM-exception
   license_family: APACHE
-  size: 299706
-  timestamp: 1701222810938
+  size: 300480
+  timestamp: 1711010792383
 - kind: conda
   name: llvm-openmp
-  version: 17.0.6
+  version: 18.1.2
   build: hcd81f8e_0
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-17.0.6-hcd81f8e_0.conda
-  sha256: 0c217326c5931c1416b82f98169b8a8a52139f6f5f299dbb2efa7b21f65f225a
-  md5: 52019d2fa0eddbbc4e6dcd30fae0c0a4
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-18.1.2-hcd81f8e_0.conda
+  sha256: 2ed8ae5a4c6122d542564a9bb9d4961ed7d2fb9581f0ea8bd81e3a83e614b110
+  md5: 34646dc152f3949a2f8a67136d406dce
   constrains:
-  - openmp 17.0.6|17.0.6.*
+  - openmp 18.1.2|18.1.2.*
   license: Apache-2.0 WITH LLVM-exception
   license_family: APACHE
-  size: 274631
-  timestamp: 1701222947083
+  size: 276238
+  timestamp: 1711010656300
 - kind: conda
   name: llvm-tools
   version: 16.0.6
@@ -11697,60 +11815,52 @@ packages:
   timestamp: 1698937846157
 - kind: conda
   name: ncurses
-  version: '6.4'
-  build: h0425590_2
-  build_number: 2
+  version: 6.4.20240210
+  build: h0425590_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/ncurses-6.4-h0425590_2.conda
-  sha256: d71cf2f2b1a9fae7ee2455a35a890423838e9594294beb4a002fe7c7b10bc086
-  md5: 4ff0a396150dedad4269e16e5810f769
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/ncurses-6.4.20240210-h0425590_0.conda
+  sha256: 4223dc34e2bddd37bf995158ae481e00be375b287d539bc7a0532634c0fc63b7
+  md5: c1a1612ddaee95c83abfa0b2ec858626
   depends:
   - libgcc-ng >=12
   license: X11 AND BSD-3-Clause
-  size: 920540
-  timestamp: 1698751239554
+  size: 926594
+  timestamp: 1710866633409
 - kind: conda
   name: ncurses
-  version: '6.4'
-  build: h463b476_2
-  build_number: 2
+  version: 6.4.20240210
+  build: h078ce10_0
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.4-h463b476_2.conda
-  sha256: f6890634f815e8408d08f36503353f8dfd7b055e4c3b9ea2ee52180255cf4b0a
-  md5: 52b6f254a7b9663e854f44b6570ed982
-  depends:
-  - __osx >=10.9
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.4.20240210-h078ce10_0.conda
+  sha256: 06f0905791575e2cd3aa961493c56e490b3d82ad9eb49f1c332bd338b0216911
+  md5: 616ae8691e6608527d0071e6766dcb81
   license: X11 AND BSD-3-Clause
-  size: 794741
-  timestamp: 1698751574074
+  size: 820249
+  timestamp: 1710866874348
 - kind: conda
   name: ncurses
-  version: '6.4'
-  build: h59595ed_2
-  build_number: 2
+  version: 6.4.20240210
+  build: h59595ed_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.4-h59595ed_2.conda
-  sha256: 91cc03f14caf96243cead96c76fe91ab5925a695d892e83285461fb927dece5e
-  md5: 7dbaa197d7ba6032caf7ae7f32c1efa0
+  url: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.4.20240210-h59595ed_0.conda
+  sha256: aa0f005b6727aac6507317ed490f0904430584fa8ca722657e7f0fb94741de81
+  md5: 97da8860a0da5413c7c98a3b3838a645
   depends:
   - libgcc-ng >=12
   license: X11 AND BSD-3-Clause
-  size: 884434
-  timestamp: 1698751260967
+  size: 895669
+  timestamp: 1710866638986
 - kind: conda
   name: ncurses
-  version: '6.4'
-  build: h93d8f39_2
-  build_number: 2
+  version: 6.4.20240210
+  build: h73e2aa4_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.4-h93d8f39_2.conda
-  sha256: ea0fca66bbb52a1ef0687d466518fe120b5f279684effd6fd336a7b0dddc423a
-  md5: e58f366bd4d767e9ab97ab8b272e7670
-  depends:
-  - __osx >=10.9
+  url: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.4.20240210-h73e2aa4_0.conda
+  sha256: 50b72acf08acbc4e5332807653e2ca6b26d4326e8af16fad1fd3f2ce9ea55503
+  md5: 50f28c512e9ad78589e3eab34833f762
   license: X11 AND BSD-3-Clause
-  size: 822031
-  timestamp: 1698751567986
+  size: 823010
+  timestamp: 1710866856626
 - kind: conda
   name: nettle
   version: 3.9.1
@@ -11937,75 +12047,75 @@ packages:
   timestamp: 1669785313586
 - kind: conda
   name: nss
-  version: '3.97'
+  version: '3.98'
   build: h1d7d5a4_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/nss-3.97-h1d7d5a4_0.conda
-  sha256: a1a62d415e5b5ddbd799ad6d92b2c4a4351fda00b54d96cac2ce7afa04b2d698
-  md5: b916d71a3032416e3f9136090d814472
+  url: https://conda.anaconda.org/conda-forge/linux-64/nss-3.98-h1d7d5a4_0.conda
+  sha256: a9bc94d03df48014011cf6caaf447f2ef86a5edf7c70d70002ec4b59f5a4e198
+  md5: 54b56c2fdf973656b748e0378900ec13
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc-ng >=12
-  - libsqlite >=3.44.2,<4.0a0
+  - libsqlite >=3.45.1,<4.0a0
   - libstdcxx-ng >=12
   - libzlib >=1.2.13,<1.3.0a0
   - nspr >=4.35,<5.0a0
   license: MPL-2.0
   license_family: MOZILLA
-  size: 2014022
-  timestamp: 1705921777003
+  size: 2019716
+  timestamp: 1708065114928
 - kind: conda
   name: nss
-  version: '3.97'
+  version: '3.98'
   build: h5ce2875_0
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/nss-3.97-h5ce2875_0.conda
-  sha256: 27786510a52aeb1115c31d8127fcc57fdec38bcef22882dd3bd05d04ca5c393d
-  md5: 5d2d69c2cce2c58171648a1fd34d6732
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/nss-3.98-h5ce2875_0.conda
+  sha256: eecb5718c43dd68cf8150b1e75c91518dae457348828361034639e9e2ea82c82
+  md5: db0d8f4d11186e4cb3f1a3e0385ca075
   depends:
-  - libcxx >=15
-  - libsqlite >=3.44.2,<4.0a0
+  - libcxx >=16
+  - libsqlite >=3.45.1,<4.0a0
   - libzlib >=1.2.13,<1.3.0a0
   - nspr >=4.35,<5.0a0
   license: MPL-2.0
   license_family: MOZILLA
-  size: 1803657
-  timestamp: 1705922174903
+  size: 1809748
+  timestamp: 1708065511899
 - kind: conda
   name: nss
-  version: '3.97'
+  version: '3.98'
   build: ha05da47_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/nss-3.97-ha05da47_0.conda
-  sha256: fe26704cb733d412fafbeaf0cc4c402f9623757bc2241381d7480a22cdeb64e4
-  md5: 6408f35df2c8ba0642b13d32915a789b
+  url: https://conda.anaconda.org/conda-forge/osx-64/nss-3.98-ha05da47_0.conda
+  sha256: 3d99dd976aeb8678e4ac5fcbd574e1de50cdc57b742e22855f294c8047d5c68e
+  md5: 79d062716d8e1f77cf806c6fe0f4405c
   depends:
-  - libcxx >=15
-  - libsqlite >=3.44.2,<4.0a0
+  - libcxx >=16
+  - libsqlite >=3.45.1,<4.0a0
   - libzlib >=1.2.13,<1.3.0a0
   - nspr >=4.35,<5.0a0
   license: MPL-2.0
   license_family: MOZILLA
-  size: 1902273
-  timestamp: 1705922096082
+  size: 1908769
+  timestamp: 1708065399315
 - kind: conda
   name: nss
-  version: '3.97'
+  version: '3.98'
   build: hc5a5cc2_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/nss-3.97-hc5a5cc2_0.conda
-  sha256: 0f8c2fc6e1b1c49db58a236150b638e990db8c8dcff592b08187ed46bba11995
-  md5: 69d61fcfcd726888d5c2add225461a35
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/nss-3.98-hc5a5cc2_0.conda
+  sha256: d1506d21d8375c1dbdd5fee11cbb6799f8f129a54bc837ca5b8baa43fbe3d36d
+  md5: 7b72650a6c08894c36bed9aebb3b32dc
   depends:
   - libgcc-ng >=12
-  - libsqlite >=3.44.2,<4.0a0
+  - libsqlite >=3.45.1,<4.0a0
   - libstdcxx-ng >=12
   - libzlib >=1.2.13,<1.3.0a0
   - nspr >=4.35,<5.0a0
   license: MPL-2.0
   license_family: MOZILLA
-  size: 2001907
-  timestamp: 1705921667319
+  size: 2011672
+  timestamp: 1708065149436
 - kind: conda
   name: numpy
   version: 1.26.4
@@ -12120,31 +12230,107 @@ packages:
 - kind: conda
   name: ocl-icd
   version: 2.3.2
-  build: hd590300_0
+  build: hd590300_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/ocl-icd-2.3.2-hd590300_0.conda
-  sha256: d413c0b42ba13532943118458caab795454f5a73d70f5d2ed2daa6118df15876
-  md5: 92e93490ee7f98bfadb389e3129b955c
+  url: https://conda.anaconda.org/conda-forge/linux-64/ocl-icd-2.3.2-hd590300_1.conda
+  sha256: 0e01384423e48e5011eb6b224da8dc5e3567c87dbcefbe60cd9d5cead276cdcd
+  md5: c66f837ac65e4d1cdeb80e2a1d5fcc3d
   depends:
   - libgcc-ng >=12
   license: BSD-2-Clause
-  size: 136327
-  timestamp: 1707866764671
+  license_family: BSD
+  size: 135681
+  timestamp: 1710946531879
 - kind: conda
-  name: ocl-icd-system
-  version: 1.0.0
-  build: '1'
+  name: openexr
+  version: 3.2.2
+  build: h2c51e1d_1
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/openexr-3.2.2-h2c51e1d_1.conda
+  sha256: 243b221c708bbe7f5c0fd72bdbd944a08f4ea9bc1e52b4f12f7fdb5f59633e13
+  md5: 4ccfab8e79256a8480165969dd1d350c
+  depends:
+  - imath >=3.1.11,<3.1.12.0a0
+  - libcxx >=16
+  - libzlib >=1.2.13,<1.3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1361156
+  timestamp: 1709261019544
+- kind: conda
+  name: openexr
+  version: 3.2.2
+  build: h3f0570e_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/openexr-3.2.2-h3f0570e_1.conda
+  sha256: 6d2b2adb875b8b5a052f423dd9c6b9df90fbecd9d726aefafcd18f3b74a9118f
+  md5: 95bd8b6b83801d99b064c785585bd15d
+  depends:
+  - imath >=3.1.11,<3.1.12.0a0
+  - libcxx >=16
+  - libzlib >=1.2.13,<1.3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1329934
+  timestamp: 1709261129338
+- kind: conda
+  name: openexr
+  version: 3.2.2
+  build: h72640d8_1
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/openexr-3.2.2-h72640d8_1.conda
+  sha256: 23a080dc31c2d557719c928c2685e2952d5b36b70aecbfd962824bd0b414cf9c
+  md5: 3cecd7892a09d59f64a3e119647630f9
+  depends:
+  - imath >=3.1.11,<3.1.12.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1208041
+  timestamp: 1709260904190
+- kind: conda
+  name: openexr
+  version: 3.2.2
+  build: haf962dd_1
   build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/ocl-icd-system-1.0.0-1.tar.bz2
-  sha256: cb0ce5ce5ede1be2fd9edf88abd3ce3e6c2b7397c0283d623e4d8ccf96a1ed09
-  md5: 577a4bd049737b11a24524e39a16a1f3
+  url: https://conda.anaconda.org/conda-forge/linux-64/openexr-3.2.2-haf962dd_1.conda
+  sha256: 01d773a14124929abd6c26169d900ce439f9df8a9e37d3ea197c7f71f61e7906
+  md5: 34e58e21fc28e404207d6ce4287da264
   depends:
-  - ocl-icd
-  license: BSD 3-Clause
+  - imath >=3.1.11,<3.1.12.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
+  license: BSD-3-Clause
   license_family: BSD
-  size: 4253
-  timestamp: 1575483836797
+  size: 1466865
+  timestamp: 1709260550301
+- kind: conda
+  name: openexr
+  version: 3.2.2
+  build: hdf561d4_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/openexr-3.2.2-hdf561d4_1.conda
+  sha256: 138e7306bce957fda18199270997dfedca1acd6d835b0ba3e9a3090998674a6b
+  md5: 0372e30a92ab93025acce24df8eed52a
+  depends:
+  - imath >=3.1.11,<3.1.12.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1388438
+  timestamp: 1709260386569
 - kind: conda
   name: openh264
   version: 2.4.1
@@ -12238,27 +12424,29 @@ packages:
 - kind: conda
   name: openssl
   version: 3.2.1
-  build: h0d3ecfb_0
+  build: h0d3ecfb_1
+  build_number: 1
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.2.1-h0d3ecfb_0.conda
-  sha256: 13663fcd4abc8681b31ccbad39800fee2127cb6159b51a989ed48a816af36cf5
-  md5: 421cc6e8715447b73c2c57dcf78cb9d2
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.2.1-h0d3ecfb_1.conda
+  sha256: 519dc941d7ab0ebf31a2878d85c2f444450e7c5f6f41c4d07252c6bb3417b78b
+  md5: eb580fb888d93d5d550c557323ac5cee
   depends:
   - ca-certificates
   constrains:
   - pyopenssl >=22.1
   license: Apache-2.0
   license_family: Apache
-  size: 2862719
-  timestamp: 1706635779319
+  size: 2855250
+  timestamp: 1710793435903
 - kind: conda
   name: openssl
   version: 3.2.1
-  build: h31becfc_0
+  build: h31becfc_1
+  build_number: 1
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.2.1-h31becfc_0.conda
-  sha256: 952ef5de4e3913621a89ca2eb8186683bb73832527219c6443c260a6b46cd149
-  md5: b7e7c53240214ae96f52a440c0b0126a
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.2.1-h31becfc_1.conda
+  sha256: 055a26e99ebc12ae0cf23266a0e62e71b59b8ce8cafb1ebb87e375ef9c758d7b
+  md5: e95eb18d256edc72058e0dc9be5338a0
   depends:
   - ca-certificates
   - libgcc-ng >=12
@@ -12266,16 +12454,17 @@ packages:
   - pyopenssl >=22.1
   license: Apache-2.0
   license_family: Apache
-  size: 3382700
-  timestamp: 1706635800272
+  size: 3380844
+  timestamp: 1710793424665
 - kind: conda
   name: openssl
   version: 3.2.1
-  build: hcfcfb64_0
+  build: hcfcfb64_1
+  build_number: 1
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/openssl-3.2.1-hcfcfb64_0.conda
-  sha256: 1df1c43136f863d5e9ba20b703001caf9a4d0ea56bdc3eeb948c977e3d4f91d3
-  md5: 158df8eead8092cf0e27167c8761a8dd
+  url: https://conda.anaconda.org/conda-forge/win-64/openssl-3.2.1-hcfcfb64_1.conda
+  sha256: 61ce4e11c3c26ed4e4d9b7e7e2483121a1741ad0f9c8db0a91a28b6e05182ce6
+  md5: 958e0418e93e50c575bff70fbcaa12d8
   depends:
   - ca-certificates
   - ucrt >=10.0.20348.0
@@ -12285,16 +12474,17 @@ packages:
   - pyopenssl >=22.1
   license: Apache-2.0
   license_family: Apache
-  size: 8229619
-  timestamp: 1706638014697
+  size: 8230112
+  timestamp: 1710796158475
 - kind: conda
   name: openssl
   version: 3.2.1
-  build: hd590300_0
+  build: hd590300_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.2.1-hd590300_0.conda
-  sha256: c02c12bdb898daacf7eb3d09859f93ea8f285fd1a6132ff6ff0493ab52c7fe57
-  md5: 51a753e64a3027bd7e23a189b1f6e91e
+  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.2.1-hd590300_1.conda
+  sha256: 2c689444ed19a603be457284cf2115ee728a3fafb7527326e96054dee7cdc1a7
+  md5: 9d731343cff6ee2e5a25c4a091bf8e2a
   depends:
   - ca-certificates
   - libgcc-ng >=12
@@ -12302,108 +12492,114 @@ packages:
   - pyopenssl >=22.1
   license: Apache-2.0
   license_family: Apache
-  size: 2863069
-  timestamp: 1706635653339
+  size: 2865379
+  timestamp: 1710793235846
 - kind: conda
   name: openssl
   version: 3.2.1
-  build: hd75f5a5_0
+  build: hd75f5a5_1
+  build_number: 1
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.2.1-hd75f5a5_0.conda
-  sha256: 20c1b1a34a1831c24d37ed1500ca07300171184af0c66598f3c5ca901634d713
-  md5: 3033be9a59fd744172b03971b9ccd081
+  url: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.2.1-hd75f5a5_1.conda
+  sha256: 7ae0ac6a1673584a8a380c2ff3d46eca48ed53bc7174c0d4eaa0dd2f247a0984
+  md5: 570a6f04802df580be529f3a72d2bbf7
   depends:
   - ca-certificates
   constrains:
   - pyopenssl >=22.1
   license: Apache-2.0
   license_family: Apache
-  size: 2509168
-  timestamp: 1706636810736
+  size: 2506344
+  timestamp: 1710793930515
 - kind: conda
   name: osqp-eigen
   version: 0.8.1
-  build: h63a7d18_0
+  build: h136a8c3_1
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/osqp-eigen-0.8.1-h136a8c3_1.conda
+  sha256: 75ee7b242b62f43f31f3caa5f85a56130dc3efeb09222ab21e041093eb364711
+  md5: 26c46a328a1a81dbd5f5d8b75a90d131
+  depends:
+  - eigen
+  - libcxx >=16
+  - libosqp >=0.6.3,<0.6.4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 33987
+  timestamp: 1709559705042
+- kind: conda
+  name: osqp-eigen
+  version: 0.8.1
+  build: h63a7d18_1
+  build_number: 1
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/osqp-eigen-0.8.1-h63a7d18_0.conda
-  sha256: 825faa6ea24ad95e18319b543cb006f6437a4cdeeacadb970700b0ee884b9392
-  md5: 0f8c9195f47fb752b7e85d33086f211c
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/osqp-eigen-0.8.1-h63a7d18_1.conda
+  sha256: a8db1a2cd767bc172bd51351719712820dab440c30f74f1b5afeaca26db4f40f
+  md5: ffc5561a5a697954fdde3289e245e2c9
   depends:
   - eigen
   - libgcc-ng >=12
   - libosqp >=0.6.3,<0.6.4.0a0
   - libstdcxx-ng >=12
-  license: LGPL-3.0-or-later
-  license_family: LGPL
-  size: 34843
-  timestamp: 1690887627026
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 34800
+  timestamp: 1709559465740
 - kind: conda
   name: osqp-eigen
   version: 0.8.1
-  build: h6d7489e_0
+  build: h6d7489e_1
+  build_number: 1
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/osqp-eigen-0.8.1-h6d7489e_0.conda
-  sha256: 47b51a36e1d54011005d77e48d2ad98319abaec483025f6067585db803726e39
-  md5: db2ae068a7eab79e4e986bb72bd50794
+  url: https://conda.anaconda.org/conda-forge/win-64/osqp-eigen-0.8.1-h6d7489e_1.conda
+  sha256: 24bd9f72d13d4451d9e7099bfaef9eddb53c95f2310acd598b536b05c31d7d38
+  md5: 623017d0d46414e5eacc08e42a7042c0
   depends:
   - eigen
   - libosqp >=0.6.3,<0.6.4.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  license: LGPL-3.0-or-later
-  license_family: LGPL
-  size: 63036
-  timestamp: 1690888036565
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 63988
+  timestamp: 1709560102716
 - kind: conda
   name: osqp-eigen
   version: 0.8.1
-  build: hdd734ac_0
+  build: hb7bbaee_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/osqp-eigen-0.8.1-hb7bbaee_1.conda
+  sha256: 4d0f259f3de97e9d397aa48fd51c47b75234a0a550014e198167cf199a091fb6
+  md5: 5d38b4edc2643631aa61e07c6b6ed3ae
+  depends:
+  - eigen
+  - libcxx >=16
+  - libosqp >=0.6.3,<0.6.4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 34303
+  timestamp: 1709559740511
+- kind: conda
+  name: osqp-eigen
+  version: 0.8.1
+  build: hdd734ac_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/osqp-eigen-0.8.1-hdd734ac_0.conda
-  sha256: 356fa62bcc752fcda14876339ed749515a9f43ac5f596bd607d17bd893cf508e
-  md5: eecff09d2a294502aad440fbfaf9d218
+  url: https://conda.anaconda.org/conda-forge/linux-64/osqp-eigen-0.8.1-hdd734ac_1.conda
+  sha256: 4fdea6a623b8c2ca45ef6576cbe287b54b129ebf4467631b7d6bcc6a940bad21
+  md5: b36c121074bec51888739cfb2762d460
   depends:
   - eigen
   - libgcc-ng >=12
   - libosqp >=0.6.3,<0.6.4.0a0
   - libstdcxx-ng >=12
-  license: LGPL-3.0-or-later
-  license_family: LGPL
-  size: 35747
-  timestamp: 1690887716943
-- kind: conda
-  name: osqp-eigen
-  version: 0.8.1
-  build: hede6739_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/osqp-eigen-0.8.1-hede6739_0.conda
-  sha256: e0883d288621e2bec3a7487c874db3a5c53e883342bd3b6b160bad699823f90e
-  md5: 3b7527f4250645372a2b138493a29632
-  depends:
-  - eigen
-  - libcxx >=15.0.7
-  - libosqp >=0.6.3,<0.6.4.0a0
-  license: LGPL-3.0-or-later
-  license_family: LGPL
-  size: 35607
-  timestamp: 1690887825800
-- kind: conda
-  name: osqp-eigen
-  version: 0.8.1
-  build: hfae311c_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/osqp-eigen-0.8.1-hfae311c_0.conda
-  sha256: 7cebc990afa753bc928250020438f628dfe5c5e03f9736cc636c34d510fd173b
-  md5: d58891e7ede6d21972ab86081a30383e
-  depends:
-  - eigen
-  - libcxx >=15.0.7
-  - libosqp >=0.6.3,<0.6.4.0a0
-  license: LGPL-3.0-or-later
-  license_family: LGPL
-  size: 34698
-  timestamp: 1690888118944
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 35336
+  timestamp: 1709559434463
 - kind: conda
   name: p11-kit
   version: 0.24.1
@@ -12468,27 +12664,27 @@ packages:
   timestamp: 1654868759643
 - kind: conda
   name: pcre2
-  version: '10.42'
+  version: '10.43'
   build: h0ad2156_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/pcre2-10.42-h0ad2156_0.conda
-  sha256: 689559d94b64914e503d2ced53b78afc19562ed1ccfb284040797a6d41bb564c
-  md5: 41de8bab2d5e5cd6daaba1896e81d366
+  url: https://conda.anaconda.org/conda-forge/osx-64/pcre2-10.43-h0ad2156_0.conda
+  sha256: 226714bbf89d45bf7da4c7551e21b8a833f51d33379fe3dfbfe31b72832d4dba
+  md5: 9c8651803886ce9d5983e107a0df4ea8
   depends:
   - bzip2 >=1.0.8,<2.0a0
   - libzlib >=1.2.13,<1.3.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 899794
-  timestamp: 1698610978148
+  size: 836581
+  timestamp: 1708118455741
 - kind: conda
   name: pcre2
-  version: '10.42'
+  version: '10.43'
   build: h17e33f8_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pcre2-10.42-h17e33f8_0.conda
-  sha256: 25e33b148478de58842ccc018fbabb414665de59270476e92c951203d4485bb1
-  md5: 59610c61da3af020289a806ec9c6a7fd
+  url: https://conda.anaconda.org/conda-forge/win-64/pcre2-10.43-h17e33f8_0.conda
+  sha256: 9a82c7d49c4771342b398661862975efb9c30e7af600b5d2e08a0bf416fda492
+  md5: d0485b8aa2cedb141a7bd27b4efa4c9c
   depends:
   - bzip2 >=1.0.8,<2.0a0
   - libzlib >=1.2.13,<1.3.0a0
@@ -12497,55 +12693,55 @@ packages:
   - vc14_runtime >=14.29.30139
   license: BSD-3-Clause
   license_family: BSD
-  size: 880802
-  timestamp: 1698611415241
+  size: 818317
+  timestamp: 1708118868321
 - kind: conda
   name: pcre2
-  version: '10.42'
+  version: '10.43'
   build: h26f9a81_0
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pcre2-10.42-h26f9a81_0.conda
-  sha256: 0335a08349ecd8dce0b81699fcd61b58415e658fe953feb27316fbb994df0685
-  md5: 3e12888ecc8ee1ebee2eef9b7856357a
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pcre2-10.43-h26f9a81_0.conda
+  sha256: 4bf7b5fa091f5e7ab0b78778458be1e81c1ffa182b63795734861934945a63a7
+  md5: 1ddc87f00014612830f3235b5ad6d821
   depends:
   - bzip2 >=1.0.8,<2.0a0
   - libzlib >=1.2.13,<1.3.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 619848
-  timestamp: 1698610997157
+  size: 615219
+  timestamp: 1708118184900
 - kind: conda
   name: pcre2
-  version: '10.42'
+  version: '10.43'
   build: hcad00b1_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.42-hcad00b1_0.conda
-  sha256: 3ca54ff0abcda964af7d4724d389ae20d931159ae1881cfe57ad4b0ab9e6a380
-  md5: 679c8961826aa4b50653bce17ee52abe
+  url: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.43-hcad00b1_0.conda
+  sha256: 766dd986a7ed6197676c14699000bba2625fd26c8a890fcb7a810e5cf56155bc
+  md5: 8292dea9e022d9610a11fce5e0896ed8
   depends:
   - bzip2 >=1.0.8,<2.0a0
   - libgcc-ng >=12
   - libzlib >=1.2.13,<1.3.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 1017235
-  timestamp: 1698610864983
+  size: 950847
+  timestamp: 1708118050286
 - kind: conda
   name: pcre2
-  version: '10.42'
+  version: '10.43'
   build: hd0f9c67_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/pcre2-10.42-hd0f9c67_0.conda
-  sha256: 7ef11cc37800dcc4693c6f827e3cb58bc8a8cefe92b4307c6826845b3f198364
-  md5: 683162253dd3b6c4d21bf037e59455f4
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/pcre2-10.43-hd0f9c67_0.conda
+  sha256: 1bac2077caa28f0764f955e522468b98316b99b2d0904e9d93a01297fe1b7ba2
+  md5: 1275fa549338ecdc8b7793589ac09150
   depends:
   - bzip2 >=1.0.8,<2.0a0
   - libgcc-ng >=12
   - libzlib >=1.2.13,<1.3.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 944649
-  timestamp: 1698610795381
+  size: 880930
+  timestamp: 1708117999756
 - kind: conda
   name: pip
   version: '24.0'
@@ -12566,21 +12762,6 @@ packages:
 - kind: conda
   name: pixman
   version: 0.43.2
-  build: h2f0025b_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/pixman-0.43.2-h2f0025b_0.conda
-  sha256: 5afb7399abf43abbe8430da48be1452027ff26d949038f33e0a2adde100174aa
-  md5: 896686714eea591ad0c0891800c571fd
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  license: MIT
-  license_family: MIT
-  size: 295200
-  timestamp: 1706552057640
-- kind: conda
-  name: pixman
-  version: 0.43.2
   build: h59595ed_0
   subdir: linux-64
   url: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.43.2-h59595ed_0.conda
@@ -12595,48 +12776,63 @@ packages:
   timestamp: 1706549500138
 - kind: conda
   name: pixman
-  version: 0.43.2
+  version: 0.43.4
+  build: h2f0025b_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/pixman-0.43.4-h2f0025b_0.conda
+  sha256: e145b0d89c800326a20d1afd86c74f9422b81549b17fe53add46c2fa43a4c93e
+  md5: 81b2ddea4b0eca188da9c5a7aa4b0cff
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 295064
+  timestamp: 1709240909660
+- kind: conda
+  name: pixman
+  version: 0.43.4
   build: h63175ca_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pixman-0.43.2-h63175ca_0.conda
-  sha256: 659db230ba8121395b23fa6fce5f16532f54e4e7397ff9e7c19d9c7e436d29f8
-  md5: 1060b0e26af2192e80b1d04cae0b029f
+  url: https://conda.anaconda.org/conda-forge/win-64/pixman-0.43.4-h63175ca_0.conda
+  sha256: 51de4d7fb41597b06d60f1b82e269dafcb55e994e08fdcca8e4d6f7d42bedd07
+  md5: b98135614135d5f458b75ab9ebb9558c
   depends:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: MIT
   license_family: MIT
-  size: 460196
-  timestamp: 1706549794397
+  size: 461854
+  timestamp: 1709239971654
 - kind: conda
   name: pixman
-  version: 0.43.2
+  version: 0.43.4
   build: h73e2aa4_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/pixman-0.43.2-h73e2aa4_0.conda
-  sha256: 26b16d9a6aed8f3d96a7dbad5d63b6ab1bcce13d77c050bcbaf7378bada2d225
-  md5: 26cf3be47886ded561d3d2cd8654893f
+  url: https://conda.anaconda.org/conda-forge/osx-64/pixman-0.43.4-h73e2aa4_0.conda
+  sha256: 3ab44e12e566c67a6e9fd831f557ab195456aa996b8dd9af19787ca80caa5cd1
+  md5: cb134c1e03fd32f4e6bea3f6de2614fd
   depends:
-  - libcxx >=15
+  - libcxx >=16
   license: MIT
   license_family: MIT
-  size: 324294
-  timestamp: 1706549556213
+  size: 323904
+  timestamp: 1709239931160
 - kind: conda
   name: pixman
-  version: 0.43.2
+  version: 0.43.4
   build: hebf3989_0
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pixman-0.43.2-hebf3989_0.conda
-  sha256: dc3ec60e769f80c1d5124ba2788e3c9122443743989ad5f92addf416c7a4e58b
-  md5: aaf3f4397959b8900c7c2f90304ccb29
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pixman-0.43.4-hebf3989_0.conda
+  sha256: df0ba2710ccdea5c909b63635529797f6eb3635b6fb77ae9cb2f183d08818409
+  md5: 0308c68e711cd295aaa026a4f8c4b1e5
   depends:
-  - libcxx >=15
+  - libcxx >=16
   license: MIT
   license_family: MIT
-  size: 198606
-  timestamp: 1706549867392
+  size: 198755
+  timestamp: 1709239846651
 - kind: conda
   name: portaudio
   version: 19.6.0
@@ -12662,7 +12858,7 @@ packages:
   sha256: a73e31c5fe9d717cd42470b394018f4e48eed4a439b9371d2c6d380c86aed591
   md5: ab049f8223bccc6f621975beaa75c624
   depends:
-  - alsa-lib >=1.2.10,<1.2.11.0a0
+  - alsa-lib >=1.2.10,<1.3.0.0a0
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   license: MIT
@@ -12696,7 +12892,7 @@ packages:
   sha256: c09ae032d0303abfea34c0957834538b48133b0431283852741ed3e0f66fdb36
   md5: 893f2c33af6b03cfd04820a8c31f5798
   depends:
-  - alsa-lib >=1.2.10,<1.2.11.0a0
+  - alsa-lib >=1.2.10,<1.3.0.0a0
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   license: MIT
@@ -12906,35 +13102,34 @@ packages:
   timestamp: 1693928953742
 - kind: conda
   name: pyparsing
-  version: 3.1.1
+  version: 3.1.2
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.1-pyhd8ed1ab_0.conda
-  sha256: 4a1332d634b6c2501a973655d68f08c9c42c0bd509c349239127b10572b8354b
-  md5: 176f7d56f0cfe9008bdf1bccd7de02fb
+  url: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.2-pyhd8ed1ab_0.conda
+  sha256: 06c77cb03e5dde2d939b216c99dd2db52ea93a4c7c599f3882f136005c359c7b
+  md5: b9a4dacf97241704529131a0dfc0494f
   depends:
   - python >=3.6
   license: MIT
   license_family: MIT
-  size: 89521
-  timestamp: 1690737983548
+  size: 89455
+  timestamp: 1709721146886
 - kind: conda
   name: python
-  version: 3.11.7
-  build: h2628c8c_1_cpython
-  build_number: 1
+  version: 3.11.8
+  build: h2628c8c_0_cpython
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/python-3.11.7-h2628c8c_1_cpython.conda
-  sha256: 668e9fd58e627c823e6e9d791e1fb8b372c76b5704a0c3b0cc94b3a34f5be582
-  md5: c2f9a938fca6aa621b44afc8f5db79ab
+  url: https://conda.anaconda.org/conda-forge/win-64/python-3.11.8-h2628c8c_0_cpython.conda
+  sha256: 8b2db64acfd351f4281d75465b09109f4b51096d5e58128cb7a4c1d2ade47203
+  md5: 5af649cf283ec4c1ffff5c4fe0cec12b
   depends:
   - bzip2 >=1.0.8,<2.0a0
   - libexpat >=2.5.0,<3.0a0
   - libffi >=3.4,<4.0a0
-  - libsqlite >=3.44.2,<4.0a0
+  - libsqlite >=3.45.1,<4.0a0
   - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.2.0,<4.0a0
+  - openssl >=3.2.1,<4.0a0
   - tk >=8.6.13,<8.7.0a0
   - tzdata
   - ucrt >=10.0.20348.0
@@ -12944,17 +13139,16 @@ packages:
   constrains:
   - python_abi 3.11.* *_cp311
   license: Python-2.0
-  size: 18191531
-  timestamp: 1703342117253
+  size: 18096526
+  timestamp: 1708116524168
 - kind: conda
   name: python
-  version: 3.11.7
-  build: h43d1f9e_1_cpython
-  build_number: 1
+  version: 3.11.8
+  build: h43d1f9e_0_cpython
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/python-3.11.7-h43d1f9e_1_cpython.conda
-  sha256: d1d98331d7593d30fba6fdb03873e2e20b81963b596ed53804423e8d14e3306c
-  md5: f14f508a1135462ecb00d28967d9612b
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/python-3.11.8-h43d1f9e_0_cpython.conda
+  sha256: 4dbd3ac5f760cbf8c613df0a29d970ed1e8235101be1fa74ccd833300661706f
+  md5: fec01f7d8fdfec9c4881a1c9bdbc959e
   depends:
   - bzip2 >=1.0.8,<2.0a0
   - ld_impl_linux-aarch64 >=2.36.1
@@ -12962,12 +13156,12 @@ packages:
   - libffi >=3.4,<4.0a0
   - libgcc-ng >=12
   - libnsl >=2.0.1,<2.1.0a0
-  - libsqlite >=3.44.2,<4.0a0
+  - libsqlite >=3.45.1,<4.0a0
   - libuuid >=2.38.1,<3.0a0
   - libxcrypt >=4.4.36
   - libzlib >=1.2.13,<1.3.0a0
   - ncurses >=6.4,<7.0a0
-  - openssl >=3.2.0,<4.0a0
+  - openssl >=3.2.1,<4.0a0
   - readline >=8.2,<9.0a0
   - tk >=8.6.13,<8.7.0a0
   - tzdata
@@ -12975,25 +13169,24 @@ packages:
   constrains:
   - python_abi 3.11.* *_cp311
   license: Python-2.0
-  size: 15302406
-  timestamp: 1703341709968
+  size: 15317480
+  timestamp: 1708116052369
 - kind: conda
   name: python
-  version: 3.11.7
-  build: h9f0c242_1_cpython
-  build_number: 1
+  version: 3.11.8
+  build: h9f0c242_0_cpython
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/python-3.11.7-h9f0c242_1_cpython.conda
-  sha256: d234064dffa64715cf0a3f6c6a3665ead193f5a898614691b08d9c5afcdf11cc
-  md5: 686f211dcfbb8d27c6fe1ca905870189
+  url: https://conda.anaconda.org/conda-forge/osx-64/python-3.11.8-h9f0c242_0_cpython.conda
+  sha256: 645dad20b46041ecd6a85eccbb3291fa1ad7921eea065c0081efff78c3d7e27a
+  md5: 22bda10a0f425564a538aed9a0e8a9df
   depends:
   - bzip2 >=1.0.8,<2.0a0
   - libexpat >=2.5.0,<3.0a0
   - libffi >=3.4,<4.0a0
-  - libsqlite >=3.44.2,<4.0a0
+  - libsqlite >=3.45.1,<4.0a0
   - libzlib >=1.2.13,<1.3.0a0
   - ncurses >=6.4,<7.0a0
-  - openssl >=3.2.0,<4.0a0
+  - openssl >=3.2.1,<4.0a0
   - readline >=8.2,<9.0a0
   - tk >=8.6.13,<8.7.0a0
   - tzdata
@@ -13001,17 +13194,16 @@ packages:
   constrains:
   - python_abi 3.11.* *_cp311
   license: Python-2.0
-  size: 15452269
-  timestamp: 1703343492323
+  size: 14067894
+  timestamp: 1708117836907
 - kind: conda
   name: python
-  version: 3.11.7
-  build: hab00c5b_1_cpython
-  build_number: 1
+  version: 3.11.8
+  build: hab00c5b_0_cpython
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.11.7-hab00c5b_1_cpython.conda
-  sha256: 8266801d3f21ae3018b997dcd05503b034016a3335aa3ab5b8c3f482af1e6580
-  md5: 27cf681282c11dba7b0b1fd266e8f289
+  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.11.8-hab00c5b_0_cpython.conda
+  sha256: f33559d7127b6a892854bc3b2b4be1406c3be9537d658cb13edae57c8c0b5a11
+  md5: 2fdc314ee058eda0114738a9309d3683
   depends:
   - bzip2 >=1.0.8,<2.0a0
   - ld_impl_linux-64 >=2.36.1
@@ -13019,12 +13211,12 @@ packages:
   - libffi >=3.4,<4.0a0
   - libgcc-ng >=12
   - libnsl >=2.0.1,<2.1.0a0
-  - libsqlite >=3.44.2,<4.0a0
+  - libsqlite >=3.45.1,<4.0a0
   - libuuid >=2.38.1,<3.0a0
   - libxcrypt >=4.4.36
   - libzlib >=1.2.13,<1.3.0a0
   - ncurses >=6.4,<7.0a0
-  - openssl >=3.2.0,<4.0a0
+  - openssl >=3.2.1,<4.0a0
   - readline >=8.2,<9.0a0
   - tk >=8.6.13,<8.7.0a0
   - tzdata
@@ -13032,25 +13224,24 @@ packages:
   constrains:
   - python_abi 3.11.* *_cp311
   license: Python-2.0
-  size: 30830615
-  timestamp: 1703344491543
+  size: 30754113
+  timestamp: 1708118457486
 - kind: conda
   name: python
-  version: 3.11.7
-  build: hdf0ec26_1_cpython
-  build_number: 1
+  version: 3.11.8
+  build: hdf0ec26_0_cpython
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.11.7-hdf0ec26_1_cpython.conda
-  sha256: 92ac26592b53ddb646237c0dd83fd073d2f181dd1553e7ac8428b4475ff5560b
-  md5: f0f1fcde592e067a5ca2187d6f232bd3
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.11.8-hdf0ec26_0_cpython.conda
+  sha256: 6c9bbac137759e013e6a50593c7cf10a06032fcb1ef3a994c598c7a95e73a8e1
+  md5: 8f4076d960f17f19ae8b2f66727ea1c6
   depends:
   - bzip2 >=1.0.8,<2.0a0
   - libexpat >=2.5.0,<3.0a0
   - libffi >=3.4,<4.0a0
-  - libsqlite >=3.44.2,<4.0a0
+  - libsqlite >=3.45.1,<4.0a0
   - libzlib >=1.2.13,<1.3.0a0
   - ncurses >=6.4,<7.0a0
-  - openssl >=3.2.0,<4.0a0
+  - openssl >=3.2.1,<4.0a0
   - readline >=8.2,<9.0a0
   - tk >=8.6.13,<8.7.0a0
   - tzdata
@@ -13058,24 +13249,24 @@ packages:
   constrains:
   - python_abi 3.11.* *_cp311
   license: Python-2.0
-  size: 14567667
-  timestamp: 1703342625860
+  size: 14623079
+  timestamp: 1708116925163
 - kind: conda
   name: python-dateutil
-  version: 2.8.2
+  version: 2.9.0
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.8.2-pyhd8ed1ab_0.tar.bz2
-  sha256: 54d7785c7678166aa45adeaccfc1d2b8c3c799ca2dc05d4a82bb39b1968bd7da
-  md5: dd999d1cc9f79e67dbb855c8924c7984
+  url: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
+  sha256: f3ceef02ac164a8d3a080d0d32f8e2ebe10dd29e3a685d240e38b3599e146320
+  md5: 2cf4264fffb9e6eff6031c5b6884d61c
   depends:
-  - python >=3.6
+  - python >=3.7
   - six >=1.5
   license: Apache-2.0
   license_family: APACHE
-  size: 245987
-  timestamp: 1626286448716
+  size: 222742
+  timestamp: 1709299922152
 - kind: conda
   name: python_abi
   version: '3.11'
@@ -13274,6 +13465,7 @@ packages:
   - qt 5.15.8
   - __osx >=10.13
   license: LGPL-3.0-only
+  license_family: LGPL
   size: 46210935
   timestamp: 1707961847477
 - kind: conda
@@ -13287,7 +13479,7 @@ packages:
   md5: 54866f708d43002a514d0b9b0f84bc11
   depends:
   - __glibc >=2.17,<3.0.a0
-  - alsa-lib >=1.2.10,<1.2.11.0a0
+  - alsa-lib >=1.2.10,<1.3.0.0a0
   - dbus >=1.13.6,<2.0a0
   - fontconfig >=2.14.2,<3.0a0
   - fonts-conda-ecosystem
@@ -13332,6 +13524,7 @@ packages:
   constrains:
   - qt 5.15.8
   license: LGPL-3.0-only
+  license_family: LGPL
   size: 61337596
   timestamp: 1707958161584
 - kind: conda
@@ -13345,7 +13538,7 @@ packages:
   md5: 4d287ec80c254043afc54cecaaf84ad5
   depends:
   - __glibc >=2.17,<3.0.a0
-  - alsa-lib >=1.2.10,<1.2.11.0a0
+  - alsa-lib >=1.2.10,<1.3.0.0a0
   - dbus >=1.13.6,<2.0a0
   - fontconfig >=2.14.2,<3.0a0
   - fonts-conda-ecosystem
@@ -13423,6 +13616,7 @@ packages:
   constrains:
   - qt 5.15.8
   license: LGPL-3.0-only
+  license_family: LGPL
   size: 51329823
   timestamp: 1707961383220
 - kind: conda
@@ -13454,6 +13648,7 @@ packages:
   constrains:
   - qt 5.15.8
   license: LGPL-3.0-only
+  license_family: LGPL
   size: 60081554
   timestamp: 1707957968211
 - kind: conda
@@ -13937,19 +14132,19 @@ packages:
   timestamp: 1706359239217
 - kind: conda
   name: setuptools
-  version: 69.0.3
+  version: 69.2.0
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-69.0.3-pyhd8ed1ab_0.conda
-  sha256: 0fe2a0473ad03dac6c7f5c42ef36a8e90673c88a0350dfefdea4b08d43803db2
-  md5: 40695fdfd15a92121ed2922900d0308b
+  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-69.2.0-pyhd8ed1ab_0.conda
+  sha256: 78a75c75a5dacda6de5f4056c9c990141bdaf4f64245673a590594d00bc63713
+  md5: da214ecd521a720a9d521c68047682dc
   depends:
-  - python >=3.7
+  - python >=3.8
   license: MIT
   license_family: MIT
-  size: 470548
-  timestamp: 1704224855187
+  size: 471183
+  timestamp: 1710344615844
 - kind: conda
   name: sigtool
   version: 0.1.3
@@ -14220,36 +14415,36 @@ packages:
 - kind: conda
   name: sysroot_linux-64
   version: '2.12'
-  build: he073ed8_16
-  build_number: 16
+  build: he073ed8_17
+  build_number: 17
   subdir: noarch
   noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.12-he073ed8_16.conda
-  sha256: 4c024b2eee24c6da7d3e08723111ec02665c578844c5b3e9e6b38f89000bec41
-  md5: 071ea8dceff4d30ac511f4a2f8437cd1
+  url: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.12-he073ed8_17.conda
+  sha256: b4e4d685e41cb36cfb16f0cb15d2c61f8f94f56fab38987a44eff95d8a673fb5
+  md5: 595db67e32b276298ff3d94d07d47fbf
   depends:
-  - kernel-headers_linux-64 2.6.32 he073ed8_16
+  - kernel-headers_linux-64 2.6.32 he073ed8_17
   license: LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0
   license_family: GPL
-  size: 15277813
-  timestamp: 1689214980563
+  size: 15127123
+  timestamp: 1708000843849
 - kind: conda
   name: sysroot_linux-aarch64
   version: '2.17'
-  build: h5b4a56d_13
-  build_number: 13
+  build: h5b4a56d_14
+  build_number: 14
   subdir: noarch
   noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-aarch64-2.17-h5b4a56d_13.conda
-  sha256: 16c9c99b04952456c344fd786d5933b5b851778b96b655d339b2f81ff8d53043
-  md5: 5493598eda29002426b4d04dcee88361
+  url: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-aarch64-2.17-h5b4a56d_14.conda
+  sha256: d239232cff55b45a1fbdea9fc660492afca16ba950785d9da3504f16de8fe765
+  md5: ba47875acf57f2717bcd55b26f4c3e00
   depends:
   - _sysroot_linux-aarch64_curr_repodata_hack 4.*
-  - kernel-headers_linux-aarch64 4.18.0 h5b4a56d_13
+  - kernel-headers_linux-aarch64 4.18.0 h5b4a56d_14
   license: LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0
   license_family: GPL
-  size: 16291428
-  timestamp: 1682995534198
+  size: 16253097
+  timestamp: 1708000911838
 - kind: conda
   name: tapi
   version: 1100.0.11
@@ -14680,20 +14875,56 @@ packages:
   size: 218421
   timestamp: 1682376911339
 - kind: conda
+  name: wayland
+  version: 1.22.0
+  build: h8c25dac_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/wayland-1.22.0-h8c25dac_1.conda
+  sha256: 9bf43998c0a4c7bff53849c8ef7638415020f9033f397a63537dfca1bf66e26a
+  md5: bfe70f700e76c87e0074c3e308513e79
+  depends:
+  - libexpat >=2.5.0,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 306491
+  timestamp: 1684198293803
+- kind: conda
+  name: wayland
+  version: 1.22.0
+  build: hce5310f_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/wayland-1.22.0-hce5310f_1.conda
+  sha256: 5e1ef10ec934065c8d49ec118319e97e4d632f88bd5043968f7ca92429711a43
+  md5: 50fa64a18cc82742e04f29c1b4537a43
+  depends:
+  - libexpat >=2.5.0,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 309547
+  timestamp: 1684198451014
+- kind: conda
   name: wheel
-  version: 0.42.0
+  version: 0.43.0
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/wheel-0.42.0-pyhd8ed1ab_0.conda
-  sha256: 80be0ccc815ce22f80c141013302839b0ed938a2edb50b846cf48d8a8c1cfa01
-  md5: 1cdea58981c5cbc17b51973bcaddcea7
+  url: https://conda.anaconda.org/conda-forge/noarch/wheel-0.43.0-pyhd8ed1ab_0.conda
+  sha256: 14ebc6f098ebc796669fa6e7d437086a0ee527c8694ff2062a8bcb6dbd9b1581
+  md5: 6e43a94e0ee67523b5e781f0faba5c45
   depends:
   - python >=3.7
   license: MIT
   license_family: MIT
-  size: 57553
-  timestamp: 1701013309664
+  size: 58048
+  timestamp: 1711016334007
 - kind: conda
   name: x264
   version: 1!164.3095
@@ -15341,42 +15572,6 @@ packages:
   size: 14468
   timestamp: 1684637984591
 - kind: conda
-  name: xorg-libxcursor
-  version: 1.2.0
-  build: h0b41bf4_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxcursor-1.2.0-h0b41bf4_1.conda
-  sha256: 109cffb4c07cec101fad55b3f8f8d1e83bb7acef00798a7d2fd6992f14218189
-  md5: b58859de3b5972860c36f638c8c0ebb6
-  depends:
-  - libgcc-ng >=12
-  - xorg-libx11 >=1.7.2,<2.0a0
-  - xorg-libxfixes 5.0.*
-  - xorg-libxrender 0.9.*
-  license: MIT
-  license_family: MIT
-  size: 31383
-  timestamp: 1677037230603
-- kind: conda
-  name: xorg-libxcursor
-  version: 1.2.0
-  build: hb4cce97_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxcursor-1.2.0-hb4cce97_1.conda
-  sha256: b95a567ea83a2bd0aa41bb7bcbe17af7e48cc7190832ab6f7699e95aed9f8dc4
-  md5: fb221f8966e4ca8d22b14011a7b35aa2
-  depends:
-  - libgcc-ng >=12
-  - xorg-libx11 >=1.7.2,<2.0a0
-  - xorg-libxfixes 5.0.*
-  - xorg-libxrender 0.9.*
-  license: MIT
-  license_family: MIT
-  size: 33356
-  timestamp: 1677037219636
-- kind: conda
   name: xorg-libxdmcp
   version: 1.1.3
   build: h27ca646_0
@@ -15597,48 +15792,6 @@ packages:
   size: 13876
   timestamp: 1667399792390
 - kind: conda
-  name: xorg-libxrandr
-  version: 1.5.2
-  build: h7f98852_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrandr-1.5.2-h7f98852_1.tar.bz2
-  sha256: ffd075a463896ed86d9519e26dc36f754b695b9c1e1b6115d34fe138b36d8200
-  md5: 5b0f7da25a4556c9619c3e4b4a98ab07
-  depends:
-  - libgcc-ng >=9.3.0
-  - xorg-libx11 >=1.7.1,<2.0a0
-  - xorg-libxext
-  - xorg-libxrender
-  - xorg-randrproto
-  - xorg-renderproto
-  - xorg-xextproto
-  license: MIT
-  license_family: MIT
-  size: 29688
-  timestamp: 1621515728586
-- kind: conda
-  name: xorg-libxrandr
-  version: 1.5.2
-  build: hf897c2e_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxrandr-1.5.2-hf897c2e_1.tar.bz2
-  sha256: 6d25ba7b97c1522ea084de1bec11bfd828afd8b62a09d67e89d22302456666c0
-  md5: 858f6db334e0e2b0011e25e033e6eb4c
-  depends:
-  - libgcc-ng >=9.3.0
-  - xorg-libx11 >=1.7.1,<2.0a0
-  - xorg-libxext
-  - xorg-libxrender
-  - xorg-randrproto
-  - xorg-renderproto
-  - xorg-xextproto
-  license: MIT
-  license_family: MIT
-  size: 30119
-  timestamp: 1621515659529
-- kind: conda
   name: xorg-libxrender
   version: 0.9.11
   build: h7935292_0
@@ -15670,36 +15823,6 @@ packages:
   license_family: MIT
   size: 37770
   timestamp: 1688300707994
-- kind: conda
-  name: xorg-randrproto
-  version: 1.5.0
-  build: h7f98852_1001
-  build_number: 1001
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-randrproto-1.5.0-h7f98852_1001.tar.bz2
-  sha256: f5c7c2de3655a95153e900118959df6a50b6c104a3d7afaee3eadbf86b85fa2e
-  md5: 68cce654461713977dac6f9ac1bce89a
-  depends:
-  - libgcc-ng >=9.3.0
-  license: MIT
-  license_family: MIT
-  size: 32984
-  timestamp: 1621340029170
-- kind: conda
-  name: xorg-randrproto
-  version: 1.5.0
-  build: hf897c2e_1001
-  build_number: 1001
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-randrproto-1.5.0-hf897c2e_1001.tar.bz2
-  sha256: cb304b318b2a335394d16acb5c8449999eaf30e010aaeb09b2d7fcc187a73edb
-  md5: b881991d65594646403c42be82f15642
-  depends:
-  - libgcc-ng >=9.3.0
-  license: MIT
-  license_family: MIT
-  size: 32963
-  timestamp: 1621339952801
 - kind: conda
   name: xorg-renderproto
   version: 0.11.1
@@ -16009,179 +16132,179 @@ packages:
 - kind: conda
   name: yarp
   version: 3.9.0
-  build: h57928b3_1
-  build_number: 1
+  build: h57928b3_2
+  build_number: 2
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/yarp-3.9.0-h57928b3_1.conda
-  sha256: 756555348c65cdb52bbd620357df0ae0319daefe001bec8778d4b21b6f499013
-  md5: 8088ba85b024eda5d4e145c5fc173840
+  url: https://conda.anaconda.org/conda-forge/win-64/yarp-3.9.0-h57928b3_2.conda
+  sha256: b66c7e0724f87191e82153a80edec11b724ecbd55e59674b9415b40d7346a092
+  md5: f0a2805f5860c1f0e1f8d05b720b0b04
   depends:
-  - libyarp 3.9.0 ha0ae21b_1
+  - libyarp 3.9.0 ha0ae21b_2
   - yarp-python >=3.9.0,<3.9.1.0a0
   license: BSD-3-Clause AND MIT AND GPL-3.0-or-later
-  size: 23377
-  timestamp: 1706037612517
+  size: 23710
+  timestamp: 1711031566614
 - kind: conda
   name: yarp
   version: 3.9.0
-  build: h694c41f_1
-  build_number: 1
+  build: h694c41f_2
+  build_number: 2
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/yarp-3.9.0-h694c41f_1.conda
-  sha256: 2f087f49a49cf27d042e06d809e64f3cea35e411148aa69bebc34fc6a11fb6af
-  md5: 7c4ba414580270e39dc1a59e65fec1c7
+  url: https://conda.anaconda.org/conda-forge/osx-64/yarp-3.9.0-h694c41f_2.conda
+  sha256: 17bf62f15a4ae584baa06ea7f410261897dee6194806d2fb0ac28b903947d5fd
+  md5: c7ec14a9432115c96d89947510040554
   depends:
-  - libyarp 3.9.0 h9c0c770_1
+  - libyarp 3.9.0 h9c0c770_2
   - yarp-python >=3.9.0,<3.9.1.0a0
   license: BSD-3-Clause AND MIT AND GPL-3.0-or-later
-  size: 23200
-  timestamp: 1706036382744
+  size: 23355
+  timestamp: 1711030426760
 - kind: conda
   name: yarp
   version: 3.9.0
-  build: h8af1aa0_1
-  build_number: 1
+  build: h8af1aa0_2
+  build_number: 2
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/yarp-3.9.0-h8af1aa0_1.conda
-  sha256: f898376a55d48aa8fa3ea430cd422a1b936998785164bafea999071371e5be57
-  md5: f37afd4e91d86faecaedd77fe3eee9cd
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/yarp-3.9.0-h8af1aa0_2.conda
+  sha256: c48c812c31b1dd440d94c17594eda018c9c88f9ff5d989057038704fd1da0573
+  md5: becf9dd80909549b1e02bc9263092ebe
   depends:
-  - libyarp 3.9.0 h6d2be9b_1
+  - libyarp 3.9.0 h6d2be9b_2
   - yarp-python >=3.9.0,<3.9.1.0a0
   license: BSD-3-Clause AND MIT AND GPL-3.0-or-later
-  size: 23079
-  timestamp: 1706036258481
+  size: 23295
+  timestamp: 1711029221232
 - kind: conda
   name: yarp
   version: 3.9.0
-  build: ha770c72_1
-  build_number: 1
+  build: ha770c72_2
+  build_number: 2
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/yarp-3.9.0-ha770c72_1.conda
-  sha256: 52e643455da12ba1a4fcc3c5614b206b2092850e86f7fbbce1f783c06a27d7d9
-  md5: baa3f7bfb0c2382aa0e44b62809e510a
+  url: https://conda.anaconda.org/conda-forge/linux-64/yarp-3.9.0-ha770c72_2.conda
+  sha256: b562749df529373eb3a1f7b322b9fa386d441d7c9eb79137efa7ac39d700c191
+  md5: 72c8bb1b7239f0ddd4d1dc2d411493f6
   depends:
-  - libyarp 3.9.0 ha614a09_1
+  - libyarp 3.9.0 ha614a09_2
   - yarp-python >=3.9.0,<3.9.1.0a0
   license: BSD-3-Clause AND MIT AND GPL-3.0-or-later
-  size: 23134
-  timestamp: 1706035101138
+  size: 23327
+  timestamp: 1711028805857
 - kind: conda
   name: yarp
   version: 3.9.0
-  build: hce30654_1
-  build_number: 1
+  build: hce30654_2
+  build_number: 2
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/yarp-3.9.0-hce30654_1.conda
-  sha256: c315b4bdca9ffa707b1edd1af4c12c81f64ee1bcba10438549816500fa88256b
-  md5: e0bc1b09a9baa66d905c40c5d959fc5c
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/yarp-3.9.0-hce30654_2.conda
+  sha256: 8054baa57e0868d222d2f14c359b346bf4ae41dca085abad65e799c2022bc694
+  md5: 8fac77dcee3e39c0e0ecadfdcc3eca40
   depends:
-  - libyarp 3.9.0 hff4382b_1
+  - libyarp 3.9.0 hff4382b_2
   - yarp-python >=3.9.0,<3.9.1.0a0
   license: BSD-3-Clause AND MIT AND GPL-3.0-or-later
-  size: 23209
-  timestamp: 1706036816531
+  size: 23443
+  timestamp: 1711030519803
 - kind: conda
   name: yarp-python
   version: 3.9.0
-  build: py311h0e2f32c_1
-  build_number: 1
+  build: py311h0e2f32c_2
+  build_number: 2
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/yarp-python-3.9.0-py311h0e2f32c_1.conda
-  sha256: 07438980aa8d10cd73e77f3ce96513542c2ffa9fb6289f4c1bd7787c149b266d
-  md5: 3002b8027d3b83789e7726c5fe495b9f
+  url: https://conda.anaconda.org/conda-forge/linux-64/yarp-python-3.9.0-py311h0e2f32c_2.conda
+  sha256: 1344c21ea481f485bb1df69498d9b29582d5b0f7a7ada1bea0dd503f7f2fcff4
+  md5: 61cabae2e70d66ff6f5627624e82c4a4
   depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  - libyarp 3.9.0 ha614a09_1
+  - libyarp 3.9.0 ha614a09_2
   - numpy
-  - openssl >=3.2.0,<4.0a0
+  - openssl >=3.2.1,<4.0a0
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
   license: BSD-3-Clause AND MIT AND GPL-3.0-or-later
-  size: 1156939
-  timestamp: 1706034479319
+  size: 1156782
+  timestamp: 1711028470304
 - kind: conda
   name: yarp-python
   version: 3.9.0
-  build: py311h1e2cc8c_1
-  build_number: 1
+  build: py311h1e2cc8c_2
+  build_number: 2
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/yarp-python-3.9.0-py311h1e2cc8c_1.conda
-  sha256: b5916b41a6c6d29356ba7ab3fda3c3ecde8d7d1231ecac4d0a2794bb0e8219d2
-  md5: e0746ac8badfeef9a085818cfe461af8
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/yarp-python-3.9.0-py311h1e2cc8c_2.conda
+  sha256: fcccc48063746cfc7e943ed632250446a0b7a6c370d966637d691410d36ebee5
+  md5: fb9395bde46c08bf3eccf2730f1a6210
   depends:
-  - libcxx >=15
-  - libyarp 3.9.0 hff4382b_1
+  - libcxx >=16
+  - libyarp 3.9.0 hff4382b_2
   - numpy
-  - openssl >=3.2.0,<4.0a0
+  - openssl >=3.2.1,<4.0a0
   - python >=3.11,<3.12.0a0
   - python >=3.11,<3.12.0a0 *_cpython
   - python_abi 3.11.* *_cp311
   license: BSD-3-Clause AND MIT AND GPL-3.0-or-later
-  size: 951417
-  timestamp: 1706035922618
+  size: 957149
+  timestamp: 1711029367813
 - kind: conda
   name: yarp-python
   version: 3.9.0
-  build: py311h22f05a9_1
-  build_number: 1
+  build: py311h22f05a9_2
+  build_number: 2
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/yarp-python-3.9.0-py311h22f05a9_1.conda
-  sha256: 32765a18b2a91db0f2ba02a2bbee5609d079fcb24e9480043e5ecf143b8aab92
-  md5: ebfa497fc5e23b7b1b433067a30b06f9
+  url: https://conda.anaconda.org/conda-forge/osx-64/yarp-python-3.9.0-py311h22f05a9_2.conda
+  sha256: 0cc1b1dc25ef97f9bc8cd1d0cc631dfa3198469454db8cab3c7a86d99371c856
+  md5: 2e355e4f0581b49fec05eae22ade3d1f
   depends:
-  - libcxx >=15
-  - libyarp 3.9.0 h9c0c770_1
+  - libcxx >=16
+  - libyarp 3.9.0 h9c0c770_2
   - numpy
-  - openssl >=3.2.0,<4.0a0
+  - openssl >=3.2.1,<4.0a0
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
   license: BSD-3-Clause AND MIT AND GPL-3.0-or-later
-  size: 1027438
-  timestamp: 1706036133957
+  size: 1027433
+  timestamp: 1711029126635
 - kind: conda
   name: yarp-python
   version: 3.9.0
-  build: py311h49b8dee_1
-  build_number: 1
+  build: py311h49b8dee_2
+  build_number: 2
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/yarp-python-3.9.0-py311h49b8dee_1.conda
-  sha256: e8468f2546f514587e29895576f9168e1157ed23a2b55c2d09c4e5987b8e648d
-  md5: 1b8e3a3616832d1390064a293c573099
+  url: https://conda.anaconda.org/conda-forge/win-64/yarp-python-3.9.0-py311h49b8dee_2.conda
+  sha256: 9ec8acecc619c103ff150825cd001dd37c6369e26bc8dd569f6df2a76c2a2e5e
+  md5: 3096cfade218dca122bb6d7fab522380
   depends:
-  - libyarp 3.9.0 ha0ae21b_1
+  - libyarp 3.9.0 ha0ae21b_2
   - numpy
-  - openssl >=3.2.0,<4.0a0
+  - openssl >=3.2.1,<4.0a0
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: BSD-3-Clause AND MIT AND GPL-3.0-or-later
-  size: 900162
-  timestamp: 1706037595584
+  size: 906088
+  timestamp: 1711031548604
 - kind: conda
   name: yarp-python
   version: 3.9.0
-  build: py311h6b46aae_1
-  build_number: 1
+  build: py311h6b46aae_2
+  build_number: 2
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/yarp-python-3.9.0-py311h6b46aae_1.conda
-  sha256: 0a2852ca2a3faefcd0d64e3d09e4807bd3a8f0edc8c02b63c0aacdddb9cc5d45
-  md5: 677d1b9bacedcae295470aec523e08f8
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/yarp-python-3.9.0-py311h6b46aae_2.conda
+  sha256: 3a9f992a80e7bef9f326110deb530649c07ab982d7c65d747a74f734d45fee31
+  md5: 8af66d7888032526e17063e34ac9558e
   depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  - libyarp 3.9.0 h6d2be9b_1
+  - libyarp 3.9.0 h6d2be9b_2
   - numpy
-  - openssl >=3.2.0,<4.0a0
+  - openssl >=3.2.1,<4.0a0
   - python >=3.11,<3.12.0a0
   - python >=3.11,<3.12.0a0 *_cpython
   - python_abi 3.11.* *_cp311
   license: BSD-3-Clause AND MIT AND GPL-3.0-or-later
-  size: 1009213
-  timestamp: 1706036004062
+  size: 1007534
+  timestamp: 1711028354095
 - kind: conda
   name: ycm-cmake-modules
   version: 0.16.2


### PR DESCRIPTION
This ensures that we do not experience the pixi error documented in https://github.com/conda-forge/yarp-feedstock/issues/42 and https://github.com/prefix-dev/pixi/issues/1031 .