### PR TITLE
iCubV2_* - Align IMU sensor names with the real robot ones

### DIFF
--- a/simmechanics/data/icub2_5/ICUB_2-5_BB_simmechanics_options.yaml.in
+++ b/simmechanics/data/icub2_5/ICUB_2-5_BB_simmechanics_options.yaml.in
@@ -690,7 +690,7 @@ sensors:
         </plugin>
   - frameName: SCSYS_L_UPPER_ARM_FT45
     linkName: l_shoulder_3
-    sensorName: l_arm_ft
+    sensorName: l_arm_ft_imu
     exportFrameInURDF: Yes
     sensorType: "accelerometer"
     sensorBlobs:
@@ -700,7 +700,7 @@ sensors:
         </plugin>
   - frameName: SCSYS_R_UPPER_ARM_FT45
     linkName: r_shoulder_3
-    sensorName: r_arm_ft
+    sensorName: r_arm_ft_imu
     exportFrameInURDF: Yes
     sensorType: "accelerometer"
     sensorBlobs:

--- a/simmechanics/data/icub2_5/conf/wrappers/inertials/alljoints-inertials_remapper.xml
+++ b/simmechanics/data/icub2_5/conf/wrappers/inertials/alljoints-inertials_remapper.xml
@@ -3,7 +3,7 @@
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="alljoints-inertials_remapper" type="multipleanalogsensorsremapper">
     <param name="OrientationSensorsNames">
-        (l_arm_ft r_arm_ft head_imu_0)
+        (head_imu_0 l_arm_ft_imu r_arm_ft_imu)
     </param>
     <action phase="startup" level="5" type="attach">
         <paramlist name="networks">


### PR DESCRIPTION
This is the twin PR of https://github.com/icub-tech-iit/ergocub-software/issues/232. 

Since with https://github.com/robotology/robots-configuration/pull/637 the sensorName tag (i.e. `<part>_ft_imu`) was added for all the ergoCub/iCub that exposes the IMU data from the FT sensors, the simulated models should be aligned accordingly.