### PR TITLE
gz-sim-yarp-plugins: add support for icub 2.x

### DIFF
--- a/simmechanics/CMakeLists.txt
+++ b/simmechanics/CMakeLists.txt
@@ -304,7 +304,14 @@ macro(generate_icub_simmechanics)
                <yarpConfigurationFile>model://iCub/conf/gazebo_icub_xsens_inertial.ini</yarpConfigurationFile>
              </plugin>
             </sensor>
-          </gazebo>")
+          </gazebo>
+  - |   
+        <gazebo>
+        <plugin name=\"gzyarp::Imu\" filename=\"gz-sim-yarp-imu-system\">
+            <yarpConfigurationFile>model://iCub/conf/gazebo_icub_xsens_inertial.ini</yarpConfigurationFile>
+        </plugin>
+        </gazebo>
+")
     endif()
 
     set(GENERATED_YAML_LOCATION ${CMAKE_CURRENT_BINARY_DIR}/${GIVTWO_YARP_ROBOT_NAME}.yaml)

--- a/simmechanics/data/icub2_5/ICUB_2-5_BB_simmechanics_options.yaml.in
+++ b/simmechanics/data/icub2_5/ICUB_2-5_BB_simmechanics_options.yaml.in
@@ -1128,6 +1128,85 @@ XMLBlobs:
           <mu2>1</mu2>
           <fdir1>0 0 0</fdir1>
         </gazebo>
+  # gz-sim plugins
+  - |
+        <gazebo>
+        <plugin name="gzyarp::ControlBoard" filename="gz-sim-yarp-controlboard-system">
+          <yarpConfigurationFile>model://iCub/conf/gazebo_icub_torso.ini</yarpConfigurationFile>
+        </plugin>
+        <plugin name="gzyarp::ControlBoard" filename="gz-sim-yarp-controlboard-system">
+          <yarpConfigurationFile>model://iCub/conf/gazebo_icub_head_without_eyes.ini</yarpConfigurationFile>
+        </plugin>
+        <plugin name="gzyarp::ControlBoard" filename="gz-sim-yarp-controlboard-system">
+          <yarpConfigurationFile>model://iCub/conf/gazebo_icub_left_arm_no_hand_for_no_hand_model.ini</yarpConfigurationFile>
+          <initialConfiguration>-0.52 0.52 0 0.785 0 0 0.0</initialConfiguration>
+        </plugin>
+        <plugin name="gzyarp::ControlBoard" filename="gz-sim-yarp-controlboard-system">
+          <yarpConfigurationFile>model://iCub/conf/gazebo_icub_right_arm_no_hand_for_no_hand_model.ini</yarpConfigurationFile>
+          <initialConfiguration>-0.52 0.52 0 0.785 0 0 0.0</initialConfiguration>
+        </plugin>
+        <plugin name="gzyarp::ControlBoard" filename="gz-sim-yarp-controlboard-system">
+          <yarpConfigurationFile>model://iCub/conf/gazebo_icub_right_leg.ini</yarpConfigurationFile>
+        </plugin>
+        <plugin name="gzyarp::ControlBoard" filename="gz-sim-yarp-controlboard-system">
+          <yarpConfigurationFile>model://iCub/conf/gazebo_icub_left_leg.ini</yarpConfigurationFile>
+        </plugin>
+        </gazebo>
+  - |
+      <gazebo>
+      <plugin name="gzyarp::ForceTorque" filename="gz-sim-yarp-forcetorque-system">
+        <yarpConfigurationFile>model://iCub/conf/FT/gazebo_icub_right_arm_ft.ini</yarpConfigurationFile>
+      </plugin>
+      </gazebo>
+  - |
+      <gazebo>
+      <plugin name="gzyarp::ForceTorque" filename="gz-sim-yarp-forcetorque-system">
+        <yarpConfigurationFile>model://iCub/conf/FT/gazebo_icub_left_arm_ft.ini</yarpConfigurationFile>
+      </plugin>
+      </gazebo>
+  - |
+      <gazebo>
+      <plugin name="gzyarp::ForceTorque" filename="gz-sim-yarp-forcetorque-system">
+        <yarpConfigurationFile>model://iCub/conf/FT/gazebo_icub_right_leg_ft.ini</yarpConfigurationFile>
+      </plugin>
+      </gazebo>
+  - |
+      <gazebo>
+      <plugin name="gzyarp::ForceTorque" filename="gz-sim-yarp-forcetorque-system">
+        <yarpConfigurationFile>model://iCub/conf/FT/gazebo_icub_left_leg_ft.ini</yarpConfigurationFile>
+      </plugin>
+      </gazebo>
+  - |
+      <gazebo>
+      <plugin name="gzyarp::ForceTorque" filename="gz-sim-yarp-forcetorque-system">
+        <yarpConfigurationFile>model://iCub/conf/FT/gazebo_icub_right_foot_ft.ini</yarpConfigurationFile>
+      </plugin>
+      </gazebo>
+
+  - |
+      <gazebo>
+      <plugin name="gzyarp::ForceTorque" filename="gz-sim-yarp-forcetorque-system">
+        <yarpConfigurationFile>model://iCub/conf/FT/gazebo_icub_left_foot_ft.ini</yarpConfigurationFile>
+      </plugin>
+      </gazebo>
+  - |
+      <gazebo>
+      <plugin name="gzyarp::Imu" filename="gz-sim-yarp-imu-system">
+        <yarpConfigurationFile>model://iCub/conf/gazebo_icub_right_arm_inertial.ini</yarpConfigurationFile>
+      </plugin>
+      </gazebo>
+  - |
+      <gazebo>
+      <plugin name="gzyarp::Imu" filename="gz-sim-yarp-imu-system">
+        <yarpConfigurationFile>model://iCub/conf/gazebo_icub_left_arm_inertial.ini</yarpConfigurationFile>
+      </plugin>
+      </gazebo>
+  - |
+      <gazebo>
+      <plugin name="gzyarp::Imu" filename="gz-sim-yarp-imu-system">
+        <yarpConfigurationFile>model://iCub/conf/gazebo_icub_inertial.ini</yarpConfigurationFile>
+      </plugin>
+      </gazebo>
   - |
         <gazebo>
         <plugin name="iCub_yarp_gazebo_plugin_ACCpart" filename="libgazebo_yarp_distributedinertials.so">
@@ -1302,6 +1381,20 @@ XMLBlobs:
           <plugin name="robotinterface" filename="libgazebo_yarp_robotinterface.so">
             <yarpRobotInterfaceConfigurationFile>model://iCub/conf/icub.xml</yarpRobotInterfaceConfigurationFile>
           </plugin>
+        </gazebo>
+  - |
+        <gazebo>
+          <plugin name="gzyarp::RobotInterface" filename="gz-sim-yarp-robotinterface-system">
+            <yarpRobotInterfaceConfigurationFile>model://iCub/conf/icub.xml</yarpRobotInterfaceConfigurationFile>
+          </plugin>
+        </gazebo>
+  - |
+        <gazebo>
+          <plugin filename="gz-sim-forcetorque-system" name="gz::sim::systems::ForceTorque"></plugin>
+        </gazebo>
+  - |
+        <gazebo>
+          <plugin filename="gz-sim-imu-system" name="gz::sim::systems::Imu"></plugin>
         </gazebo>
 @ADDITIONAL_XML_BLOBS@
 

--- a/simmechanics/data/icub2_5/conf/FT/gazebo_icub_left_arm_ft.ini
+++ b/simmechanics/data/icub2_5/conf/FT/gazebo_icub_left_arm_ft.ini
@@ -1,2 +1,4 @@
 disableImplicitNetworkWrapper
 yarpDeviceName icub_left_arm_ft
+jointName l_arm_ft_sensor
+sensorName l_arm_ft

--- a/simmechanics/data/icub2_5/conf/FT/gazebo_icub_left_foot_ft.ini
+++ b/simmechanics/data/icub2_5/conf/FT/gazebo_icub_left_foot_ft.ini
@@ -1,2 +1,4 @@
 disableImplicitNetworkWrapper
 yarpDeviceName icub_left_foot_ft
+jointName l_foot_ft_sensor
+sensorName l_foot_ft

--- a/simmechanics/data/icub2_5/conf/FT/gazebo_icub_left_leg_ft.ini
+++ b/simmechanics/data/icub2_5/conf/FT/gazebo_icub_left_leg_ft.ini
@@ -1,2 +1,4 @@
 disableImplicitNetworkWrapper
 yarpDeviceName icub_left_leg_ft
+jointName l_leg_ft_sensor
+sensorName l_leg_ft

--- a/simmechanics/data/icub2_5/conf/FT/gazebo_icub_right_arm_ft.ini
+++ b/simmechanics/data/icub2_5/conf/FT/gazebo_icub_right_arm_ft.ini
@@ -1,2 +1,4 @@
 disableImplicitNetworkWrapper
 yarpDeviceName icub_right_arm_ft
+jointName r_arm_ft_sensor
+sensorName r_arm_ft

--- a/simmechanics/data/icub2_5/conf/FT/gazebo_icub_right_foot_ft.ini
+++ b/simmechanics/data/icub2_5/conf/FT/gazebo_icub_right_foot_ft.ini
@@ -1,2 +1,4 @@
 disableImplicitNetworkWrapper
 yarpDeviceName icub_right_foot_ft
+jointName r_foot_ft_sensor
+sensorName r_foot_ft

--- a/simmechanics/data/icub2_5/conf/FT/gazebo_icub_right_leg_ft.ini
+++ b/simmechanics/data/icub2_5/conf/FT/gazebo_icub_right_leg_ft.ini
@@ -1,3 +1,4 @@
 disableImplicitNetworkWrapper
 yarpDeviceName icub_right_leg_ft
-
+jointName r_leg_ft_sensor
+sensorName r_leg_ft

--- a/simmechanics/data/icub2_5/conf/gazebo_icub_inertial.ini
+++ b/simmechanics/data/icub2_5/conf/gazebo_icub_inertial.ini
@@ -1,2 +1,4 @@
 disableImplicitNetworkWrapper
 yarpDeviceName head_inertial_hardware_device
+parentLinkName head
+sensorName head_imu_0

--- a/simmechanics/data/icub2_5/conf/gazebo_icub_left_arm_inertial.ini
+++ b/simmechanics/data/icub2_5/conf/gazebo_icub_left_arm_inertial.ini
@@ -1,2 +1,4 @@
 disableImplicitNetworkWrapper
 yarpDeviceName left_arm_inertial_hardware_device
+parentLinkName l_shoulder_3
+sensorName l_arm_ft_imu

--- a/simmechanics/data/icub2_5/conf/gazebo_icub_right_arm_inertial.ini
+++ b/simmechanics/data/icub2_5/conf/gazebo_icub_right_arm_inertial.ini
@@ -1,2 +1,4 @@
 disableImplicitNetworkWrapper
 yarpDeviceName right_arm_inertial_hardware_device
+parentLinkName r_shoulder_3
+sensorName r_arm_ft_imu

--- a/simmechanics/data/icub2_5/conf/gazebo_icub_xsens_inertial.ini
+++ b/simmechanics/data/icub2_5/conf/gazebo_icub_xsens_inertial.ini
@@ -5,3 +5,6 @@ period 2
 
 device multipleanalogsensorsserver
 subdevice gazebo_imu
+yarpDeviceName waist_inertial_hardware_device
+parentLinkName root_link
+sensorName root_link_imu_acc


### PR DESCRIPTION
This PR add the usage of `gz-sim` plugins in the icub 2.x models (not visuomanip)

cc @xela-95 